### PR TITLE
chore(ci): add type: build label to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,9 @@ updates:
   schedule:
     interval: weekly
   open-pull-requests-limit: 10
+  labels:
+    - "dependencies"
+    - "type: build"
   target-branch: code/cash
   reviewers:
   - bmc08gt


### PR DESCRIPTION
## Summary
- Adds explicit `labels` config to `.github/dependabot.yml` so Dependabot PRs automatically receive both `dependencies` and `type: build` labels.