### PR TITLE
fix: preserve exception chain in FailedToSubmitBuyToServer

### DIFF
--- a/apps/flipcash/shared/onramp/deeplinks/src/main/kotlin/com/flipcash/app/onramp/PhantomWalletController.kt
+++ b/apps/flipcash/shared/onramp/deeplinks/src/main/kotlin/com/flipcash/app/onramp/PhantomWalletController.kt
@@ -252,7 +252,7 @@ class PhantomWalletController @Inject constructor(
                 signature = signature,
             ).getOrElse { cause ->
                 return@withContext Result.failure(
-                    DeeplinkOnRampError.FailedToSubmitBuyToServer(message = cause.message)
+                    DeeplinkOnRampError.FailedToSubmitBuyToServer(message = cause.message, cause = cause)
                 )
             }
 


### PR DESCRIPTION
Pass `cause` through when wrapping gRPC errors so
FlipcashBugsnagErrorCallback can unwrap to the underlying StatusException and correctly filter handled INTERNAL errors.