### PR TITLE
feat(verification): support full-screen and target navigation for drop-in use cases

### DIFF
--- a/apps/flipcash/core/src/main/kotlin/com/flipcash/app/core/AppRoute.kt
+++ b/apps/flipcash/core/src/main/kotlin/com/flipcash/app/core/AppRoute.kt
@@ -50,6 +50,8 @@ sealed interface AppRoute : NavKey, Parcelable {
         data class Purchase(val fromLogin: Boolean = false) : Onboarding
 
         @Serializable
+        data class ContactPermission(val postCreate: Boolean): Onboarding
+        @Serializable
         data class NotificationPermission(val postCreate: Boolean = false) : Onboarding
         @Serializable
         data class NotificationPermissionRationale(val permanentlyDenied: Boolean = false) : Onboarding
@@ -88,6 +90,8 @@ sealed interface AppRoute : NavKey, Parcelable {
         val includeEmail: Boolean = true,
         val email: String? = null,
         val emailVerificationCode: String? = null,
+        val target: AppRoute? = null,
+        val fullScreen: Boolean = false,
     ) : AppRoute, FlowRouteWithResult<VerificationResult> {
         override val initialStack: List<NavKey>
             get() = buildVerificationInitialStack(

--- a/apps/flipcash/features/contact-verification/src/main/kotlin/com/flipcash/app/contact/verification/VerificationFlowScreen.kt
+++ b/apps/flipcash/features/contact-verification/src/main/kotlin/com/flipcash/app/contact/verification/VerificationFlowScreen.kt
@@ -46,7 +46,11 @@ fun VerificationFlowScreen(
                 route = route,
                 value = NavResultOrCanceled.ReturnValue(result),
             )
-            outerNavigator.pop()
+            if (route.target != null && result is VerificationResult.Success) {
+                outerNavigator.replace(route.target!!)
+            } else {
+                outerNavigator.pop()
+            }
         },
         entryProvider = verificationEntryProvider(route),
     )
@@ -59,13 +63,13 @@ private fun verificationEntryProvider(
         VerificationFlowIntroContent(isForOnRamp = step.isForOnRamp)
     }
     annotatedEntry<VerificationStep.PhoneEntry> {
-        PhoneVerificationContent()
+        PhoneVerificationContent(isInModal = !route.fullScreen)
     }
     annotatedEntry<VerificationStep.PhoneCode> {
-        PhoneCodeContent(includeEmail = route.includeEmail)
+        PhoneCodeContent(includeEmail = route.includeEmail, isInModal = !route.fullScreen)
     }
     annotatedEntry<VerificationStep.PhoneCountryCode> {
-        PhoneCountryCodeContent()
+        PhoneCountryCodeContent(isInModal = !route.fullScreen)
     }
     annotatedEntry<VerificationStep.EmailEntry> {
         EmailVerificationContent(

--- a/apps/flipcash/features/contact-verification/src/main/kotlin/com/flipcash/app/contact/verification/phone/PhoneCodeScreen.kt
+++ b/apps/flipcash/features/contact-verification/src/main/kotlin/com/flipcash/app/contact/verification/phone/PhoneCodeScreen.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.flow.onEach
 @Composable
 fun PhoneCodeContent(
     includeEmail: Boolean,
+    isInModal: Boolean = true,
 ) {
     val flowNavigator = rememberFlowNavigator<VerificationStep, VerificationResult>()
     val viewModel = flowSharedViewModel<PhoneVerificationViewModel>()
@@ -34,7 +35,7 @@ fun PhoneCodeContent(
     ) {
         AppBarWithTitle(
             title = stringResource(R.string.title_enterTheCode),
-            isInModal = true,
+            isInModal = isInModal,
             titleAlignment = Alignment.CenterHorizontally,
             backButton = true,
             onBackIconClicked = { flowNavigator.back() },

--- a/apps/flipcash/features/contact-verification/src/main/kotlin/com/flipcash/app/contact/verification/phone/PhoneCountryCodeScreen.kt
+++ b/apps/flipcash/features/contact-verification/src/main/kotlin/com/flipcash/app/contact/verification/phone/PhoneCountryCodeScreen.kt
@@ -20,7 +20,7 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 
 @Composable
-fun PhoneCountryCodeContent() {
+fun PhoneCountryCodeContent(isInModal: Boolean = true) {
     val flowNavigator = rememberFlowNavigator<VerificationStep, VerificationResult>()
     val viewModel = flowSharedViewModel<PhoneVerificationViewModel>()
 
@@ -30,7 +30,7 @@ fun PhoneCountryCodeContent() {
     ) {
         AppBarWithTitle(
             title = stringResource(R.string.title_verifyPhoneNumber),
-            isInModal = true,
+            isInModal = isInModal,
             titleAlignment = Alignment.CenterHorizontally,
             backButton = true,
             onBackIconClicked = { flowNavigator.back() },

--- a/apps/flipcash/features/contact-verification/src/main/kotlin/com/flipcash/app/contact/verification/phone/PhoneVerificationScreen.kt
+++ b/apps/flipcash/features/contact-verification/src/main/kotlin/com/flipcash/app/contact/verification/phone/PhoneVerificationScreen.kt
@@ -25,7 +25,7 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 
 @Composable
-fun PhoneVerificationContent() {
+fun PhoneVerificationContent(isInModal: Boolean = true) {
     val codeNavigator = LocalCodeNavigator.current
     val flowNavigator = rememberFlowNavigator<VerificationStep, VerificationResult>()
     val viewModel = flowSharedViewModel<PhoneVerificationViewModel>()
@@ -37,7 +37,7 @@ fun PhoneVerificationContent() {
     ) {
         AppBarWithTitle(
             title = stringResource(R.string.title_verifyPhoneNumber),
-            isInModal = true,
+            isInModal = isInModal,
             titleAlignment = Alignment.CenterHorizontally,
             backButton = true,
             onBackIconClicked = {


### PR DESCRIPTION
Add `target` and `fullScreen` params to AppRoute.Verification so the flow can forward-navigate on success (replace) and render with status bar padding when used outside of a modal sheet (e.g. onboarding).

Wire phone verification into the onboarding flow from AccessKeyScreen.