### PR TITLE
fix(compose): API quality and cleanup fixes

### DIFF
--- a/apps/flipcash/features/appsettings/src/main/kotlin/com/flipcash/app/appsettings/internal/AppSettingsScreenContent.kt
+++ b/apps/flipcash/features/appsettings/src/main/kotlin/com/flipcash/app/appsettings/internal/AppSettingsScreenContent.kt
@@ -24,7 +24,7 @@ internal fun AppSettingsScreenContent() {
     val context = LocalContext.current
 
     LazyColumn {
-        items(appSettings) { option ->
+        items(appSettings, key = { it.setting.type.key }) { option ->
             if (option.visible) {
                 SettingsSwitchRow(
                     modifier = Modifier.animateItem(),

--- a/apps/flipcash/features/bill-customization/src/main/kotlin/com/flipcash/app/bill/customization/features/TextureControls.kt
+++ b/apps/flipcash/features/bill-customization/src/main/kotlin/com/flipcash/app/bill/customization/features/TextureControls.kt
@@ -109,8 +109,9 @@ internal fun TextureControls(
             state.blendModes.map { it.blendMode }.forEachIndexed { index, mode ->
                 BlendModeTab(
                     mode = mode,
-                    isSelected = index == selectedTabIndex
-                ) { dispatchEvent(GraphicsEvent.CommitBlendMode(mode)) }
+                    isSelected = index == selectedTabIndex,
+                    onClick = { dispatchEvent(GraphicsEvent.CommitBlendMode(mode)) },
+                )
             }
         }
 
@@ -139,8 +140,8 @@ internal fun TextureControls(
 internal fun BlendModeTab(
     mode: BlendMode,
     isSelected: Boolean,
-    modifier: Modifier = Modifier,
     onClick: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     val backgroundColor by animateColorAsState(
         if (isSelected) Color.White.copy(0.30f) else Color.Transparent

--- a/apps/flipcash/features/contact-verification/src/main/kotlin/com/flipcash/app/contact/verification/internal/phone/PhoneCountryCodeScreen.kt
+++ b/apps/flipcash/features/contact-verification/src/main/kotlin/com/flipcash/app/contact/verification/internal/phone/PhoneCountryCodeScreen.kt
@@ -58,7 +58,7 @@ private fun PhoneCountrySelectionList(
     onSelection: (CountryLocale) -> Unit
 ) {
     LazyColumn(modifier) {
-        items(availableLocales) { countryCode ->
+        items(availableLocales, key = { it.countryCode }) { countryCode ->
             Row(
                 modifier = Modifier
                     .fillMaxWidth()

--- a/apps/flipcash/shared/region-selection/ui/src/main/kotlin/com/flipcash/app/currency/internal/RegionSelectionScreen.kt
+++ b/apps/flipcash/shared/region-selection/ui/src/main/kotlin/com/flipcash/app/currency/internal/RegionSelectionScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -49,10 +48,6 @@ internal fun RegionSelectionScreen(viewModel: RegionSelectionViewModel) {
         modifier = Modifier.imePadding(),
         verticalArrangement = Arrangement.spacedBy(CodeTheme.dimens.grid.x2),
     ) {
-        LaunchedEffect(Unit) {
-            snapshotFlow { state.searchState.text }
-                .launchIn(this)
-        }
         SearchInput(
             modifier = Modifier
                 .padding(horizontal = CodeTheme.dimens.grid.x3)

--- a/ui/components/src/main/kotlin/com/getcode/ui/components/Flippable.kt
+++ b/ui/components/src/main/kotlin/com/getcode/ui/components/Flippable.kt
@@ -13,7 +13,6 @@ import androidx.compose.ui.graphics.graphicsLayer
 
 enum class CardFace(
     val angle: Float,
-    var noAnim: Boolean = false
 ) {
     Front(0f) {
         override val next: CardFace
@@ -47,7 +46,7 @@ fun FlippableCard(
         animateFloatAsState(
             targetValue = cardFace.angle,
             animationSpec = tween(
-                durationMillis = if (cardFace.noAnim) 0 else flipMs,
+                durationMillis = flipMs,
                 easing = FastOutSlowInEasing,
             )
         )

--- a/ui/emojis/src/main/kotlin/com/getcode/ui/emojis/EmojiGarden.kt
+++ b/ui/emojis/src/main/kotlin/com/getcode/ui/emojis/EmojiGarden.kt
@@ -145,7 +145,7 @@ fun EmojiGarden(onClick: (String) -> Unit) {
                         color = CodeTheme.colors.textSecondary
                     )
                 }
-                items(frequentEmojis) { emoji ->
+                items(frequentEmojis, key = { "freq_${it.unicode}" }) { emoji ->
                     EmojiRender(
                         emoji = emoji.unicode,
                         showBackground = false,
@@ -171,7 +171,7 @@ fun EmojiGarden(onClick: (String) -> Unit) {
                         color = CodeTheme.colors.textSecondary
                     )
                 }
-                items(emojis.values.flatten()) { (emoji, _) ->
+                items(emojis.values.flatten(), key = { "${category.name}_${it.unicode}" }) { (emoji, _) ->
                     EmojiRender(
                         emoji = emoji,
                         showBackground = false,


### PR DESCRIPTION
- Remove mutable `var noAnim` from CardFace enum (shared singleton mutation)
- Remove dead LaunchedEffect with no-op snapshotFlow in RegionSelectionScreen
- Fix modifier parameter ordering in BlendModeTab (required params before modifier)
- Add stable keys to lazy lists: PhoneCountryCodeScreen, AppSettingsScreenContent, EmojiGarden