### PR TITLE
fix(direct-send): gate Flipcash contacts discovery prompt to ContactList step

### DIFF
--- a/apps/flipcash/features/direct-send/src/main/kotlin/com/flipcash/app/directsend/SendFlowScreen.kt
+++ b/apps/flipcash/features/direct-send/src/main/kotlin/com/flipcash/app/directsend/SendFlowScreen.kt
@@ -1,6 +1,7 @@
 package com.flipcash.app.directsend
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -17,6 +18,7 @@ import com.getcode.navigation.annotatedEntry
 import com.getcode.navigation.flow.FlowExitReason
 import com.getcode.navigation.flow.FlowHost
 import com.getcode.navigation.results.NavResultStateRegistry
+import com.getcode.navigation.flow.flowSharedViewModel
 import com.getcode.navigation.scenes.LocalBottomSheetDismissDispatcher
 
 @Composable
@@ -42,12 +44,23 @@ fun SendFlowScreen(resultStateRegistry: NavResultStateRegistry) {
 
 private fun sendEntryProvider(): (NavKey) -> NavEntry<NavKey> = entryProvider {
     annotatedEntry<SendStep.PhoneGate> {
+        SyncStep(it)
         PhoneGateLandingScreen()
     }
     annotatedEntry<SendStep.ContactsGate> {
+        SyncStep(it)
         ContactsPermissionGateScreen()
     }
     annotatedEntry<SendStep.ContactList> {
+        SyncStep(it)
         ContactListScreen()
+    }
+}
+
+@Composable
+private fun SyncStep(step: SendStep) {
+    val viewModel = flowSharedViewModel<SendFlowViewModel>()
+    LaunchedEffect(step) {
+        viewModel.dispatchEvent(SendFlowViewModel.Event.OnStepChanged(step))
     }
 }

--- a/apps/flipcash/features/direct-send/src/main/kotlin/com/flipcash/app/directsend/internal/SendFlowViewModel.kt
+++ b/apps/flipcash/features/direct-send/src/main/kotlin/com/flipcash/app/directsend/internal/SendFlowViewModel.kt
@@ -46,6 +46,7 @@ internal class SendFlowViewModel @Inject constructor(
 
     data class State @OptIn(ExperimentalMaterial3Api::class) constructor(
         val steps: List<SendStep> = listOf(SendStep.ContactList),
+        val currentStep: SendStep? = null,
         val searchState: TextFieldState = TextFieldState(),
         val isPickerMode: Boolean = false,
         val contactSyncState: LoadingSuccessState = LoadingSuccessState(),
@@ -54,6 +55,7 @@ internal class SendFlowViewModel @Inject constructor(
 
     sealed interface Event {
         data class StepsUpdated(val steps: List<SendStep>, val isPickerMode: Boolean) : Event
+        data class OnStepChanged(val step: SendStep) : Event
 
         data object ContactsGranted : Event
         data class ContactsPicked(val contacts: List<PickedContact>) : Event
@@ -164,6 +166,7 @@ internal class SendFlowViewModel @Inject constructor(
 
         contactCoordinator.state
             .filter { it.hasDiscoveredFlipcashContacts && it.flipcashE164s.isNotEmpty() }
+            .filter { stateFlow.value.currentStep is SendStep.ContactList }
             .take(1)
             .onEach { contactState ->
                 val count = contactState.flipcashE164s.size
@@ -220,6 +223,10 @@ internal class SendFlowViewModel @Inject constructor(
             when (event) {
                 is Event.StepsUpdated -> { state ->
                     state.copy(steps = event.steps, isPickerMode = event.isPickerMode)
+                }
+
+                is Event.OnStepChanged -> { state ->
+                    state.copy(currentStep = event.step)
                 }
 
                 is Event.ContactsGranted -> { state -> state }


### PR DESCRIPTION
Track the current SendStep so the discovery snackbar only fires when the user is on the ContactList screen, not during gate screens.