### PR TITLE
feat(notifications): trigger contact sync on CONTACT_JOIN push

### DIFF
--- a/apps/flipcash/shared/notifications/build.gradle.kts
+++ b/apps/flipcash/shared/notifications/build.gradle.kts
@@ -9,6 +9,7 @@ android {
 
 dependencies {
     implementation(project(":apps:flipcash:shared:authentication"))
+    implementation(project(":apps:flipcash:shared:contacts"))
     implementation(project(":apps:flipcash:shared:persistence:sources"))
     implementation(project(":apps:flipcash:shared:phone"))
     implementation(project(":apps:flipcash:shared:push"))

--- a/apps/flipcash/shared/notifications/src/main/kotlin/com/flipcash/app/notifications/NotificationService.kt
+++ b/apps/flipcash/shared/notifications/src/main/kotlin/com/flipcash/app/notifications/NotificationService.kt
@@ -11,6 +11,7 @@ import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.net.toUri
 import com.flipcash.app.auth.AuthManager
+import com.flipcash.app.contacts.ContactCoordinator
 import com.flipcash.app.core.util.Linkify
 import com.flipcash.app.persistence.sources.ContactDataSource
 import com.flipcash.app.phone.PhoneUtils
@@ -62,6 +63,9 @@ class NotificationService : FirebaseMessagingService(),
     lateinit var contactDataSource: ContactDataSource
 
     @Inject
+    lateinit var contactCoordinator: ContactCoordinator
+
+    @Inject
     lateinit var phoneUtils: PhoneUtils
 
     override fun onNewToken(token: String) {
@@ -102,8 +106,13 @@ class NotificationService : FirebaseMessagingService(),
             .takeIf { it.isNotEmpty() }
             ?.let { NotificationPayload.fromEncoded(it) }
 
-        if (payload?.navigation is NavigationTrigger.CurrencyInfo) {
-            launch { tokenCoordinator.update() }
+        when {
+            payload?.navigation is NavigationTrigger.CurrencyInfo -> {
+                launch { tokenCoordinator.update() }
+            }
+            payload?.category == NotificationCategory.CONTACT_JOIN -> {
+                launch { contactCoordinator.sync() }
+            }
         }
 
         launch {


### PR DESCRIPTION
When a CONTACT_JOIN push notification is received, sync contacts to update the isOnFlipcash status for the newly joined contact.