### PR TITLE
fix(oc): replace hex dump of ByteString fields with size summary in gRPC logging

### DIFF
--- a/services/opencode/src/main/kotlin/com/getcode/opencode/utils/logging/LoggingClientCallListener.kt
+++ b/services/opencode/src/main/kotlin/com/getcode/opencode/utils/logging/LoggingClientCallListener.kt
@@ -135,7 +135,7 @@ private fun formatFieldValue(fieldName: String, value: Any): String? = when (val
         if (value.serializedSize == 0) null else formatProto(value)
     }
     is ByteString -> {
-        if (value.isEmpty) null else value.toByteArray().toHex().masked()
+        if (value.isEmpty) null else "<${value.size()} bytes>"
     }
     is List<*> -> {
         if (value.isEmpty()) null


### PR DESCRIPTION
Large ByteString values (e.g. image payloads) were being fully hex-encoded and logged, causing excessive memory allocation and log output that degraded image processing performance. Now logs just the byte count instead.