### PR TITLE
fix(logging): filter FIS_AUTH_ERROR from Bugsnag reports

### DIFF
--- a/libs/logging/src/main/kotlin/com/getcode/utils/ErrorUtils.kt
+++ b/libs/logging/src/main/kotlin/com/getcode/utils/ErrorUtils.kt
@@ -80,10 +80,11 @@ object ErrorUtils {
                 throwable is UnknownHostException ||
                 throwable.cause is UnknownHostException
 
-    private fun isGmsTransientError(throwable: Throwable): Boolean {
-        fun check(t: Throwable?) = t is java.io.IOException && t.message == "SERVICE_NOT_AVAILABLE"
-        return check(throwable) || check(throwable.cause)
-    }
+    private val gmsTransientMessages = setOf("SERVICE_NOT_AVAILABLE", "FIS_AUTH_ERROR")
+
+    private fun isGmsTransientError(throwable: Throwable): Boolean =
+        generateSequence(throwable) { it.cause }
+            .any { it is java.io.IOException && it.message in gmsTransientMessages }
 
     val ignoredGrpcStatusCodes = setOf(
         // Transport/transient


### PR DESCRIPTION
Firebase Installations Service auth errors are transient and not actionable from the client. Expand isGmsTransientError() to catch FIS_AUTH_ERROR and walk the full cause chain so nested IOExceptions are detected.