### PR TITLE
chore: remove RxJava dependency entirely

### DIFF
--- a/apps/flipcash/app/src/main/kotlin/com/flipcash/app/FlipcashApp.kt
+++ b/apps/flipcash/app/src/main/kotlin/com/flipcash/app/FlipcashApp.kt
@@ -14,10 +14,8 @@ import coil3.request.crossfade
 import com.flipcash.app.auth.AuthManager
 import com.flipcash.app.currency.PreferredCurrencyController
 import com.getcode.opencode.repositories.EventRepository
-import com.getcode.utils.ErrorUtils
 import com.getcode.utils.trace
 import dagger.hilt.android.HiltAndroidApp
-import io.reactivex.rxjava3.plugins.RxJavaPlugins
 import javax.inject.Inject
 
 @HiltAndroidApp
@@ -43,10 +41,6 @@ class FlipcashApp : Application(), Configuration.Provider, SingletonImageLoader.
 
     override fun onCreate() {
         super.onCreate()
-
-        RxJavaPlugins.setErrorHandler {
-            ErrorUtils.handleError(it)
-        }
 
         authManager.init()
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -42,9 +42,6 @@ hilt = "2.59.2"
 hilt-jetpack = "1.3.0"
 okhttp = "5.3.2"
 retrofit = "3.0.0"
-rxjava = "3.1.12"
-rxandroid = "3.0.2"
-
 kin-sdk = "2.1.2"
 grpc-android = "1.81.0"
 slf4j = "1.7.36"
@@ -130,7 +127,6 @@ lifecycle-viewmodel-navigation3 = { module = "androidx.lifecycle:lifecycle-viewm
 androidx-browser = { module = "androidx.browser:browser", version.ref = "androidx-browser" }
 androidx-paging-runtime = { module = "androidx.paging:paging-runtime-ktx", version.ref = "androidx-paging" }
 androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "androidx-room" }
-androidx-room-rxjava3 = { module = "androidx.room:room-rxjava3", version.ref = "androidx-room" }
 androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref = "androidx-room" }
 androidx-room-ktx = { module = "androidx.room:room-ktx", version.ref = "androidx-room" }
 androidx-room-paging = { module = "androidx.room:room-paging", version.ref = "androidx-room" }
@@ -163,7 +159,6 @@ kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref =
 kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-play-services = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-play-services", version.ref = "kotlinx-coroutines" }
-kotlinx-coroutines-rx3 = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-rx3", version.ref = "kotlinx-coroutines" }
 kotlinx-collections-immutable = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version = "0.4.0" }
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }
 kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlinx-serialization" }
