### PR TITLE
feat(contacts): persist display number and upsert contact metadata

### DIFF
--- a/apps/flipcash/shared/contacts/src/main/kotlin/com/flipcash/app/contacts/ContactCoordinator.kt
+++ b/apps/flipcash/shared/contacts/src/main/kotlin/com/flipcash/app/contacts/ContactCoordinator.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.ProcessLifecycleOwner
 import com.flipcash.app.contacts.device.DeviceContact
 import com.flipcash.app.contacts.device.PickedContactData
 import com.flipcash.app.contacts.device.ScopeAwareContactReader
+import com.flipcash.app.phone.PhoneUtils
 import com.flipcash.app.contacts.sync.ContactChecksum
 import com.flipcash.app.persistence.FlipcashDatabase
 import com.flipcash.app.persistence.entities.ContactMappingEntity
@@ -52,6 +53,7 @@ class ContactCoordinator @Inject constructor(
     private val resolverController: ResolverController,
     private val networkObserver: NetworkConnectivityListener,
     private val contactReader: ScopeAwareContactReader,
+    private val phoneUtils: PhoneUtils,
 ) : SessionListener, DefaultLifecycleObserver {
 
     companion object {
@@ -157,6 +159,7 @@ class ContactCoordinator @Inject constructor(
                 androidContactId = mapping.androidContactId,
                 displayName = mapping.displayName,
                 photoUri = mapping.photoUri,
+                displayNumber = mapping.displayNumber,
             )
         }
         val flipcashE164s = mappings.filter { it.isOnFlipcash }.map { it.e164 }.toSet()
@@ -202,26 +205,26 @@ class ContactCoordinator @Inject constructor(
             val adds = newE164s - existingE164s
             val removes = existingE164s - newE164s
 
-            // 4. Persist new mappings
-            if (adds.isNotEmpty()) {
-                val newEntities = adds.mapNotNull { e164 ->
-                    deviceContacts[e164]?.let { contact ->
-                        ContactMappingEntity(
-                            e164 = contact.e164,
-                            androidContactId = contact.androidContactId,
-                            displayName = contact.displayName,
-                            photoUri = contact.photoUri,
-                        )
-                    }
-                }
-                dao.upsertMappings(newEntities)
+            // 4. Persist all mappings (upsert fixes metadata staleness for name/photo changes)
+            val allEntities = deviceContacts.values.map { contact ->
+                ContactMappingEntity(
+                    e164 = contact.e164,
+                    androidContactId = contact.androidContactId,
+                    displayName = contact.displayName,
+                    photoUri = contact.photoUri,
+                    displayNumber = phoneUtils.formatNumber(contact.e164),
+                )
             }
+            dao.upsertMappings(allEntities)
             if (removes.isNotEmpty()) {
                 dao.deleteMappings(removes.toList())
             }
 
-            // Update in-memory contacts
-            _state.update { it.copy(contacts = deviceContacts) }
+            // Update in-memory contacts with displayNumber
+            val enrichedContacts = deviceContacts.mapValues { (_, contact) ->
+                contact.copy(displayNumber = phoneUtils.formatNumber(contact.e164))
+            }
+            _state.update { it.copy(contacts = enrichedContacts) }
 
             // 5. CheckSync with server
             val syncState = dao.getSyncState()

--- a/apps/flipcash/shared/contacts/src/main/kotlin/com/flipcash/app/contacts/device/DeviceContactReader.kt
+++ b/apps/flipcash/shared/contacts/src/main/kotlin/com/flipcash/app/contacts/device/DeviceContactReader.kt
@@ -1,5 +1,7 @@
 package com.flipcash.app.contacts.device
 
+import com.flipcash.app.phone.PhoneUtils
+
 interface DeviceContactReader {
     suspend fun readAll(): Result<Map<String, DeviceContact>>
 }
@@ -9,6 +11,7 @@ data class DeviceContact(
     val androidContactId: Long,
     val displayName: String,
     val photoUri: String?,
+    val displayNumber: String = "",
 )
 
 data class PickedContactData(

--- a/apps/flipcash/shared/persistence/db/schemas/com.flipcash.app.persistence.FlipcashDatabase/17.json
+++ b/apps/flipcash/shared/persistence/db/schemas/com.flipcash.app.persistence.FlipcashDatabase/17.json
@@ -1,0 +1,476 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 17,
+    "identityHash": "e860c8c5c416d8bc45fb4c7a555e536f",
+    "entities": [
+      {
+        "tableName": "messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`idBase58` TEXT NOT NULL, `text` TEXT NOT NULL, `amountUsdc` INTEGER, `amountNative` INTEGER, `nativeCurrency` TEXT, `rate` REAL, `state` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `metadata` TEXT, `mintBase58` TEXT DEFAULT 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', PRIMARY KEY(`idBase58`))",
+        "fields": [
+          {
+            "fieldPath": "idBase58",
+            "columnName": "idBase58",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amountUsdc",
+            "columnName": "amountUsdc",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "amountNative",
+            "columnName": "amountNative",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "nativeCurrency",
+            "columnName": "nativeCurrency",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "rate",
+            "columnName": "rate",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadata",
+            "columnName": "metadata",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mintBase58",
+            "columnName": "mintBase58",
+            "affinity": "TEXT",
+            "defaultValue": "'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "idBase58"
+          ]
+        }
+      },
+      {
+        "tableName": "tokens",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`address` TEXT NOT NULL, `decimals` INTEGER NOT NULL, `name` TEXT NOT NULL, `symbol` TEXT NOT NULL, `created_at` INTEGER, `description` TEXT NOT NULL, `image_url` TEXT NOT NULL, `social_links` TEXT, `bill_customizations` TEXT, `holder_metrics` TEXT, `vm_vm` TEXT NOT NULL, `vm_authority` TEXT NOT NULL, `vm_lock_duration_days` INTEGER NOT NULL, `lp_currency_config` TEXT, `lp_liquidity_pool` TEXT, `lp_seed` TEXT, `lp_authority` TEXT, `lp_mint_vault` TEXT, `lp_core_mint_vault` TEXT, `lp_circulating_supply_quarks` INTEGER, `lp_sell_fee_bps` INTEGER, `lp_price_amount_usd` REAL, `lp_market_cap_amount_usd` REAL, PRIMARY KEY(`address`))",
+        "fields": [
+          {
+            "fieldPath": "address",
+            "columnName": "address",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "decimals",
+            "columnName": "decimals",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "symbol",
+            "columnName": "symbol",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "image_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "socialLinks",
+            "columnName": "social_links",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "billCustomizationsJson",
+            "columnName": "bill_customizations",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "holderMetricsJson",
+            "columnName": "holder_metrics",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "vmMetadata.vm",
+            "columnName": "vm_vm",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vmMetadata.authority",
+            "columnName": "vm_authority",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vmMetadata.lockDurationInDays",
+            "columnName": "vm_lock_duration_days",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "launchpadMetadata.currencyConfig",
+            "columnName": "lp_currency_config",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "launchpadMetadata.liquidityPool",
+            "columnName": "lp_liquidity_pool",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "launchpadMetadata.seed",
+            "columnName": "lp_seed",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "launchpadMetadata.authority",
+            "columnName": "lp_authority",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "launchpadMetadata.mintVault",
+            "columnName": "lp_mint_vault",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "launchpadMetadata.coreMintVault",
+            "columnName": "lp_core_mint_vault",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "launchpadMetadata.currentCirculatingSupplyQuarks",
+            "columnName": "lp_circulating_supply_quarks",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "launchpadMetadata.sellFeeBps",
+            "columnName": "lp_sell_fee_bps",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "launchpadMetadata.priceAmount",
+            "columnName": "lp_price_amount_usd",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "launchpadMetadata.marketCapAmount",
+            "columnName": "lp_market_cap_amount_usd",
+            "affinity": "REAL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "address"
+          ]
+        }
+      },
+      {
+        "tableName": "token_social_links",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `token_address` TEXT NOT NULL, `type` TEXT NOT NULL, `value` TEXT NOT NULL, FOREIGN KEY(`token_address`) REFERENCES `tokens`(`address`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tokenAddress",
+            "columnName": "token_address",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_token_social_links_token_address",
+            "unique": false,
+            "columnNames": [
+              "token_address"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_token_social_links_token_address` ON `${TABLE_NAME}` (`token_address`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "tokens",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "token_address"
+            ],
+            "referencedColumns": [
+              "address"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "token_valuation",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`token_address` TEXT NOT NULL, `balance_quarks` INTEGER NOT NULL, `cost_basis` REAL NOT NULL, PRIMARY KEY(`token_address`), FOREIGN KEY(`token_address`) REFERENCES `tokens`(`address`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "tokenAddress",
+            "columnName": "token_address",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "balanceQuarks",
+            "columnName": "balance_quarks",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "costBasis",
+            "columnName": "cost_basis",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "token_address"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_token_valuation_token_address",
+            "unique": false,
+            "columnNames": [
+              "token_address"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_token_valuation_token_address` ON `${TABLE_NAME}` (`token_address`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "tokens",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "token_address"
+            ],
+            "referencedColumns": [
+              "address"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "currency_creator_draft",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `description` TEXT NOT NULL, `icon_uri` TEXT, `bill_customizations` TEXT, `attestations` TEXT, `current_step` TEXT NOT NULL, `created_mint` TEXT, `saved_at` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "iconUri",
+            "columnName": "icon_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "billCustomizations",
+            "columnName": "bill_customizations",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "attestations",
+            "columnName": "attestations",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "currentStep",
+            "columnName": "current_step",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdMint",
+            "columnName": "created_mint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "savedAt",
+            "columnName": "saved_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "contact_sync_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `checksumBytes` BLOB NOT NULL, `lastSyncTimestamp` INTEGER NOT NULL, `needsFullUpload` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "checksumBytes",
+            "columnName": "checksumBytes",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncTimestamp",
+            "columnName": "lastSyncTimestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "needsFullUpload",
+            "columnName": "needsFullUpload",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "contact_mapping",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`e164` TEXT NOT NULL, `androidContactId` INTEGER NOT NULL, `displayName` TEXT NOT NULL, `photoUri` TEXT, `isOnFlipcash` INTEGER NOT NULL, `displayNumber` TEXT NOT NULL DEFAULT '', PRIMARY KEY(`e164`))",
+        "fields": [
+          {
+            "fieldPath": "e164",
+            "columnName": "e164",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "androidContactId",
+            "columnName": "androidContactId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "photoUri",
+            "columnName": "photoUri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isOnFlipcash",
+            "columnName": "isOnFlipcash",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayNumber",
+            "columnName": "displayNumber",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "e164"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'e860c8c5c416d8bc45fb4c7a555e536f')"
+    ]
+  }
+}

--- a/apps/flipcash/shared/persistence/db/src/main/kotlin/com/flipcash/app/persistence/FlipcashDatabase.kt
+++ b/apps/flipcash/shared/persistence/db/src/main/kotlin/com/flipcash/app/persistence/FlipcashDatabase.kt
@@ -54,8 +54,9 @@ import com.getcode.utils.subByteArray
         AutoMigration(from = 13, to = 14),
         AutoMigration(from = 14, to = 15),
         AutoMigration(from = 15, to = 16),
+        AutoMigration(from = 16, to = 17),
     ],
-    version = 16,
+    version = 17,
 )
 @TypeConverters(TokenTypeConverters::class)
 abstract class FlipcashDatabase : RoomDatabase() {

--- a/apps/flipcash/shared/persistence/db/src/main/kotlin/com/flipcash/app/persistence/entities/ContactMappingEntity.kt
+++ b/apps/flipcash/shared/persistence/db/src/main/kotlin/com/flipcash/app/persistence/entities/ContactMappingEntity.kt
@@ -1,5 +1,6 @@
 package com.flipcash.app.persistence.entities
 
+import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 
@@ -11,4 +12,6 @@ data class ContactMappingEntity(
     val displayName: String,
     val photoUri: String?,
     val isOnFlipcash: Boolean = false,
+    @ColumnInfo(defaultValue = "")
+    val displayNumber: String = "",
 )


### PR DESCRIPTION
Add displayNumber column to contact_mapping table (DB v17, AutoMigration). Switch from insert-only to upsert-all strategy in ContactCoordinator so contact name/photo metadata stays fresh. Format phone numbers via PhoneUtils for user-friendly display.