### PR TITLE
fix(onramp): map region mismatch error and show proper alert

### DIFF
--- a/apps/flipcash/shared/onramp/coinbase/src/main/kotlin/com/flipcash/app/onramp/CoinbaseOnRampHandler.kt
+++ b/apps/flipcash/shared/onramp/coinbase/src/main/kotlin/com/flipcash/app/onramp/CoinbaseOnRampHandler.kt
@@ -77,6 +77,13 @@ private fun showOnRampFailure(resources: Resources, error: CoinbaseOnRampWebErro
             )
         }
 
+        is CoinbaseOnRampWebError.GuestRegionMismatch -> {
+            BottomBarManager.showAlert(
+                title = resources.getString(R.string.error_title_onrampRegionMismatch),
+                message = resources.getString(R.string.error_description_onrampRegionMismatch),
+            )
+        }
+
         is CoinbaseOnRampWebError.GuestGooglePayError -> {
             BottomBarManager.showError(
                 title = resources.getString(R.string.error_title_onrampTransactionFailed),

--- a/apps/flipcash/shared/onramp/coinbase/src/main/kotlin/com/flipcash/app/onramp/internal/CoinbaseOnRampEventHandler.kt
+++ b/apps/flipcash/shared/onramp/coinbase/src/main/kotlin/com/flipcash/app/onramp/internal/CoinbaseOnRampEventHandler.kt
@@ -274,6 +274,7 @@ sealed class CoinbaseOnRampWebError(val data: String? = null): Throwable() {
     class GuestTransactionSendFailed(data: String? = null) : CoinbaseOnRampWebError(data), NotifiableError
     class GuestTransactionAvsValidationFailed(data: String? = null) : CoinbaseOnRampWebError(data)
     class GuestTransactionTransactionFailed(data: String? = null) : CoinbaseOnRampWebError(data), NotifiableError
+    class GuestRegionMismatch(data: String? = null) : CoinbaseOnRampWebError(data)
     class GuestGooglePayNotReady(data: String? = null) : CoinbaseOnRampWebError(data)
     class Internal(data: String? = null) : CoinbaseOnRampWebError(data), NotifiableError
     class GooglePayButtonNotFound(data: String? = null) : CoinbaseOnRampWebError(data), NotifiableError
@@ -290,6 +291,7 @@ sealed class CoinbaseOnRampWebError(val data: String? = null): Throwable() {
                 "ERROR_CODE_GUEST_TRANSACTION_SEND_FAILED" -> GuestTransactionSendFailed(data)
                 "ERROR_CODE_GUEST_TRANSACTION_AVS_VALIDATION_FAILED" -> GuestTransactionAvsValidationFailed(data)
                 "ERROR_CODE_GUEST_TRANSACTION_TRANSACTION_FAILED" -> GuestTransactionTransactionFailed(data)
+                "ERROR_CODE_GUEST_REGION_MISMATCH" -> GuestRegionMismatch(data)
                 "ERROR_CODE_GUEST_GOOGLE_PAY_NOT_READY" -> GuestGooglePayNotReady(data)
                 "ERROR_CODE_INTERNAL" -> Internal(data)
                 "ERROR_CODE_GOOGLE_PAY_BUTTON_NOT_FOUND" -> GooglePayButtonNotFound(data)

--- a/apps/flipcash/shared/onramp/coinbase/src/test/kotlin/com/flipcash/app/onramp/internal/CoinbaseOnRampEventHandlerTest.kt
+++ b/apps/flipcash/shared/onramp/coinbase/src/test/kotlin/com/flipcash/app/onramp/internal/CoinbaseOnRampEventHandlerTest.kt
@@ -210,6 +210,7 @@ class CoinbaseOnRampWebErrorTest {
             "ERROR_CODE_GUEST_TRANSACTION_SEND_FAILED" to CoinbaseOnRampWebError.GuestTransactionSendFailed::class,
             "ERROR_CODE_GUEST_TRANSACTION_AVS_VALIDATION_FAILED" to CoinbaseOnRampWebError.GuestTransactionAvsValidationFailed::class,
             "ERROR_CODE_GUEST_TRANSACTION_TRANSACTION_FAILED" to CoinbaseOnRampWebError.GuestTransactionTransactionFailed::class,
+            "ERROR_CODE_GUEST_REGION_MISMATCH" to CoinbaseOnRampWebError.GuestRegionMismatch::class,
             "ERROR_CODE_INTERNAL" to CoinbaseOnRampWebError.Internal::class,
             "ERROR_CODE_GOOGLE_PAY_BUTTON_NOT_FOUND" to CoinbaseOnRampWebError.GooglePayButtonNotFound::class,
         )
@@ -240,6 +241,12 @@ class CoinbaseOnRampWebErrorTest {
         val error = CoinbaseOnRampWebError.WebViewTimeout()
         assertIs<NotifiableError>(error)
         assertIs<Throwable>(error)
+    }
+
+    @Test
+    fun guestRegionMismatchIsNotNotifiable() {
+        val error = CoinbaseOnRampWebError.GuestRegionMismatch()
+        assertFalse(error is NotifiableError)
     }
 
     @Test


### PR DESCRIPTION
ERROR_CODE_GUEST_REGION_MISMATCH was falling through to Unknown, reporting noise to Bugsnag and showing a generic error. Add dedicated GuestRegionMismatch type (non-notifiable) with the existing region mismatch alert strings.