### PR TITLE
fix: preserve source file names in R8 to fix error modal call site tracking

### DIFF
--- a/apps/flipcash/app/proguard-rules.pro
+++ b/apps/flipcash/app/proguard-rules.pro
@@ -3,6 +3,9 @@
 -obfuscationdictionary shuffled-dictionary.txt
 -classobfuscationdictionary shuffled-dictionary.txt
 
+# Preserve source file names and line numbers for stack traces (call site tracking, Bugsnag)
+-keepattributes SourceFile,LineNumberTable
+
 # Keep screen names
 -keepnames class * implements cafe.adriel.voyager.core.screen.Screen
 


### PR DESCRIPTION
Without -keepattributes SourceFile,LineNumberTable, R8 replaces source file names with its mapping hash, causing call sites to appear as r8-map-id-<hash>:<line> instead of the actual file and line number.