### PR TITLE
fix: swap launchMode to singleTask to prevent cash links opening inside messenger apps

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -41,7 +41,7 @@
             android:screenOrientation="portrait"
             android:hardwareAccelerated="true"
             android:windowSoftInputMode="adjustResize"
-            android:launchMode="singleTop">
+            android:launchMode="singleTask">
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/app/src/main/java/com/getcode/view/MainActivity.kt
+++ b/app/src/main/java/com/getcode/view/MainActivity.kt
@@ -60,7 +60,7 @@ class MainActivity : FragmentActivity() {
         super.onNewIntent(intent)
         if (intent != null) {
             val cachedIntent = DeeplinkState.debounceIntent
-            if (cachedIntent != null && cachedIntent?.data == intent.data) {
+            if (cachedIntent != null && cachedIntent.data == intent.data) {
                 Timber.d("Debouncing Intent " + intent.data)
                 DeeplinkState.debounceIntent = null
                 return


### PR DESCRIPTION
>The system creates a new task and instantiates the activity at the root of the new task. However, if an instance of the activity already exists in a separate task, the system routes the intent to the existing instance through a call to its onNewIntent() method, rather than creating a new instance. Only one instance of the activity can exist at a time.