### PR TITLE
chore: migrate to AGP 9.1.1 and Gradle 9.3.1

### DIFF
--- a/apps/flipcash/app/build.gradle.kts
+++ b/apps/flipcash/app/build.gradle.kts
@@ -14,9 +14,15 @@ plugins {
     alias(libs.plugins.firebase.perf)
     alias(libs.plugins.bugsnag.gradle)
     alias(libs.plugins.secrets)
-    alias(libs.plugins.versioning)
     id("org.jetbrains.kotlin.plugin.compose")
     alias(libs.plugins.kover)
+}
+
+fun gitVersionCode(): Int {
+    val result = providers.exec {
+        commandLine("git", "rev-list", "--count", "HEAD")
+    }.standardOutput.asText.get().trim()
+    return result.toInt().also { println("VersionCode $it") }
 }
 
 val contributorsSigningConfig = ContributorsSignatory(rootProject)
@@ -28,7 +34,7 @@ android {
     compileSdk = Android.compileSdkVersion
 
     defaultConfig {
-        versionCode = Packaging.Flipcash.versionCode ?: versioning.getVersionCode()
+        versionCode = Packaging.Flipcash.versionCode ?: gitVersionCode()
         versionName = Packaging.Flipcash.versionName
         applicationId = appNamespace
         minSdk = Android.minSdkVersion
@@ -54,6 +60,7 @@ android {
     buildFeatures {
         buildConfig = true
         compose = true
+        resValues = true
     }
 
     buildTypes {
@@ -99,11 +106,6 @@ configurations.all {
     // for error reporting. Without the Crashlytics Gradle plugin the SDK crashes
     // at startup due to a missing build ID resource.
     exclude(group = "com.google.firebase", module = "firebase-crashlytics")
-}
-
-versioning {
-    excludeBuildTypes = "debug"
-    keepOriginalBundleFile = true
 }
 
 bugsnag {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,6 @@ plugins {
     alias(libs.plugins.bugsnag.android) apply false
     alias(libs.plugins.bugsnag.gradle) apply false
     alias(libs.plugins.secrets) apply false
-    alias(libs.plugins.versioning) apply false
     alias(libs.plugins.navigation.safeargs) apply false
     alias(libs.plugins.protobuf) apply false
     alias(libs.plugins.androidx.room) apply false

--- a/gradle.properties
+++ b/gradle.properties
@@ -37,3 +37,8 @@ android.defaults.buildfeatures.usestaticrclass=true
 # Enables Kotlin compilation for Android testFixtures source sets
 android.experimental.enableTestFixturesKotlinSupport=true
 android.suppressUnsupportedOptionWarnings=android.suppressUnsupportedOptionWarnings,android.experimental.enableTestFixturesKotlinSupport
+android.uniquePackageNames=false
+android.dependency.useConstraints=true
+android.r8.strictFullModeForKeepRules=false
+android.builtInKotlin=false
+android.newDsl=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ kotlinx-serialization = "1.11.0"
 kotlinx-datetime = "0.7.1"
 
 kover = "0.9.8"
-agp = "8.9.3"
+agp = "9.1.1"
 google-services = "4.4.4"
 
 androidx-appcompat = "1.7.1"
@@ -97,7 +97,6 @@ archCore = "2.2.0"
 screenshot = "0.0.1-alpha14"
 
 secrets-gradle-plugin = "2.0.1"
-versioning-gradle-plugin = "2.4.0"
 firebase-perf-plugin = "2.0.2"
 uiToolingPreview = "1.11.0"
 uiTooling = "1.11.0"
@@ -334,7 +333,6 @@ firebase-perf = { id = "com.google.firebase.firebase-perf", version.ref = "fireb
 bugsnag-android = { id = "com.bugsnag.android.gradle", version.ref = "bugsnag-agp" }
 bugsnag-gradle = { id = "com.bugsnag.gradle", version.ref = "bugsnag-gradle-plugin" }
 secrets = { id = "com.google.android.libraries.mapsplatform.secrets-gradle-plugin", version.ref = "secrets-gradle-plugin" }
-versioning = { id = "de.nanogiants.android-versioning", version.ref = "versioning-gradle-plugin" }
 navigation-safeargs = { id = "androidx.navigation.safeargs.kotlin", version.ref = "androidx-navigation" }
 protobuf = { id = "com.google.protobuf", version.ref = "protobuf-plugin" }
 androidx-room = { id = "androidx.room", version.ref = "androidx-room" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue May 13 10:46:03 EDT 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/vendor/opencv/sdk/build.gradle
+++ b/vendor/opencv/sdk/build.gradle
@@ -110,8 +110,6 @@ android {
         minSdkVersion Android.minSdkVersion
         targetSdkVersion Android.targetSdkVersion
 
-        versionCode openCVersionCode
-        versionName openCVersionName
 
         externalNativeBuild {
             cmake {
@@ -142,7 +140,7 @@ android {
                 doNotStrip '**/*.so'  // controlled by OpenCV CMake scripts
             }
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.txt'
         }
     }
 


### PR DESCRIPTION
- Upgrade AGP from 8.9.3 to 9.1.1 and Gradle wrapper from 8.11.1 to 9.3.1
- Remove de.nanogiants.android-versioning plugin (incompatible with Gradle 9 due to removed convention API); replace with inline gitVersionCode() using providers.exec for the same git rev-list --count HEAD logic
- Fix OpenCV proguard: use proguard-android-optimize.txt (AGP 9 removed support for the non-optimize variant)
- Move resValues = true from global gradle.properties into the app module buildFeatures block (the global default property is deprecated)
- Remove deprecated gradle.properties options no longer recognized: android.sdk.defaultTargetSdkToCompileSdkIfUnset, android.enableAppCompileTimeRClass, android.usesSdkInManifest.disallowed, android.r8.optimizedResourceShrinking

Remaining deprecated options kept intentionally:
- android.builtInKotlin=false and android.newDsl=false opt out of AGP 9 built-in Kotlin support. Removing them requires dropping org.jetbrains.kotlin.android from all 100+ modules and migrating to AGP built-in Kotlin compilation — planned as a follow-up.