### PR TITLE
fix(cash): race between give transactor dispose and start on quick bg/fg

### DIFF
--- a/services/opencode/src/main/kotlin/com/getcode/opencode/internal/transactors/GiveBillTransactor.kt
+++ b/services/opencode/src/main/kotlin/com/getcode/opencode/internal/transactors/GiveBillTransactor.kt
@@ -21,6 +21,7 @@ import com.getcode.utils.TraceType
 import com.getcode.utils.trace
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.isActive
 import kotlin.time.Duration
 
 /**
@@ -112,6 +113,10 @@ internal class GiveBillTransactor(
      * @return the confirmed [TransactionMetadata.SendPublicPayment] on success.
      */
     suspend fun start(): Result<TransactionMetadata.SendPublicPayment> {
+        if (!scope.isActive) {
+            return logAndFail(GiveTransactorError.Other(message = "Transactor was disposed"))
+        }
+
         val ownerKey = owner
             ?: return logAndFail(GiveTransactorError.Other(message = "No owner key. Did you call with() first?"))
         val desiredToken = token
@@ -212,13 +217,13 @@ internal class GiveBillTransactor(
 
     /** Cancels the coroutine scope and clears all held state. */
     fun dispose() {
+        scope.cancel()
         owner = null
         presentationData = BillPresentationData(emptyList(), emptyList())
         rendezvousKey = null
         receivingAccount = null
         token = null
         providedVerifiedState = null
-        scope.cancel()
     }
 
     sealed class GiveTransactorError(

--- a/services/opencode/src/main/kotlin/com/getcode/opencode/managers/BillTransactionManager.kt
+++ b/services/opencode/src/main/kotlin/com/getcode/opencode/managers/BillTransactionManager.kt
@@ -4,7 +4,6 @@ import com.getcode.opencode.controllers.AccountController
 import com.getcode.opencode.controllers.MessagingController
 import com.getcode.opencode.controllers.TransactionController
 import com.getcode.opencode.exchange.VerifiedFiatCalculator
-import com.getcode.opencode.internal.domain.mapping.MintMapper
 import com.getcode.opencode.internal.manager.VerifiedState
 import com.getcode.opencode.internal.transactors.AccountClusterFactory
 import com.getcode.opencode.internal.transactors.BillPresentationData


### PR DESCRIPTION
When the user backgrounds and foregrounds quickly during an active give-bill flow, cancelAwaitForGrab() can dispose the transactor between with() and start(), nulling owner before start() reads it.

Fix by making the transactor self-protecting:
- Reorder dispose() to cancel the scope before nulling fields
- Check scope.isActive at the top of start() to bail out if disposed

Bugsnag: 6a021d748c3285d1a5987c43