### PR TITLE
fix: keep dynamically-referenced resources from shrinking

### DIFF
--- a/apps/flipcash/app/src/main/res/raw/com.flipcash.app.android.keep.xml
+++ b/apps/flipcash/app/src/main/res/raw/com.flipcash.app.android.keep.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools"
+    tools:keep="@drawable/ic_flag_*,@drawable/ic_currency_*,@drawable/bill_texture_*" />


### PR DESCRIPTION
Flag icons, currency icons, and bill textures are only referenced via getIdentifier() at runtime, causing the resource shrinker to strip them in release builds.