### PR TITLE
chore(ci): add auto-labeler for PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -83,6 +83,12 @@
           - "apps/flipcash/shared/push/**"
           - "libs/messaging/**"
 
+"area: deeplinks":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "apps/flipcash/shared/router/**"
+          - "apps/flipcash/shared/onramp/deeplinks/**"
+
 "area: build-system":
   - changed-files:
       - any-glob-to-any-file:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,94 @@
+"area: payments":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "apps/flipcash/shared/payments/**"
+          - "apps/flipcash/features/cash/**"
+          - "apps/flipcash/features/transactions/**"
+          - "apps/flipcash/features/withdrawal/**"
+          - "apps/flipcash/shared/transfers/**"
+          - "apps/flipcash/shared/bills/**"
+          - "apps/flipcash/shared/google-play-billing/**"
+          - "definitions/**/micropayment/**"
+
+"area: crypto":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "libs/crypto/**"
+          - "libs/encryption/**"
+          - "services/opencode/**/solana/**"
+
+"area: intents":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "services/code/**/intents/**"
+          - "services/flipchat/**/intents/**"
+          - "services/opencode/**/intents/**"
+
+"area: auth":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "apps/flipcash/features/login/**"
+          - "apps/flipcash/shared/authentication/**"
+          - "apps/flipcash/shared/accesskey/**"
+          - "apps/flipcash/shared/session/**"
+          - "apps/flipcash/features/contact-verification/**"
+          - "apps/flipcash/shared/phone/**"
+
+"area: tokens":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "apps/flipcash/features/tokens/**"
+          - "apps/flipcash/shared/tokens/**"
+          - "apps/flipcash/core/**/tokens/**"
+
+"area: ui":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "ui/**"
+          - "apps/flipcash/shared/theme/**"
+          - "apps/flipcash/features/bill-customization/**"
+
+"area: network":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "libs/network/**"
+          - "services/code/**"
+          - "services/flipcash/**"
+          - "services/flipcash-compose/**"
+          - "services/opencode/**"
+          - "services/opencode-compose/**"
+          - "definitions/**"
+
+"area: onramp":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "apps/flipcash/features/onramp/**"
+          - "apps/flipcash/features/deposit/**"
+          - "apps/flipcash/features/purchase/**"
+          - "apps/flipcash/shared/onramp/**"
+
+"area: scanner":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "apps/flipcash/features/scanner/**"
+          - "ui/scanner/**"
+          - "vendor/**/scanner/**"
+          - "libs/code-detection/**"
+          - "libs/quickresponse/**"
+
+"area: notifications":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "apps/flipcash/shared/notifications/**"
+          - "apps/flipcash/shared/push/**"
+          - "libs/messaging/**"
+
+"area: build-system":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "build-logic/**"
+          - "build.gradle.kts"
+          - "settings.gradle.kts"
+          - "gradle/**"
+          - "gradle.properties"
+          - "*.versions.toml"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,56 @@
+name: Label PRs
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  area-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          sync-labels: false
+
+  type-label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const title = context.payload.pull_request.title;
+            const prefixMap = {
+              'feat': 'type: feature',
+              'fix': 'type: fix',
+              'refactor': 'type: refactor',
+              'chore': 'type: chore',
+              'build': 'type: build',
+              'test': 'type: test',
+              'docs': 'type: docs',
+            };
+
+            const match = title.match(/^(\w+)(\(.+\))?[!]?:/);
+            if (!match) return;
+
+            const prefix = match[1];
+            const label = prefixMap[prefix];
+            if (!label) return;
+
+            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            if (labels.some(l => l.name === label)) return;
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: [label],
+            });


### PR DESCRIPTION
## Summary
- Adds `.github/labeler.yml` with file-path-to-area-label mappings for all 11 area labels
- Adds `.github/workflows/labeler.yml` with two jobs:
  - **area-labels**: runs `actions/labeler@v5` to apply area labels based on changed files
  - **type-label**: parses conventional commit prefix from PR title and applies the matching `type:` label
- Labels are additive only — manually applied labels are never removed