### PR TITLE
fix(user): remove eager Firebase.messaging call that crashes before FirebaseApp init

### DIFF
--- a/services/flipcash/build.gradle.kts
+++ b/services/flipcash/build.gradle.kts
@@ -47,7 +47,6 @@ dependencies {
 
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.installations)
-    implementation(libs.firebase.messaging)
 
     implementation(libs.play.integrity)
 

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/user/UserManager.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/user/UserManager.kt
@@ -17,8 +17,6 @@ import com.getcode.opencode.model.financial.usdf
 import com.getcode.services.opencode.BuildConfig
 import com.getcode.utils.TraceManager
 import com.getcode.utils.base58
-import com.google.firebase.Firebase
-import com.google.firebase.messaging.messaging
 import com.hoc081098.channeleventbus.ChannelEventBus
 import com.mixpanel.android.mpmetrics.MixpanelAPI
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -104,9 +102,6 @@ class UserManager @Inject constructor(
             didDetectUnlockedAccount()
         }
 
-        Firebase.messaging.token.addOnSuccessListener { token ->
-            set(pushToken = token)
-        }
     }
 
     fun establish(entropy: String) {


### PR DESCRIPTION
The `Firebase.messaging.token` call in `UserManager.init` runs during Hilt graph construction in `FlipcashApp.onCreate()`. On some devices, Firebase has not yet initialized at this point, causing an IllegalStateException.

This call is redundant — `AuthManager.updateFcmToken()` already fetches and registers the push token via `PushTokenProvider` during login/soft-login.

Fixes: Bugsnag 6a0c83a8dd5b5015ce623eae