### PR TITLE
fix(phone): prevent crash when country locale list is empty

### DIFF
--- a/apps/flipcash/shared/phone/src/main/kotlin/com/flipcash/app/phone/PhoneUtils.kt
+++ b/apps/flipcash/shared/phone/src/main/kotlin/com/flipcash/app/phone/PhoneUtils.kt
@@ -41,7 +41,14 @@ class PhoneUtils @Inject constructor(
         countryCodesMap = countryLocales.map { it }.associateBy { it.phoneCode }
         val isoCountry = Locale.getDefault().country
         defaultCountryLocale =
-            countryLocales.find { it.countryCode == isoCountry } ?: countryLocales.first()
+            countryLocales.find { it.countryCode == isoCountry }
+                ?: countryLocales.firstOrNull()
+                ?: CountryLocale(
+                    name = Locale(Locale.getDefault().language, isoCountry).displayCountry,
+                    phoneCode = phoneNumberUtil.getCountryCodeForRegion(isoCountry),
+                    countryCode = isoCountry,
+                    resId = null
+                )
     }
 
 


### PR DESCRIPTION
PhoneUtils.init called .first() on countryLocales after filtering to entries with flag drawables. If no flags resolved, the list was empty causing NoSuchElementException and a fatal crash on launch.

Use .firstOrNull() with a fallback CountryLocale from the device locale instead.