### PR TITLE
fix: use Locale#language instead of languageTag

### DIFF
--- a/api/src/main/java/com/getcode/network/repository/IdentityRepository.kt
+++ b/api/src/main/java/com/getcode/network/repository/IdentityRepository.kt
@@ -215,7 +215,7 @@ class IdentityRepository @Inject constructor(
         locale: Locale,
         owner: KeyPair,
     ): Result<Unit> {
-        val localeTag = locale.toLanguageTag()
+        val localeTag = locale.toString()
         Timber.i("Attempting to update locale to $localeTag")
         val containerId = getUserContainerId()
         val request = UpdatePreferencesRequest.newBuilder()


### PR DESCRIPTION
This results in a whole bunch of suffixes depending on system and we only need the language