### PR TITLE
chore: migrate to AGP built-in Kotlin compilation

### DIFF
--- a/apps/flipcash/app/build.gradle.kts
+++ b/apps/flipcash/app/build.gradle.kts
@@ -4,7 +4,6 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     id("com.android.application")
-    id("org.jetbrains.kotlin.android")
     id("org.jetbrains.kotlin.plugin.parcelize")
     id("com.google.devtools.ksp")
     id("org.jetbrains.kotlin.plugin.serialization")

--- a/build-logic/convention/src/main/kotlin/AndroidFeatureConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidFeatureConventionPlugin.kt
@@ -1,4 +1,4 @@
-import com.android.build.gradle.LibraryExtension
+import com.android.build.api.dsl.LibraryExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.VersionCatalogsExtension

--- a/build-logic/convention/src/main/kotlin/AndroidLibraryComposeConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidLibraryComposeConventionPlugin.kt
@@ -1,4 +1,4 @@
-import com.android.build.gradle.LibraryExtension
+import com.android.build.api.dsl.LibraryExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.VersionCatalogsExtension

--- a/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
@@ -1,4 +1,4 @@
-import com.android.build.gradle.LibraryExtension
+import com.android.build.api.dsl.LibraryExtension
 import org.gradle.api.JavaVersion
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -15,7 +15,6 @@ class AndroidLibraryConventionPlugin : Plugin<Project> {
         with(target) {
             with(pluginManager) {
                 apply("com.android.library")
-                apply("org.jetbrains.kotlin.android")
                 apply("org.jetbrains.kotlin.plugin.serialization")
                 if (!providers.gradleProperty("skipCoverage").orNull.toBoolean()) {
                     apply("org.jetbrains.kotlinx.kover")
@@ -60,6 +59,9 @@ class AndroidLibraryConventionPlugin : Plugin<Project> {
             dependencies {
                 "implementation"(libs.findLibrary("timber").get())
                 "implementation"(libs.findLibrary("kotlinx-coroutines-core").get())
+                // AGP's built-in Kotlin no longer auto-selects the kotlin-test
+                // JUnit variant, so provide it explicitly for all library modules.
+                "testImplementation"(libs.findLibrary("kotlin-test-junit").get())
             }
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,6 @@ buildscript {
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.android.library) apply false
-    alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.parcelize) apply false
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.kotlin.ksp) apply false

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,5 +40,3 @@ android.suppressUnsupportedOptionWarnings=android.suppressUnsupportedOptionWarni
 android.uniquePackageNames=false
 android.dependency.useConstraints=true
 android.r8.strictFullModeForKeepRules=false
-android.builtInKotlin=false
-android.newDsl=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,7 +38,7 @@ compose-webview = "2.0.3"
 compose-accompanist = "0.36.0"
 compose-coil = "3.4.0"
 
-hilt = "2.58"
+hilt = "2.59.2"
 hilt-jetpack = "1.3.0"
 okhttp = "5.3.2"
 retrofit = "3.0.0"
@@ -160,6 +160,7 @@ hilt-nav-compose = { module = "androidx.hilt:hilt-navigation-compose", version.r
 # Kotlin
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
+kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-play-services = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-play-services", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-rx3 = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-rx3", version.ref = "kotlinx-coroutines" }


### PR DESCRIPTION
Remove org.jetbrains.kotlin.android plugin in favor of AGP 9's built-in Kotlin support. Upgrade Hilt to 2.59.2 for AGP 9 new DSL compatibility and switch convention plugins to com.android.build.api.dsl.LibraryExtension. Add explicit kotlin-test-junit dependency since AGP's built-in Kotlin does not auto-select the JUnit variant for kotlin("test").