### PR TITLE
fix(kikcodescanner): don't YUV compress image data

### DIFF
--- a/app/src/main/java/com/kik/kikx/kikcodes/implementation/KikCodeScannerImpl.kt
+++ b/app/src/main/java/com/kik/kikx/kikcodes/implementation/KikCodeScannerImpl.kt
@@ -38,11 +38,6 @@ class KikCodeScannerImpl : KikCodeScanner {
     override suspend fun scanKikCode(imageData: ByteArray, width: Int, height: Int): Result<ScannableKikCode> {
         val source = PlanarYUVLuminanceSource(imageData, width, height, 0, 0, width, height, false)
 
-        val yuv = YuvImage(imageData, ImageFormat.NV21, width, height, null)
-
-        val bos = ByteArrayOutputStream()
-        yuv.compressToJpeg(Rect(0, 0, yuv.width, yuv.height), 100, bos)
-
         return try {
             val scanResult = Scanner.scan(source.matrix, width, height, SCAN_QUALITY) ?: throw KikCodeScanner.NoKikCodeFoundException()
             runCatching { KikCode.parse(scanResult.data)?.toModelKikCode() ?: throw KikCodeScanner.NoKikCodeFoundException() }


### PR DESCRIPTION
The YUV image nor the compressed result were actually being used so we can remove these safely and resolve the crash on certain device sets entirely.