@@ -199,10 +194,6 @@ voyager-hilt = { module = "cafe.adriel.voyager:voyager-hilt", version.ref = "voy
 voyager-bottomsheet = { module = "cafe.adriel.voyager:voyager-bottom-sheet-navigator", version.ref = "voyager" }
 voyager-tabs = { module = "cafe.adriel.voyager:voyager-tab-navigator", version.ref = "voyager" }
 voyager-transitions = { module = "cafe.adriel.voyager:voyager-transitions", version.ref = "voyager" }
-
-# RxJava
-rxjava = { module = "io.reactivex.rxjava3:rxjava", version.ref = "rxjava" }
-rxandroid = { module = "io.reactivex.rxjava3:rxandroid", version.ref = "rxandroid" }
 
 # Networking / gRPC / Protobuf
 slf4j = { module = "org.slf4j:slf4j-android", version.ref = "slf4j" }

--- a/libs/locale/impl/build.gradle.kts
+++ b/libs/locale/impl/build.gradle.kts
@@ -14,7 +14,6 @@ dependencies {
     api(libs.androidx.annotation)
     api(libs.kotlin.stdlib)
     api(libs.kotlinx.coroutines.core)
-    api(libs.kotlinx.coroutines.rx3)
 
     implementation(libs.bundles.hilt)
     ksp(libs.bundles.hilt.compiler)

--- a/libs/locale/public/build.gradle.kts
+++ b/libs/locale/public/build.gradle.kts
@@ -13,5 +13,4 @@ dependencies {
     api(libs.androidx.annotation)
     api(libs.kotlin.stdlib)
     api(libs.kotlinx.coroutines.core)
-    api(libs.kotlinx.coroutines.rx3)
 }

--- a/libs/logging/build.gradle.kts
+++ b/libs/logging/build.gradle.kts
@@ -29,7 +29,6 @@ dependencies {
 
     api(libs.timber)
     implementation(libs.androidx.annotation)
-    implementation(libs.rxjava)
     implementation(libs.grpc.kotlin)
     implementation(project(":libs:messaging"))
 }

--- a/libs/logging/src/main/kotlin/com/getcode/utils/ErrorUtils.kt
+++ b/libs/logging/src/main/kotlin/com/getcode/utils/ErrorUtils.kt
@@ -6,8 +6,6 @@ import com.getcode.manager.TopBarManager
 import io.grpc.Status
 import io.grpc.StatusException
 import io.grpc.StatusRuntimeException
-import io.reactivex.rxjava3.exceptions.OnErrorNotImplementedException
-import io.reactivex.rxjava3.exceptions.UndeliverableException
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.TimeoutCancellationException
 import timber.log.Timber
@@ -40,7 +38,7 @@ object ErrorUtils {
         if (isGmsTransientError(throwable)) return
 
         val throwableCause: Throwable =
-            if (throwable.cause != null && (throwable is UndeliverableException || throwable is OnErrorNotImplementedException || throwable is CodeServerError))
+            if (throwable.cause != null && throwable is CodeServerError)
                 throwable.cause ?: throwable
             else throwable
 

--- a/services/flipcash-compose/build.gradle.kts
+++ b/services/flipcash-compose/build.gradle.kts
@@ -36,7 +36,6 @@ dependencies {
     implementation(libs.androidx.lifecycle.runtime)
     implementation(libs.androidx.room.runtime)
     implementation(libs.androidx.room.ktx)
-    implementation(libs.androidx.room.rxjava3)
     implementation(libs.androidx.room.paging)
     implementation(libs.okhttp)
     implementation(libs.mixpanel)

--- a/services/flipcash/build.gradle.kts
+++ b/services/flipcash/build.gradle.kts
@@ -41,7 +41,6 @@ dependencies {
     implementation(libs.androidx.lifecycle.runtime)
     implementation(libs.androidx.room.runtime)
     implementation(libs.androidx.room.ktx)
-    implementation(libs.androidx.room.rxjava3)
     implementation(libs.androidx.room.paging)
     implementation(libs.okhttp)
     implementation(libs.mixpanel)

--- a/ui/navigation/build.gradle.kts
+++ b/ui/navigation/build.gradle.kts
@@ -18,8 +18,6 @@ dependencies {
     api(project(":ui:resources"))
     implementation(project(":ui:theme"))
 
-    api(libs.rxjava)
-
     implementation(libs.compose.material3)
     implementation(libs.compose.activities)
     implementation(libs.bundles.kotlinx.serialization)

--- a/ui/navigation/src/main/kotlin/com/getcode/view/BaseViewModel.kt
+++ b/ui/navigation/src/main/kotlin/com/getcode/view/BaseViewModel.kt
@@ -2,7 +2,6 @@ package com.getcode.view
 
 import androidx.lifecycle.ViewModel
 import com.getcode.util.resources.ResourceHelper
-import io.reactivex.rxjava3.disposables.CompositeDisposable
 
 @Deprecated(
     message = "Replaced With BaseViewModel2",
@@ -10,13 +9,6 @@ import io.reactivex.rxjava3.disposables.CompositeDisposable
 abstract class BaseViewModel(
     private val resources: ResourceHelper,
 ) : ViewModel() {
-    private val compositeDisposable = CompositeDisposable()
-
-    override fun onCleared() {
-        super.onCleared()
-        compositeDisposable.clear()
-    }
-
     open fun setIsLoading(isLoading: Boolean) {}
 
     fun getString(resId: Int): String = resources.getString(resId)

--- a/ui/resources/build.gradle.kts
+++ b/ui/resources/build.gradle.kts
@@ -13,5 +13,4 @@ dependencies {
     implementation(libs.androidx.exifinterface)
     api(libs.kotlin.stdlib)
     api(libs.kotlinx.coroutines.core)
-    api(libs.kotlinx.coroutines.rx3)
 }


### PR DESCRIPTION
RxJava was no longer used in any application code. Remove all traces including rxjava, rxandroid, room-rxjava3, and kotlinx-coroutines-rx3 from dependencies and version catalog.