### PR TITLE
fix(payments): correct deposit USDC button label and action

### DIFF
--- a/apps/flipcash/core/src/main/res/values/strings.xml
+++ b/apps/flipcash/core/src/main/res/values/strings.xml
@@ -182,7 +182,7 @@
 
     <string name="title_learnToDeposit">Purchase USDF on a crypto exchange with your bank account, and then deposit into Flipcash</string>
     <string name="action_learnHowToDepositFunds">Learn How to Get USDF</string>
-    <string name="action_depositUsdc">Deposit USDF</string>
+    <string name="action_depositUsdc">Deposit USDC</string>
 
     <string name="title_learnToWithdraw">You can withdraw your funds at any time, and move them into your bank account</string>
     <string name="action_learnHowToWithdrawFunds">Learn How to Withdraw Funds</string>

--- a/apps/flipcash/shared/payments/src/main/kotlin/com/flipcash/app/payments/internal/Buttons.kt
+++ b/apps/flipcash/shared/payments/src/main/kotlin/com/flipcash/app/payments/internal/Buttons.kt
@@ -81,7 +81,7 @@ internal fun purchaseOptions(
         if (state.canUseOtherWallets) {
             add(
                 BottomBarAction(
-                    text = resources.getString(R.string.title_onrampProviderOtherWallet),
+                    text = resources.getString(R.string.action_depositUsdc),
                     onClick = { onClick(PurchaseMethod.OtherWallet) }
                 )
             )


### PR DESCRIPTION
Update the "Other Wallet" option in purchase flow to say "Depoist USDC">