### PR TITLE
style(discovery): use secondary text color for negative holder delta

### DIFF
--- a/apps/flipcash/features/discovery/src/main/kotlin/com/flipcash/app/discovery/internal/components/TokenMetricsRow.kt
+++ b/apps/flipcash/features/discovery/src/main/kotlin/com/flipcash/app/discovery/internal/components/TokenMetricsRow.kt
@@ -9,7 +9,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.Text
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -130,7 +130,10 @@ internal fun TokenMetricsRow(
                 Text(
                     modifier = Modifier.alignByBaseline(),
                     text = deltaForWindow,
-                    color = change.color,
+                    color = when (change) {
+                        LineTrend.Down -> CodeTheme.colors.textSecondary
+                        LineTrend.Up -> change.color
+                    },
                     style = CodeTheme.typography.caption,
                 )
             }


### PR DESCRIPTION
Use textSecondary instead of error red for negative holder count changes in the currencies list to reduce visual noise.