### PR TITLE
fix(crypto): add Parcelable.Creator to Mint to prevent ClassCastException

### DIFF
--- a/libs/encryption/keys/src/main/kotlin/com/getcode/solana/keys/Mint.kt
+++ b/libs/encryption/keys/src/main/kotlin/com/getcode/solana/keys/Mint.kt
@@ -1,5 +1,7 @@
 package com.getcode.solana.keys
 
+import android.os.Parcel
+import android.os.Parcelable
 import com.getcode.utils.serializer.MintAsStringSerializer
 import com.getcode.vendor.Base58
 import kotlinx.serialization.Serializable
@@ -9,6 +11,13 @@ class Mint(bytes: List<Byte>): PublicKey(bytes) {
     constructor(base58: String) : this(Base58.decode(base58).toList())
 
     companion object {
+        @JvmField
+        val CREATOR: Parcelable.Creator<Mint> =
+            object : Parcelable.Creator<Mint> {
+                override fun createFromParcel(parcel: Parcel) = Mint(parcel.readString().orEmpty())
+                override fun newArray(size: Int) = arrayOfNulls<Mint?>(size)
+            }
+
         val kin: Mint
             get() = Mint("kinXdEcpDQeHPEuQnqmUgtYykqKGVFq6CeVX5iAHJq6")
 


### PR DESCRIPTION
Mint inherits from PublicKey but lacked its own CREATOR, causing PublicKey.CREATOR to be used during unparceling. This returned a PublicKey instance that failed to cast to Mint during state restoration.