### PR TITLE
fix(bugsnag): prioritize production track when resolving release stage

### DIFF
--- a/apps/flipcash/shared/appupdates/src/main/kotlin/com/flipcash/app/updates/ReleaseStageProvider.kt
+++ b/apps/flipcash/shared/appupdates/src/main/kotlin/com/flipcash/app/updates/ReleaseStageProvider.kt
@@ -9,10 +9,10 @@ interface ReleaseStageProvider {
 internal fun resolveStage(manifest: ReleaseManifest, versionCode: Int): ReleaseStage {
     val tracks = manifest.tracks
     return when (versionCode) {
-        tracks.internal?.versionCode -> ReleaseStage.Internal
-        tracks.alpha?.versionCode -> ReleaseStage.Alpha
-        tracks.beta?.versionCode -> ReleaseStage.Beta
         tracks.production?.versionCode -> ReleaseStage.Production
+        tracks.beta?.versionCode -> ReleaseStage.Beta
+        tracks.alpha?.versionCode -> ReleaseStage.Alpha
+        tracks.internal?.versionCode -> ReleaseStage.Internal
         else -> {
             val prodCode = tracks.production?.versionCode
             if (prodCode != null && versionCode > prodCode) ReleaseStage.Internal else ReleaseStage.Production


### PR DESCRIPTION
Reorder when branches so production is checked before internal, preventing promoted versions from being misreported as Internal.