### PR TITLE
fix(startup): move CameraX initialization off main thread

### DIFF
--- a/apps/flipcash/app/src/main/kotlin/com/flipcash/app/internal/startup/CameraXInitializer.kt
+++ b/apps/flipcash/app/src/main/kotlin/com/flipcash/app/internal/startup/CameraXInitializer.kt
@@ -3,10 +3,15 @@ package com.flipcash.app.internal.startup
 import android.content.Context
 import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.startup.Initializer
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
 class CameraXInitializer: Initializer<Unit> {
     override fun create(context: Context) {
-        ProcessCameraProvider.getInstance(context)
+        CoroutineScope(Dispatchers.IO).launch {
+            ProcessCameraProvider.getInstance(context)
+        }
     }
 
     override fun dependencies(): List<Class<out Initializer<*>?>?> {


### PR DESCRIPTION
Dispatch ProcessCameraProvider.getInstance() to Dispatchers.IO to avoid blocking the main thread during ContentProvider initialization.