### PR TITLE
feat(bill-customization): generate gradient from random hue with fixed saturation/value stops

### DIFF
--- a/apps/flipcash/core/src/main/res/values/strings.xml
+++ b/apps/flipcash/core/src/main/res/values/strings.xml
@@ -373,7 +373,7 @@
     <string name="title_noTransactionHistory">No Activity</string>
     <string name="description_noTransactionHistory">Your recent activity will appear here when you send or receive money</string>
 
-    <string name="title_billCustomizer">Bill Creator</string>
+    <string name="title_billCustomizer">Bill Designer</string>
     <string name="title_createYourCurrency">Create Your Currency</string>
     <string name="subtitle_currencyCreatorInfo">Launch your own currency in minutes.\nReady to use right away.</string>
     <string name="title_currencyCreatorStepName">Name</string>

--- a/apps/flipcash/features/bill-customization/src/main/kotlin/com/flipcash/app/bill/customization/BillCustomizationScaffold.kt
+++ b/apps/flipcash/features/bill-customization/src/main/kotlin/com/flipcash/app/bill/customization/BillCustomizationScaffold.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -134,7 +135,6 @@ fun BillPlaygroundScaffold(content: @Composable () -> Unit) {
                 canCopy = controller.canCopy,
                 onUndo = { controller.dispatchEvent(Event.Undo) },
                 onCopy = { controller.dispatchEvent(Event.Copy) },
-                onBack = { controller.cancel() },
                 onDone = { controller.cancel() },
             )
         }
@@ -165,7 +165,6 @@ fun BillPlaygroundScaffold(content: @Composable () -> Unit) {
 @Composable
 private fun TopBar(
     modifier: Modifier = Modifier,
-    onBack: () -> Unit,
     canUndo: Boolean,
     canCopy: Boolean,
     onUndo: () -> Unit,
@@ -180,12 +179,12 @@ private fun TopBar(
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically
     ) {
-        AppBarDefaults.UpNavigation { onBack() }
-
         Row(
             horizontalArrangement = Arrangement.spacedBy(CodeTheme.dimens.grid.x2),
             verticalAlignment = Alignment.CenterVertically
         ) {
+            Spacer(Modifier.weight(1f))
+
             val undoAlpha by animateFloatAsState(
                 targetValue = if (canUndo) 1f else ContentAlpha.disabled,
             )

--- a/apps/flipcash/shared/bill-customization/src/main/kotlin/com/flipcash/app/bill/customization/internal/defaults/ColorDefaults.kt
+++ b/apps/flipcash/shared/bill-customization/src/main/kotlin/com/flipcash/app/bill/customization/internal/defaults/ColorDefaults.kt
@@ -1,7 +1,12 @@
 package com.flipcash.app.bill.customization.internal.defaults
 
+import androidx.compose.ui.graphics.Color
+import androidx.core.graphics.toColorInt
 import com.flipcash.app.bill.customization.models.ColorStore
 import com.getcode.opencode.model.ui.BillBackground
+import com.getcode.ui.utils.Hsv
+import com.getcode.ui.utils.color
+import com.getcode.ui.utils.hsv
 
 
 internal const val MaxGradientColors = 3
@@ -34,10 +39,18 @@ internal val PresetGradients: List<BillBackground.Gradient> = listOf(
 internal fun buildGradient(): List<ColorStore> {
     val swatches = PresetColorOptions
 
-    // return a random 3 color gradient
+    // select a random base
+    val base = Color(swatches.random().colorHex.toColorInt())
+
+    // mutate per recipe
+    val top = base.hsv.copy(s = 0.53f, v = 1f,)
+    val mid = base.hsv.copy(s = 1f, v = 0.71f,)
+    val bottom = base.hsv.copy(s = 1f, v = 0.23f,)
+
+    // return the random hue gradient
     return listOf(
-        ColorStore(swatches.random().colorHex),
-        ColorStore(swatches.random().colorHex),
-        ColorStore(swatches.random().colorHex),
+        ColorStore(top.color),
+        ColorStore(mid.color),
+        ColorStore(bottom.color),
     )
 }


### PR DESCRIPTION
- Replace independent random swatch selection with a single random base hue, deriving top/mid/bottom gradient colors via HSV adjustments for a more cohesive bill gradient.
- Update name of Bill Creator in Advanced Settings to Bill Designer
- Hide back button from designer