### PR TITLE
fix(billing): guard billing client connection behind requiresIapForRegistration flag

### DIFF
--- a/apps/flipcash/shared/session/src/main/kotlin/com/flipcash/app/session/internal/RealSessionController.kt
+++ b/apps/flipcash/shared/session/src/main/kotlin/com/flipcash/app/session/internal/RealSessionController.kt
@@ -173,6 +173,7 @@ class RealSessionController @Inject constructor(
             .mapNotNull { it.authState }
             .filter { it.isAtLeastRegistered }
             .distinctUntilChanged()
+            .filter { userManager.state.value.flags?.requiresIapForRegistration == true }
             .onEach { billingClient.connect() }
             .launchIn(scope)
 
@@ -242,7 +243,7 @@ class RealSessionController @Inject constructor(
         checkPendingItemsInFeed()
         bringActivityFeedCurrent()
         shareSheetController.checkForShare()
-        if (userManager.authState.isAtLeastRegistered) {
+        if (userManager.authState.isAtLeastRegistered && userManager.state.value.flags?.requiresIapForRegistration == true) {
             billingClient.connect()
         }
     }


### PR DESCRIPTION
The billing client was eagerly connecting on every app foreground and auth state change, even though the purchase feature is unused. This triggered a known Play Billing Library crash in ProxyBillingActivity on certain devices during cold launch.

Only connect the billing client when the server flag is enabled.