### PR TITLE
fix(direct-send): pass token balance to verified fiat calculator

### DIFF
--- a/apps/flipcash/features/direct-send/src/main/kotlin/com/flipcash/app/directsend/internal/SendFlowViewModel.kt
+++ b/apps/flipcash/features/direct-send/src/main/kotlin/com/flipcash/app/directsend/internal/SendFlowViewModel.kt
@@ -14,6 +14,7 @@ import com.flipcash.app.core.send.SendStep
 import com.flipcash.app.featureflags.FeatureFlag
 import com.flipcash.app.featureflags.FeatureFlagController
 import com.flipcash.app.permissions.PickedContact
+import com.flipcash.app.tokens.TokenCoordinator
 import com.flipcash.features.directsend.R
 import com.flipcash.services.user.UserManager
 import com.getcode.manager.BottomBarManager
@@ -56,6 +57,7 @@ internal class SendFlowViewModel @Inject constructor(
     private val exchange: Exchange,
     private val verifiedFiatCalculator: VerifiedFiatCalculator,
     private val transactionController: TransactionController,
+    private val tokenCoordinator: TokenCoordinator,
 ) : BaseViewModel<SendFlowViewModel.State, SendFlowViewModel.Event>(
     initialState = State(),
     updateStateForEvent = updateStateForEvent,
@@ -264,9 +266,11 @@ internal class SendFlowViewModel @Inject constructor(
 
                     val source = owner.withTimelockForToken(token)
 
+                    val balance = tokenCoordinator.balanceForToken(token)
                     val verifiedFiat = verifiedFiatCalculator.compute(
                         amount = amount,
                         token = token,
+                        balance = balance,
                         rate = rate,
                     ).getOrElse { error ->
                         dispatchEvent(Event.SendStateUpdated())


### PR DESCRIPTION
The direct send flow was not passing the token balance to verifiedFiatCalculator.compute(), so the calculator's balance capping logic never fired. This caused submit intent failures when a user tried to send back a small received amount in a different currency (e.g. 0.01 CAD displayed as 0.01 USD when the actual USD value was ~0.007).