### PR TITLE
fix: prevent camera from starting inadvertently after stopping

### DIFF
--- a/app/src/main/java/com/getcode/view/camera/KikCodeScannerView.kt
+++ b/app/src/main/java/com/getcode/view/camera/KikCodeScannerView.kt
@@ -10,6 +10,7 @@ import io.reactivex.rxjava3.functions.BiFunction
 import io.reactivex.rxjava3.processors.BehaviorProcessor
 import kotlinx.coroutines.flow.Flow
 import org.kin.sdk.base.tools.Optional
+import timber.log.Timber
 
 class KikCodeScannerView @JvmOverloads constructor(
     context: Context,
@@ -36,6 +37,7 @@ class KikCodeScannerView @JvmOverloads constructor(
     }
 
     fun startPreview() {
+        Timber.d("start : $previewing")
         if (previewing) {
             return
         }
@@ -64,6 +66,7 @@ class KikCodeScannerView @JvmOverloads constructor(
     }
 
     fun stopPreview() {
+        Timber.d("stop : $previewing")
         if (!previewing) {
             return
         }

--- a/app/src/main/java/com/getcode/view/main/home/HomeViewModel.kt
+++ b/app/src/main/java/com/getcode/view/main/home/HomeViewModel.kt
@@ -928,9 +928,6 @@ class HomeViewModel @Inject constructor(
         view: KikCodeScannerView,
         scanner: KikCodeScanner
     ): Flowable<ScannableKikCode> {
-        if (!view.previewing) {
-            view.startPreview()
-        }
         return Single.defer {
             view.previewSize()
                 .subscribeOn(Schedulers.computation())


### PR DESCRIPTION
was causing scans to not register after bg->fg