### PR TITLE
feat: return SwapResult.OpenDeposit to Token Info and push Deposit in-stack

### DIFF
--- a/apps/flipcash/features/tokens/src/main/kotlin/com/flipcash/app/tokens/SwapFlowScreen.kt
+++ b/apps/flipcash/features/tokens/src/main/kotlin/com/flipcash/app/tokens/SwapFlowScreen.kt
@@ -1,12 +1,10 @@
 package com.flipcash.app.tokens
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.snapshots.Snapshot
 import androidx.navigation3.runtime.NavEntry
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entryProvider
 import com.flipcash.app.core.AppRoute
-import com.flipcash.app.core.extensions.openAsSheet
 import com.flipcash.app.core.tokens.SwapResult
 import com.flipcash.app.core.tokens.SwapStep
 import com.getcode.navigation.annotatedEntry
@@ -18,7 +16,6 @@ import com.getcode.navigation.flow.FlowHost
 import com.getcode.navigation.flow.deliverFlowResult
 import com.getcode.navigation.results.NavResultOrCanceled
 import com.getcode.navigation.results.NavResultStateRegistry
-import com.getcode.navigation.scenes.LocalSheetNavigator
 
 @Composable
 fun SwapFlowScreen(
@@ -26,7 +23,6 @@ fun SwapFlowScreen(
     resultStateRegistry: NavResultStateRegistry,
 ) {
     val outerNavigator = LocalCodeNavigator.current
-    val rootNavigator = LocalSheetNavigator.current
     val initialStack = route.rememberInitialStack<SwapStep>()
 
     FlowHost<SwapStep, SwapResult>(
@@ -38,27 +34,17 @@ fun SwapFlowScreen(
                 FlowExitReason.Canceled,
                 FlowExitReason.BackedOutOfRoot -> SwapResult.Canceled
             }
+            outerNavigator.deliverFlowResult(
+                route = route,
+                value = NavResultOrCanceled.ReturnValue(result),
+            )
             when (result) {
-                is SwapResult.OpenDeposit -> {
-                    Snapshot.withMutableSnapshot {
-                        rootNavigator?.hide()
-                        // can only deposit USDC from this flow
-                        rootNavigator?.openAsSheet(AppRoute.Transfers.Deposit(showOtherOptions = false))
-                    }
+                SwapResult.Success -> {
+                    if (route.shortfall != null) outerNavigator.popAll()
+                    else outerNavigator.popUntil { it is AppRoute.Token.Info }
                 }
-                else -> {
-                    outerNavigator.deliverFlowResult(
-                        route = route,
-                        value = NavResultOrCanceled.ReturnValue(result),
-                    )
-                    when (result) {
-                        SwapResult.Success -> {
-                            if (route.shortfall != null) outerNavigator.popAll()
-                            else outerNavigator.popUntil { it is AppRoute.Token.Info }
-                        }
-                        SwapResult.Canceled -> outerNavigator.pop()
-                    }
-                }
+                SwapResult.OpenDeposit,
+                SwapResult.Canceled -> outerNavigator.pop()
             }
         },
         entryProvider = swapEntryProvider(),

--- a/apps/flipcash/features/tokens/src/main/kotlin/com/flipcash/app/tokens/TokenInfoScreen.kt
+++ b/apps/flipcash/features/tokens/src/main/kotlin/com/flipcash/app/tokens/TokenInfoScreen.kt
@@ -14,12 +14,15 @@ import com.flipcash.app.analytics.Analytics
 import com.flipcash.app.analytics.Button
 import com.flipcash.app.analytics.rememberAnalytics
 import com.flipcash.app.core.AppRoute
+import com.flipcash.app.core.tokens.SwapResult
 import com.flipcash.app.core.ui.TokenIconWithName
 import com.flipcash.app.tokens.internal.TokenInfoScreen
 import com.flipcash.app.tokens.ui.TokenInfoViewModel
 import com.flipcash.features.tokens.R
 import com.flipcash.services.internal.model.thirdparty.OnRampProvider
 import com.getcode.navigation.core.LocalCodeNavigator
+import com.getcode.navigation.results.NavResultOrCanceled
+import com.getcode.navigation.results.navigateForResult
 import com.getcode.opencode.model.financial.Fiat
 import com.getcode.solana.keys.Mint
 import com.getcode.theme.CodeTheme
@@ -105,8 +108,18 @@ fun TokenInfoScreen(
             viewModel.eventFlow
                 .filterIsInstance<TokenInfoViewModel.Event.OpenScreen>()
                 .map { it.screen }
-                .onEach {
-                    navigator.push(it)
+                .onEach { screen ->
+                    when (screen) {
+                        is AppRoute.Token.Swap -> {
+                            navigator.navigateForResult<SwapResult>(screen) { result ->
+                                if (result is NavResultOrCanceled.ReturnValue &&
+                                    result.value is SwapResult.OpenDeposit) {
+                                    navigator.push(AppRoute.Transfers.Deposit(showOtherOptions = false))
+                                }
+                            }
+                        }
+                        else -> navigator.push(screen)
+                    }
                 }.launchIn(this)
         }
     }


### PR DESCRIPTION
Instead of hiding the sheet and opening a new sheet for deposit when the user selects "other wallet" during swap, deliver the result back to Token Info via navigateForResult and push the deposit screen in-stack.