### PR TITLE
fix(compose): parameter ordering, missing Modifier, and stale side effect keys

### DIFF
--- a/apps/flipcash/app/src/main/kotlin/com/flipcash/app/internal/ui/navigation/MainRoot.kt
+++ b/apps/flipcash/app/src/main/kotlin/com/flipcash/app/internal/ui/navigation/MainRoot.kt
@@ -18,7 +18,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.res.painterResource
 import androidx.navigation3.runtime.NavKey
 import com.flipcash.app.android.R
@@ -79,7 +79,7 @@ internal fun MainRoot(deepLink: () -> DeepLink?) {
                 label = "loading visibility"
             )
             CodeCircularProgressIndicator(
-                modifier = Modifier.alpha(loadingAlpha)
+                modifier = Modifier.graphicsLayer { alpha = loadingAlpha }
             )
         }
     }

--- a/apps/flipcash/features/backupkey/src/main/kotlin/com/flipcash/app/backupkey/internal/BackupKeyScreenContent.kt
+++ b/apps/flipcash/features/backupkey/src/main/kotlin/com/flipcash/app/backupkey/internal/BackupKeyScreenContent.kt
@@ -25,6 +25,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -59,8 +60,8 @@ internal fun BackupKeyScreenContent(viewModel: BackupKeyScreenViewModel) {
     val resources = LocalResources.current
     val dataState by viewModel.uiFlow.collectAsStateWithLifecycle()
 
-    var isExportSeedRequested by remember { mutableStateOf(false) }
-    var isStoragePermissionGranted by remember { mutableStateOf(false) }
+    var isExportSeedRequested by rememberSaveable { mutableStateOf(false) }
+    var isStoragePermissionGranted by rememberSaveable { mutableStateOf(false) }
     val isAccessKeyVisible = remember { MutableTransitionState(false) }
 
     val onPermissionResult = { result: PermissionResult ->

--- a/apps/flipcash/features/bill-customization/src/main/kotlin/com/flipcash/app/bill/customization/features/TextureControls.kt
+++ b/apps/flipcash/features/bill-customization/src/main/kotlin/com/flipcash/app/bill/customization/features/TextureControls.kt
@@ -91,10 +91,13 @@ internal fun TextureControls(
             }
         }
 
+        val blendModes = remember(state.blendModes) {
+            state.blendModes.map { it.blendMode }
+        }
+
         val selectedTabIndex by remember(state.selectedBlendMode) {
             derivedStateOf {
-                val option = state.selectedBlendMode.blendMode
-                state.blendModes.map { it.blendMode }.indexOf(option).takeIf { it >= 0 } ?: 0
+                blendModes.indexOf(state.selectedBlendMode.blendMode).takeIf { it >= 0 } ?: 0
             }
         }
 
@@ -106,7 +109,7 @@ internal fun TextureControls(
             indicator = {}, // no indicator
             divider = {} // no divider
         ) {
-            state.blendModes.map { it.blendMode }.forEachIndexed { index, mode ->
+            blendModes.forEachIndexed { index, mode ->
                 BlendModeTab(
                     mode = mode,
                     isSelected = index == selectedTabIndex,

--- a/apps/flipcash/features/cash/src/main/kotlin/com/flipcash/app/cash/internal/CashScreenContent.kt
+++ b/apps/flipcash/features/cash/src/main/kotlin/com/flipcash/app/cash/internal/CashScreenContent.kt
@@ -7,7 +7,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -22,7 +22,7 @@ import com.getcode.ui.theme.CodeButton
 @Composable
 internal fun GiveScreenContent(viewModel: CashScreenViewModel) {
     val navigator = LocalCodeNavigator.current
-    val state by viewModel.stateFlow.collectAsState()
+    val state by viewModel.stateFlow.collectAsStateWithLifecycle()
     Column(
         modifier = Modifier.fillMaxSize(),
     ) {

--- a/apps/flipcash/features/device-logs/src/main/kotlin/com/flipcash/app/devicelogs/internal/DeviceLogsScreen.kt
+++ b/apps/flipcash/features/device-logs/src/main/kotlin/com/flipcash/app/devicelogs/internal/DeviceLogsScreen.kt
@@ -196,7 +196,10 @@ private fun LogList(
             ),
             verticalArrangement = Arrangement.spacedBy(2.dp),
         ) {
-            items(lines.asReversed()) { line ->
+            items(
+                items = lines.asReversed(),
+                key = { it.hashCode() },
+            ) { line ->
                 LogLine(line = line, filter = filter)
             }
         }

--- a/apps/flipcash/features/direct-send/src/main/kotlin/com/flipcash/app/directsend/internal/screens/ContactListScreen.kt
+++ b/apps/flipcash/features/direct-send/src/main/kotlin/com/flipcash/app/directsend/internal/screens/ContactListScreen.kt
@@ -88,7 +88,7 @@ internal fun ContactListScreen() {
 
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
 
-    LaunchedEffect(Unit) {
+    LaunchedEffect(viewModel) {
         viewModel.eventFlow
             .filterIsInstance<SendFlowViewModel.Event.SendInvite>()
             .collect { event ->
@@ -96,7 +96,7 @@ internal fun ContactListScreen() {
             }
     }
 
-    LaunchedEffect(Unit) {
+    LaunchedEffect(viewModel) {
         viewModel.eventFlow
             .filterIsInstance<SendFlowViewModel.Event.NavigateToAmountEntry>()
             .collect { event ->

--- a/apps/flipcash/features/direct-send/src/main/kotlin/com/flipcash/app/directsend/internal/screens/ContactsPermissionGateScreen.kt
+++ b/apps/flipcash/features/direct-send/src/main/kotlin/com/flipcash/app/directsend/internal/screens/ContactsPermissionGateScreen.kt
@@ -50,7 +50,7 @@ internal fun ContactsPermissionGateScreen() {
         }
     }
 
-    LaunchedEffect(Unit) {
+    LaunchedEffect(viewModel) {
         viewModel.eventFlow
             .filterIsInstance<SendFlowViewModel.Event.ContactSyncComplete>()
             .collect { flowNavigator.proceed() }

--- a/apps/flipcash/features/login/src/main/kotlin/com/flipcash/app/login/internal/screens/AccessKeyScreenContent.kt
+++ b/apps/flipcash/features/login/src/main/kotlin/com/flipcash/app/login/internal/screens/AccessKeyScreenContent.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -78,8 +79,8 @@ internal fun AccessKeyScreen(
 
     val composeScope = rememberCoroutineScope()
 
-    var isExportSeedRequested by remember { mutableStateOf(false) }
-    var isStoragePermissionGranted by remember { mutableStateOf(false) }
+    var isExportSeedRequested by rememberSaveable { mutableStateOf(false) }
+    var isStoragePermissionGranted by rememberSaveable { mutableStateOf(false) }
 
     val onPermissionResult = { result: PermissionResult ->
         isStoragePermissionGranted = result == PermissionResult.Granted

--- a/apps/flipcash/features/shareapp/src/main/kotlin/com/flipcash/app/shareapp/internal/ShareAppScreenContent.kt
+++ b/apps/flipcash/features/shareapp/src/main/kotlin/com/flipcash/app/shareapp/internal/ShareAppScreenContent.kt
@@ -21,7 +21,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.layout.boundsInWindow
@@ -113,7 +113,7 @@ internal fun ShareAppScreenContent() {
             Text(
                 modifier = Modifier
                     .padding(bottom = CodeTheme.dimens.grid.x4)
-                    .alpha(contentAlpha),
+                    .graphicsLayer { alpha = contentAlpha },
                 text = stringResource(R.string.subtitle_scanToDownload),
                 style = CodeTheme.typography.textLarge,
                 textAlign = TextAlign.Center
@@ -139,7 +139,7 @@ internal fun ShareAppScreenContent() {
             )
 
             Row(
-                modifier = Modifier.alpha(contentAlpha),
+                modifier = Modifier.graphicsLayer { alpha = contentAlpha },
                 horizontalArrangement = Arrangement.spacedBy(
                     space = CodeTheme.dimens.inset,
                     alignment = Alignment.CenterHorizontally

--- a/apps/flipcash/features/tokens/src/main/kotlin/com/flipcash/app/tokens/PhantomWalletScreens.kt
+++ b/apps/flipcash/features/tokens/src/main/kotlin/com/flipcash/app/tokens/PhantomWalletScreens.kt
@@ -47,7 +47,7 @@ internal fun PhantomConnectConfirmationScreen() {
             .launchIn(this)
     }
 
-    LaunchedEffect(Unit) {
+    LaunchedEffect(viewModel) {
         viewModel.eventFlow
             .filterIsInstance<SwapViewModel.Event.PhantomConnected>()
             .onEach { flowNavigator.navigateTo(SwapStep.PhantomConfirmTransaction) }

--- a/apps/flipcash/features/userflags/src/main/kotlin/com/flipcash/app/userflags/internal/UserFlagsEditor.kt
+++ b/apps/flipcash/features/userflags/src/main/kotlin/com/flipcash/app/userflags/internal/UserFlagsEditor.kt
@@ -75,13 +75,19 @@ private fun UserFlagsEditor(
                 ) {
                     // Read-only section
                     item { SectionHeader("Read-Only") }
-                    items(state.readOnlyEntries) { entry ->
+                    items(
+                        items = state.readOnlyEntries,
+                        key = { it.label },
+                    ) { entry ->
                         ReadOnlyRow(entry)
                     }
 
                     // Editable section
                     item { SectionHeader("Overridable") }
-                    items(state.editableEntries) { entry ->
+                    items(
+                        items = state.editableEntries,
+                        key = { it.field.label },
+                    ) { entry ->
                         EditableRow(
                             modifier = Modifier.fillMaxWidth(),
                             entry = entry,

--- a/apps/flipcash/shared/appupdates/src/main/kotlin/com/flipcash/app/updates/LocalAppUpdater.kt
+++ b/apps/flipcash/shared/appupdates/src/main/kotlin/com/flipcash/app/updates/LocalAppUpdater.kt
@@ -1,10 +1,10 @@
 package com.flipcash.app.updates
 
-import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.staticCompositionLocalOf
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
-val LocalAppUpdater = compositionLocalOf<AppUpdateController> { StubAppUpdateController() }
+val LocalAppUpdater = staticCompositionLocalOf<AppUpdateController> { StubAppUpdateController() }
 
 class StubAppUpdateController(updateInfo: UpdateInfo? = null): AppUpdateController {
     override val availableUpdate: StateFlow<UpdateInfo?> = MutableStateFlow(updateInfo)

--- a/apps/flipcash/shared/onramp/coinbase/src/main/kotlin/com/flipcash/app/onramp/CoinbaseOnRampLocal.kt
+++ b/apps/flipcash/shared/onramp/coinbase/src/main/kotlin/com/flipcash/app/onramp/CoinbaseOnRampLocal.kt
@@ -1,6 +1,6 @@
 package com.flipcash.app.onramp
 
-import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.staticCompositionLocalOf
 
 val LocalCoinbaseOnRampController =
-    compositionLocalOf<CoinbaseOnRampController> { throw IllegalStateException() }
+    staticCompositionLocalOf<CoinbaseOnRampController> { throw IllegalStateException() }

--- a/ui/biometrics/src/main/kotlin/com/getcode/ui/biometrics/Biometrics.kt
+++ b/ui/biometrics/src/main/kotlin/com/getcode/ui/biometrics/Biometrics.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -62,7 +63,7 @@ fun rememberBiometricsState(
     }
 
     var lastAuthTimestamp by remember {
-        mutableStateOf(0L)
+        mutableLongStateOf(0L)
     }
 
     LaunchedEffect(checkBiometrics, requireBiometrics, canAuthenticate) {

--- a/ui/components/src/main/kotlin/com/getcode/ui/components/Badge.kt
+++ b/ui/components/src/main/kotlin/com/getcode/ui/components/Badge.kt
@@ -23,8 +23,8 @@ import com.getcode.theme.CodeTheme
 
 @Composable
 fun Badge(
-    modifier: Modifier = Modifier,
     count: Int,
+    modifier: Modifier = Modifier,
     showMoreUnread: Boolean = count > 99,
     color: Color = CodeTheme.colors.brand,
     contentColor: Color = Color.White,

--- a/ui/components/src/main/kotlin/com/getcode/ui/components/ConnectionStatusComponent.kt
+++ b/ui/components/src/main/kotlin/com/getcode/ui/components/ConnectionStatusComponent.kt
@@ -16,8 +16,8 @@ import com.getcode.utils.network.NetworkState
 import com.getcode.utils.network.connectivity.NetworkStateProvider
 
 @Composable
-fun ConnectionStatus(state: NetworkState) {
-    Row {
+fun ConnectionStatus(state: NetworkState, modifier: Modifier = Modifier) {
+    Row(modifier = modifier) {
         when  {
             !state.connected && state.type != ConnectionType.Unknown -> {
                 CodeCircularProgressIndicator(

--- a/ui/components/src/main/kotlin/com/getcode/ui/components/Pill.kt
+++ b/ui/components/src/main/kotlin/com/getcode/ui/components/Pill.kt
@@ -20,11 +20,11 @@ import com.getcode.theme.CodeTheme
 
 @Composable
 fun Pill(
+    text: String,
     modifier: Modifier = Modifier,
     backgroundColor: Color = Black50,
     contentColor: Color = Color.White,
     shape: CornerBasedShape = CircleShape,
-    text: String,
     textStyle: TextStyle = CodeTheme.typography.caption,
     contentPadding: PaddingValues = PaddingValues(
         horizontal = CodeTheme.dimens.grid.x2,
@@ -60,11 +60,10 @@ fun Pill(
     content: @Composable () -> Unit,
 ) {
     Row(
-        modifier = Modifier
+        modifier = modifier
             .wrapContentSize()
             .clip(shape)
             .background(backgroundColor)
-            .then(modifier)
             .padding(contentPadding)
     ) {
         CompositionLocalProvider(LocalContentColor provides contentColor) {

--- a/ui/components/src/main/kotlin/com/getcode/ui/components/SegmentedControl.kt
+++ b/ui/components/src/main/kotlin/com/getcode/ui/components/SegmentedControl.kt
@@ -14,12 +14,12 @@ import androidx.compose.ui.unit.Dp
 fun <T> SegmentedControl(
     options: List<T>,
     selected: T?,
+    onSelectionChanged: (T) -> Unit,
+    modifier: Modifier = Modifier,
     colors: SegmentedButtonColors = SegmentedButtonDefaults.colors(),
     contentPadding: PaddingValues = SegmentedButtonDefaults.ContentPadding,
-    mapper: @Composable SingleChoiceSegmentedButtonRowScope.(T) -> Unit,
     space: Dp = SegmentedButtonDefaults.BorderWidth,
-    modifier: Modifier = Modifier,
-    onSelectionChanged: (T) -> Unit,
+    mapper: @Composable SingleChoiceSegmentedButtonRowScope.(T) -> Unit,
 ) {
     SingleChoiceSegmentedButtonRow(
         modifier = modifier,

--- a/ui/components/src/main/kotlin/com/getcode/ui/components/SlideToConfirm.kt
+++ b/ui/components/src/main/kotlin/com/getcode/ui/components/SlideToConfirm.kt
@@ -162,6 +162,7 @@ fun SlideToConfirm(
     },
 ) {
     val currentIsLoading by rememberUpdatedState(isLoading)
+    val currentOnConfirm by rememberUpdatedState(onConfirm)
     val hapticFeedback = LocalHapticFeedback.current
     val density = LocalDensity.current
     val thumbSize = Thumb.Size
@@ -210,7 +211,7 @@ fun SlideToConfirm(
             .filter { it == 1f }
             .collect {
                 hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
-                onConfirm()
+                currentOnConfirm()
                 // Give the caller a moment to set isLoading = true.
                 // If they don't, the confirmation was rejected — reset.
                 delay(200)

--- a/ui/components/src/main/kotlin/com/getcode/ui/components/bars/BottomBarContainer.kt
+++ b/ui/components/src/main/kotlin/com/getcode/ui/components/bars/BottomBarContainer.kt
@@ -42,9 +42,8 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clipToBounds
-import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
@@ -121,7 +120,7 @@ fun BottomBarContainer(barMessages: BarMessages, onShown: (BottomBarManager.Bott
                 Box(
                     modifier = Modifier
                         .fillMaxSize()
-                        .alpha(scrimAlpha)
+                        .graphicsLayer { alpha = scrimAlpha }
                         .background(CodeTheme.colors.scrim)
                         .rememberedClickable(
                             indication = null,
@@ -257,7 +256,7 @@ fun BottomBarView(
                                 color = LocalContentColor.current.copy(alpha = 0.8f),
                             )
                             Icon(
-                                modifier = Modifier.rotate(rotation),
+                                modifier = Modifier.graphicsLayer { rotationZ = rotation },
                                 imageVector = Icons.Rounded.ExpandMore,
                                 contentDescription = null,
                                 tint = LocalContentColor.current.copy(alpha = 0.8f),

--- a/ui/components/src/main/kotlin/com/getcode/ui/components/chat/messagecontents/Feedback.kt
+++ b/ui/components/src/main/kotlin/com/getcode/ui/components/chat/messagecontents/Feedback.kt
@@ -67,9 +67,11 @@ internal fun Feedback(
                 )
             }
 
-            val rxns = reactions
-                .sortedBy { it.sentAt }
-                .groupBy { it.emoji }
+            val rxns = remember(reactions) {
+                reactions
+                    .sortedBy { it.sentAt }
+                    .groupBy { it.emoji }
+            }
 
             rxns.onEach { (emoji, occurrences) ->
                 EmojiCounter(

--- a/ui/components/src/main/kotlin/com/getcode/ui/components/chat/messagecontents/MessageTextContent.kt
+++ b/ui/components/src/main/kotlin/com/getcode/ui/components/chat/messagecontents/MessageTextContent.kt
@@ -352,7 +352,9 @@ private fun MarkupTextHandler(
 
         options.onMarkupClicked != null -> {
             val markupTextHelper = remember { MarkupTextHelper() }
-            val markups = options.markupsToResolve.map { Markup.create(it) }
+            val markups = remember(options.markupsToResolve) {
+                options.markupsToResolve.map { Markup.create(it) }
+            }
 
             val annotatedString = markupTextHelper.annotate(text.text, markups)
             val markupHoist = LocalTextLayoutResult.current

--- a/ui/components/src/main/kotlin/com/getcode/ui/theme/CodeSegmentedControl.kt
+++ b/ui/components/src/main/kotlin/com/getcode/ui/theme/CodeSegmentedControl.kt
@@ -14,9 +14,9 @@ import com.getcode.ui.components.SegmentedControl
 fun <T> CodeSegmentedControl(
     options: List<T>,
     selected: T?,
-    mapper: @Composable SingleChoiceSegmentedButtonRowScope.(T) -> Unit,
-    modifier: Modifier = Modifier,
     onSelectionChanged: (T) -> Unit,
+    modifier: Modifier = Modifier,
+    mapper: @Composable SingleChoiceSegmentedButtonRowScope.(T) -> Unit,
 ) {
     SegmentedControl(
         options = options,

--- a/ui/components/src/main/kotlin/com/getcode/ui/theme/CodeSwitch.kt
+++ b/ui/components/src/main/kotlin/com/getcode/ui/theme/CodeSwitch.kt
@@ -40,9 +40,9 @@ object CodeToggleSwitchDefaults {
 
 @Composable
 fun CodeToggleSwitch(
+    checked: Boolean,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
-    checked: Boolean,
     onCheckedChange: ((Boolean) -> Unit)? = null,
 ) {
     val width = 51.dp
@@ -62,7 +62,7 @@ fun CodeToggleSwitch(
     val trackColor by colors.trackColor(enabled = enabled, checked = checked)
     val thumbColor by colors.thumbColor(enabled = enabled, checked = checked)
     Canvas(
-        modifier = Modifier
+        modifier = modifier
             .size(width = width, height = height)
             .addIf(onCheckedChange != null) {
                 Modifier.pointerInput(Unit) {
@@ -72,7 +72,7 @@ fun CodeToggleSwitch(
                         }
                     )
                 }
-            }.then(modifier)
+            }
     ) {
         drawRoundRect(
             color = trackColor,

--- a/ui/emojis/src/main/kotlin/com/getcode/ui/emojis/EmojiSearch.kt
+++ b/ui/emojis/src/main/kotlin/com/getcode/ui/emojis/EmojiSearch.kt
@@ -51,7 +51,10 @@ fun EmojiSearchResults(
             bottom = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding() + CodeTheme.dimens.grid.x2
         )
     ) {
-        items(results.orEmpty()) { emoji ->
+        items(
+            items = results.orEmpty(),
+            key = { it.unicode },
+        ) { emoji ->
             Row(
                 modifier = Modifier
                     .clickable { onSelected(emoji.unicode) },

--- a/ui/emojis/src/main/kotlin/com/getcode/ui/emojis/FrequentlyUsedEmojis.kt
+++ b/ui/emojis/src/main/kotlin/com/getcode/ui/emojis/FrequentlyUsedEmojis.kt
@@ -49,7 +49,10 @@ fun FrequentlyUsedEmojis(
             .height(CodeTheme.dimens.grid.x9),
         contentPadding = PaddingValues(horizontal = CodeTheme.dimens.inset)
     ) {
-        items(frequentlyUsedEmojis) { emoji ->
+        items(
+            items = frequentlyUsedEmojis,
+            key = { it },
+        ) { emoji ->
             EmojiRender(
                 emoji = emoji,
                 size = DpSize(


### PR DESCRIPTION
## Summary

**Parameter ordering corrections**
- `SegmentedControl` / `CodeSegmentedControl`: move `modifier` after required params, trailing lambda last
- `Badge`: move required `count` before `modifier`
- `Pill`: move required `text` before `modifier`; fix modifier chain so caller modifier is outermost
- `CodeToggleSwitch`: move required `checked` before `modifier`; fix modifier chain

**Missing modifier parameter**
- `ConnectionStatus`: add `modifier: Modifier = Modifier` so callers can control layout