### PR TITLE
chore(home/bill): ignore visibility of status bar inset and always of…

### DIFF
--- a/app/src/main/java/com/getcode/view/main/bill/CashBill.kt
+++ b/app/src/main/java/com/getcode/view/main/bill/CashBill.kt
@@ -1,6 +1,7 @@
 package com.getcode.view.main.bill
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -9,6 +10,7 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.statusBarsIgnoringVisibility
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material.Text
@@ -37,6 +39,7 @@ import com.getcode.util.nonScaledSp
 import com.getcode.util.toDp
 import com.kik.kikx.kincodes.KikCodeContentView
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 internal fun CashBill(
     modifier: Modifier = Modifier,
@@ -45,7 +48,7 @@ internal fun CashBill(
 ) {
     ConstraintLayout(
         modifier = modifier
-            .windowInsetsPadding(WindowInsets.statusBars)
+            .windowInsetsPadding(WindowInsets.statusBarsIgnoringVisibility)
             .aspectRatio(0.555f)
             .heightIn(0.dp, 800.dp)
             .fillMaxHeight(0.85f)

--- a/app/src/main/java/com/getcode/view/main/bill/PaymentReceiptBill.kt
+++ b/app/src/main/java/com/getcode/view/main/bill/PaymentReceiptBill.kt
@@ -5,11 +5,13 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.statusBarsIgnoringVisibility
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.shape.CircleShape
@@ -38,6 +40,7 @@ import com.getcode.theme.withRobotoMono
 import com.getcode.view.main.home.components.PriceWithFlag
 import com.kik.kikx.kincodes.KikCodeContentView
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 internal fun Receipt(
     modifier: Modifier = Modifier,
@@ -48,7 +51,7 @@ internal fun Receipt(
     val screenHeight = LocalConfiguration.current.screenHeightDp.dp
     BoxWithConstraints(
         modifier = modifier
-            .windowInsetsPadding(WindowInsets.statusBars)
+            .windowInsetsPadding(WindowInsets.statusBarsIgnoringVisibility)
             .padding(horizontal = CodeTheme.dimens.inset)
             .padding(
                 top = screenHeight * 0.10f,


### PR DESCRIPTION
…fset

Some devices hide the status bar when showing share sheet causing the bill to shift while it's open.