### PR TITLE
Android App Links Not Working on Android 12 and Beyond

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -51,6 +51,11 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
 
+                // TODO: This intent filter is designed to function exclusively on Android 11 and earlier versions.
+                // Digital app link handling is imperative for this use case.
+                // For detailed guidance and testing of digital app link (DAL) files, please consult the documentation at:
+                // https://developer.android.com/training/app-links/verify-android-applinks#test-dal-files
+
                 <data
                     android:scheme="https"
                     android:host="@string/root_url_app_no_protocol"


### PR DESCRIPTION
# Android App Links Support in Code

## Problem

On apps targeting Android 12 and above, there have been changes in how Android App Links work. These changes aim to make the experience better and give developers more control. To ensure our app links work smoothly, we need to prove to Android that these links belong to us. How? By uploading a digital asset link file to our server. This file tells Android, "Trust us, these links are ours."

## See the Issue in Action

Before we dive into the solution, check out these videos to see the problem for yourself:

- **Android 11 and Below**: [Watch Here](https://drive.google.com/file/d/1t9nI_Pf-cK8D35Zzpm4fCkY9yKK3anIo/view?usp=sharing)
- **Android 12 and Above**: [Watch Here](https://drive.google.com/file/d/1nniIqdGNYfkzBL1djb_KoLqP_w6pqrwf/view?usp=sharing)

## App Links 101

App links are like deep links on steroids. Click a link to our website on your Android device, and it should open our app directly, no questions asked. No more picking the right app – it's all seamless.

## Sample App Links

Here are some examples of the app links we're using:

- [https://app.getcode.com/login?data={UNIQUE_ACCESS_CODE}](https://app.getcode.com/login?data={UNIQUE_ACCESS_CODE})
- [https://app.getcode.com/login/#/e={UNIQUE_ACCESS_CODE}](https://app.getcode.com/login/#/e={UNIQUE_ACCESS_CODE})
- [https://cash.getcode.com/cash/{UNIQUE_ACCESS_CODE}](https://cash.getcode.com/cash/{UNIQUE_ACCESS_CODE})

## In Our Case

We've got multiple subdomains like ```app.getcode.com``` and ```cash.getcode.com.``` Each needs its own digital asset file. Check out the official Android documentation [here](https://developer.android.com/training/app-links/verify-android-applinks#web-assoc) for more details.

## Digital Asset File Example

Here's a sample digital asset file:

```json
[
  {
    "relation": ["delegate_permission/common.handle_all_urls"],
    "target": {
      "package_name": “com.getcode”,
      "sha256_cert_fingerprints":
      [“{SHA_256}”]
    }
  }
]
```

## Where to Publish the Digital Asset File

The file goes here: https://getcode.com/.well-known/assetlinks.json

## Verification

Use this link to check if everything's in order: [https://digitalassetlinks.googleapis.com/v1/statements:list?source.web.site=https://www.getcode.com&relation=delegate_permission/common.handle_all_urls](https://digitalassetlinks.googleapis.com/v1/statements:list?source.web.site=https://www.getcode.com&relation=delegate_permission/common.handle_all_urls)

**DoorDash Example**

For inspiration, see how DoorDash handles their asset links file: [https://digitalassetlinks.googleapis.com/v1/statements:list?source.web.site=https://www.doordash.com&relation=delegate_permission/common.handle_all_urls](https://digitalassetlinks.googleapis.com/v1/statements:list?source.web.site=https://www.doordash.com&relation=delegate_permission/common.handle_all_urls)


## What I Need from You

To get those app links working again, Need you to create that assets links file and upload it to the server at the location mentioned. For the production version, generate the SHA256 using the production keystore file. For debugging, generate it using your development device. 