### PR TITLE
fix: send up language for locale

### DIFF
--- a/api/src/main/java/com/getcode/network/repository/IdentityRepository.kt
+++ b/api/src/main/java/com/getcode/network/repository/IdentityRepository.kt
@@ -215,7 +215,7 @@ class IdentityRepository @Inject constructor(
         locale: Locale,
         owner: KeyPair,
     ): Result<Unit> {
-        val localeTag = locale.toString()
+        val localeTag = locale.language
         Timber.i("Attempting to update locale to $localeTag")
         val containerId = getUserContainerId()
         val request = UpdatePreferencesRequest.newBuilder()


### PR DESCRIPTION
RPC regex isn't validating for the entire IETF BCP 47 spec currently so send up the language it's after for localization