### PR TITLE
fix(compose): migrate collectAsState to lifecycle-aware and fix state issues

### DIFF
--- a/apps/flipcash/app/src/main/kotlin/com/flipcash/app/internal/ui/App.kt
+++ b/apps/flipcash/app/src/main/kotlin/com/flipcash/app/internal/ui/App.kt
@@ -13,7 +13,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -109,7 +109,7 @@ internal fun App(
     }
 
     val session = LocalSessionController.current!!
-    val userState by userManager.state.collectAsState()
+    val userState by userManager.state.collectAsStateWithLifecycle()
 
     FlipcashTheme {
         rememberQrBitmapPainter(

--- a/apps/flipcash/app/src/main/kotlin/com/flipcash/app/internal/ui/navigation/decorators/NavBlockingOverlayEntryDecorator.kt
+++ b/apps/flipcash/app/src/main/kotlin/com/flipcash/app/internal/ui/navigation/decorators/NavBlockingOverlayEntryDecorator.kt
@@ -3,7 +3,7 @@ package com.flipcash.app.internal.ui.navigation.decorators
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -26,7 +26,7 @@ fun NavBlockingOverlayEntryDecorator(): NavEntryDecorator<NavKey> {
             entry.Content()
 
             val userManager = LocalUserManager.current
-            val userState by userManager!!.state.collectAsState()
+            val userState by userManager!!.state.collectAsStateWithLifecycle()
             val authState = userState.authState
 
             if (authState is AuthState.LoggedIn) {

--- a/apps/flipcash/core/src/main/kotlin/com/flipcash/app/core/ui/AmountWithKeypad.kt
+++ b/apps/flipcash/core/src/main/kotlin/com/flipcash/app/core/ui/AmountWithKeypad.kt
@@ -5,7 +5,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -32,7 +32,7 @@ fun AmountWithKeypad(
     onDecimal: () -> Unit = { },
 ) {
     val networkObserver = LocalNetworkObserver.current
-    val networkState by networkObserver.state.collectAsState()
+    val networkState by networkObserver.state.collectAsStateWithLifecycle()
 
     Column(
         modifier = modifier,

--- a/apps/flipcash/features/backupkey/src/main/kotlin/com/flipcash/app/backupkey/internal/BackupKeyScreenContent.kt
+++ b/apps/flipcash/features/backupkey/src/main/kotlin/com/flipcash/app/backupkey/internal/BackupKeyScreenContent.kt
@@ -21,7 +21,7 @@ import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -57,7 +57,7 @@ import com.getcode.util.permissions.rememberStoragePermission
 internal fun BackupKeyScreenContent(viewModel: BackupKeyScreenViewModel) {
     val context = LocalContext.current
     val resources = LocalResources.current
-    val dataState by viewModel.uiFlow.collectAsState()
+    val dataState by viewModel.uiFlow.collectAsStateWithLifecycle()
 
     var isExportSeedRequested by remember { mutableStateOf(false) }
     var isStoragePermissionGranted by remember { mutableStateOf(false) }

--- a/apps/flipcash/features/login/src/main/kotlin/com/flipcash/app/login/OnboardingFlowScreen.kt
+++ b/apps/flipcash/features/login/src/main/kotlin/com/flipcash/app/login/OnboardingFlowScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -281,7 +280,7 @@ private fun onboardingEntryProvider(
 @Composable
 private fun LoginStepContent(seed: String?) {
     val vm = hiltViewModel<LoginViewModel>()
-    val state by vm.stateFlow.collectAsState()
+    val state by vm.stateFlow.collectAsStateWithLifecycle()
     val flowNavigator = rememberFlowNavigator<OnboardingStep, OnboardingResult>()
     val outerNavigator = LocalOuterCodeNavigator.current
     var visible by remember { mutableStateOf(false) }
@@ -427,7 +426,7 @@ private fun AccessKeyStepContent() {
 private fun PurchaseStepContent() {
     val viewModel = hiltViewModel<PurchaseAccountViewModel>()
     val flowNavigator = rememberFlowNavigator<OnboardingStep, OnboardingResult>()
-    val state by viewModel.stateFlow.collectAsState()
+    val state by viewModel.stateFlow.collectAsStateWithLifecycle()
 
     LaunchedEffect(viewModel) {
         viewModel.eventFlow

--- a/apps/flipcash/features/login/src/main/kotlin/com/flipcash/app/login/internal/screens/AccessKeyScreenContent.kt
+++ b/apps/flipcash/features/login/src/main/kotlin/com/flipcash/app/login/internal/screens/AccessKeyScreenContent.kt
@@ -23,7 +23,7 @@ import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -74,7 +74,7 @@ internal fun AccessKeyScreen(
     val navigator = LocalCodeNavigator.current
     val context = LocalContext.current
     val resources = LocalResources.current
-    val dataState by viewModel.uiFlow.collectAsState()
+    val dataState by viewModel.uiFlow.collectAsStateWithLifecycle()
 
     val composeScope = rememberCoroutineScope()
 

--- a/apps/flipcash/features/login/src/main/kotlin/com/flipcash/app/login/internal/screens/SeedInputContent.kt
+++ b/apps/flipcash/features/login/src/main/kotlin/com/flipcash/app/login/internal/screens/SeedInputContent.kt
@@ -22,7 +22,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.SettingsBackupRestore
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -65,7 +65,7 @@ internal fun SeedInputContent(
     viewModel: SeedInputViewModel,
     onCantFind: () -> Unit,
 ) {
-    val dataState by viewModel.uiFlow.collectAsState()
+    val dataState by viewModel.uiFlow.collectAsStateWithLifecycle()
     SeedInputContent(
         state = dataState,
         onTextChange = { viewModel.onTextChange(it) },
@@ -86,7 +86,7 @@ private fun SeedInputContent(
     val focusManager = LocalFocusManager.current
     val focusRequester = remember { FocusRequester() }
     val featureFlags = LocalFeatureFlags.current
-    val restoreEnabled by featureFlags.observe(FeatureFlag.CredentialManager).collectAsState()
+    val restoreEnabled by featureFlags.observe(FeatureFlag.CredentialManager).collectAsStateWithLifecycle()
 
     val keyboardVisible by keyboardAsState()
     val ime = LocalSoftwareKeyboardController.current

--- a/apps/flipcash/features/purchase/src/main/kotlin/com/flipcash/app/purchase/internal/PurchaseAccountScreenContent.kt
+++ b/apps/flipcash/features/purchase/src/main/kotlin/com/flipcash/app/purchase/internal/PurchaseAccountScreenContent.kt
@@ -12,7 +12,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CheckCircleOutline
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -45,7 +45,7 @@ import kotlinx.coroutines.flow.onEach
 fun PurchaseAccountScreen(viewModel: PurchaseAccountViewModel) {
     val navigator = LocalCodeNavigator.current
 
-    val state by viewModel.stateFlow.collectAsState()
+    val state by viewModel.stateFlow.collectAsStateWithLifecycle()
 
     LaunchedEffect(viewModel) {
         viewModel.eventFlow

--- a/apps/flipcash/features/scanner/src/main/kotlin/com/flipcash/app/scanner/internal/Scanner.kt
+++ b/apps/flipcash/features/scanner/src/main/kotlin/com/flipcash/app/scanner/internal/Scanner.kt
@@ -4,7 +4,7 @@ import android.annotation.SuppressLint
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -43,8 +43,8 @@ internal fun Scanner() {
     val router = LocalRouter.current!!
     val navigator = LocalCodeNavigator.current
     val session = LocalSessionController.current!!
-    val state by session.state.collectAsState()
-    val billState by session.billState.collectAsState()
+    val state by session.state.collectAsStateWithLifecycle()
+    val billState by session.billState.collectAsStateWithLifecycle()
     val analytics = rememberAnalytics()
 
     var isPaused by remember { mutableStateOf(false) }

--- a/apps/flipcash/features/scanner/src/main/kotlin/com/flipcash/app/scanner/internal/bills/BillContainerView.kt
+++ b/apps/flipcash/features/scanner/src/main/kotlin/com/flipcash/app/scanner/internal/bills/BillContainerView.kt
@@ -20,8 +20,7 @@ import androidx.compose.material.DismissValue
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.SideEffect
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -95,12 +94,12 @@ internal fun BillContainer(
 
     val cameraPermission = rememberCameraPermission { onPermissionResult(it) }
 
-    SideEffect {
+    LaunchedEffect(cameraPermission.status) {
         onPermissionResult(cameraPermission.status)
     }
 
-    val state by session.state.collectAsState()
-    val billState by session.billState.collectAsState()
+    val state by session.state.collectAsStateWithLifecycle()
+    val billState by session.billState.collectAsStateWithLifecycle()
 
     val autoStart = state.autoStartCamera == true
     var cameraStarted by remember { mutableStateOf(autoStart) }

--- a/apps/flipcash/features/scanner/src/main/kotlin/com/flipcash/app/scanner/internal/ui/components/DecorView.kt
+++ b/apps/flipcash/features/scanner/src/main/kotlin/com/flipcash/app/scanner/internal/ui/components/DecorView.kt
@@ -26,7 +26,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Icon
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -142,7 +141,7 @@ internal fun DecorView(
             }
 
             Column(modifier = Modifier.align(Alignment.BottomCenter)) {
-                val networkState by LocalNetworkObserver.current.state.collectAsState()
+                val networkState by LocalNetworkObserver.current.state.collectAsStateWithLifecycle()
 
                 AnimatedVisibility(
                     modifier = Modifier

--- a/apps/flipcash/shared/onramp/coinbase/src/main/kotlin/com/flipcash/app/onramp/CoinbaseOnRampHandler.kt
+++ b/apps/flipcash/shared/onramp/coinbase/src/main/kotlin/com/flipcash/app/onramp/CoinbaseOnRampHandler.kt
@@ -3,7 +3,7 @@ package com.flipcash.app.onramp
 import android.content.res.Resources
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.LocalResources
 import com.flipcash.app.core.AppRoute
@@ -18,7 +18,7 @@ fun CoinbaseOnRampHandler(
     controller: CoinbaseOnRampController = LocalCoinbaseOnRampController.current,
     content: @Composable () -> Unit,
 ) {
-    val state by controller.state.collectAsState()
+    val state by controller.state.collectAsStateWithLifecycle()
     val resources = LocalResources.current
     when (val current = state) {
         is CoinbaseOnRampState.Paying -> {

--- a/ui/components/src/main/kotlin/com/getcode/ui/components/bars/BottomBarContainer.kt
+++ b/ui/components/src/main/kotlin/com/getcode/ui/components/bars/BottomBarContainer.kt
@@ -32,7 +32,7 @@ import androidx.compose.material.icons.rounded.ExpandMore
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
@@ -70,7 +70,7 @@ import kotlinx.coroutines.launch
 @Composable
 fun BottomBarContainer(barMessages: BarMessages, onShown: (BottomBarManager.BottomBarMessage) -> Unit = {}) {
     val scope = rememberCoroutineScope()
-    val bottomBarMessage by barMessages.bottomBar.collectAsState()
+    val bottomBarMessage by barMessages.bottomBar.collectAsStateWithLifecycle()
     val bottomBarVisibleState = remember(bottomBarMessage?.id) { MutableTransitionState(false) }
     var bottomBarMessageDismissId by remember { mutableLongStateOf(0L) }
     val animationScale by rememberAnimationScale()

--- a/ui/components/src/main/kotlin/com/getcode/ui/components/bars/TopBarContainer.kt
+++ b/ui/components/src/main/kotlin/com/getcode/ui/components/bars/TopBarContainer.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.*
 import androidx.compose.runtime.*
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
@@ -27,28 +28,28 @@ import com.getcode.theme.*
 import com.getcode.ui.components.R
 import com.getcode.ui.components.VerticalDivider
 import com.getcode.ui.core.rememberedClickable
-import java.util.*
-import kotlin.concurrent.timerTask
+import kotlinx.coroutines.delay
 
 @Composable
 fun TopBarContainer(
     barMessages: BarMessages,
 ) {
-    val topBarMessage by barMessages.topBar.collectAsState()
+    val topBarMessage by barMessages.topBar.collectAsStateWithLifecycle()
     val topBarVisibleState = remember { MutableTransitionState(false) }
     var topBarMessageDismissId by remember { mutableLongStateOf(0L) }
 
-    if (!topBarVisibleState.targetState && !topBarVisibleState.currentState) {
-        Timer().schedule(timerTask {
+    LaunchedEffect(topBarMessage?.id) {
+        if (!topBarVisibleState.targetState && !topBarVisibleState.currentState) {
+            delay(50)
             topBarVisibleState.targetState = topBarMessage != null
-        }, 50)
 
-        if (topBarMessageDismissId == topBarMessage?.id) {
-            TopBarManager.setMessageShown(topBarMessage?.id ?: 0)
-            topBarMessageDismissId = 0
-        }
-        if (topBarMessage == null) {
-            topBarVisibleState.targetState = false
+            if (topBarMessageDismissId == topBarMessage?.id) {
+                TopBarManager.setMessageShown(topBarMessage?.id ?: 0)
+                topBarMessageDismissId = 0
+            }
+            if (topBarMessage == null) {
+                topBarVisibleState.targetState = false
+            }
         }
     }
 

--- a/ui/navigation/src/main/kotlin/com/getcode/ui/utils/DisableSheetGestures.kt
+++ b/ui/navigation/src/main/kotlin/com/getcode/ui/utils/DisableSheetGestures.kt
@@ -19,7 +19,7 @@ import androidx.lifecycle.repeatOnLifecycle
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
-var LocalSheetGesturesState = compositionLocalOf<(Boolean) -> Unit> { {  } }
+val LocalSheetGesturesState = compositionLocalOf<(Boolean) -> Unit> { {  } }
 
 @Composable
 fun DisableSheetGestures(


### PR DESCRIPTION
- Replace 18 collectAsState() calls with collectAsStateWithLifecycle() across 14 files to stop flow collection when backgrounded
- Fix var LocalSheetGesturesState to val to prevent accidental reassignment of the CompositionLocal reference
- Replace Timer() in TopBarContainer composition body with LaunchedEffect, preventing uncancelled timer creation on every recompose
- Replace SideEffect with LaunchedEffect(cameraPermission.status) in BillContainerView to prevent permission alert firing on every recompose