### PR TITLE
fix: make Firebase initialization synchronous to prevent race condition

### DIFF
--- a/apps/flipcash/app/src/main/kotlin/com/flipcash/app/internal/startup/FirebaseInitializer.kt
+++ b/apps/flipcash/app/src/main/kotlin/com/flipcash/app/internal/startup/FirebaseInitializer.kt
@@ -4,15 +4,10 @@ import android.content.Context
 import androidx.startup.Initializer
 import com.google.firebase.Firebase
 import com.google.firebase.initialize
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 
 class FirebaseInitializer: Initializer<Unit> {
     override fun create(context: Context) {
-        CoroutineScope(Dispatchers.IO).launch {
-            Firebase.initialize(context)
-        }
+        Firebase.initialize(context)
     }
 
     override fun dependencies(): List<Class<out Initializer<*>?>?> {


### PR DESCRIPTION
FirebaseInitializer was launching Firebase.initialize() on Dispatchers.IO, but UserManager accesses Firebase.messaging.token synchronously during Hilt injection in Application.onCreate(). This race causes IllegalStateException when the IO coroutine hasn't completed before injection runs.