### PR TITLE
fix(compose): modifier ordering, missing params, effect cleanup

### DIFF
--- a/apps/flipcash/core/src/main/kotlin/com/flipcash/app/core/ui/TileButton.kt
+++ b/apps/flipcash/core/src/main/kotlin/com/flipcash/app/core/ui/TileButton.kt
@@ -30,11 +30,11 @@ fun TileButton(
 ) {
     Box(
         modifier = modifier
+            .clip(CodeTheme.shapes.extraSmall)
             .background(
                 color = CodeTheme.colors.surfaceVariant,
                 shape = CodeTheme.shapes.extraSmall,
             )
-            .clip(CodeTheme.shapes.extraSmall)
             .clickable(onClick = onClick)
             .padding(contentPadding),
         contentAlignment = Alignment.Center,

--- a/apps/flipcash/core/src/main/kotlin/com/flipcash/app/core/ui/TokenSelectionPill.kt
+++ b/apps/flipcash/core/src/main/kotlin/com/flipcash/app/core/ui/TokenSelectionPill.kt
@@ -19,9 +19,9 @@ import com.getcode.ui.core.R
 import androidx.compose.foundation.clickable
 
 @Composable
-fun TokenSelectionPill(token: Token?, onClick: () -> Unit) {
+fun TokenSelectionPill(token: Token?, modifier: Modifier = Modifier, onClick: () -> Unit) {
     Box(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .wrapContentHeight(),
         contentAlignment = Alignment.Center
@@ -60,10 +60,11 @@ fun TokenSelectionPill(
     tokenName: String,
     tokenImageUrl: String?,
     tokenSymbol: String,
+    modifier: Modifier = Modifier,
     onClick: () -> Unit
 ) {
     Box(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .wrapContentHeight(),
         contentAlignment = Alignment.Center

--- a/ui/components/src/main/kotlin/com/getcode/ui/components/ListItem.kt
+++ b/ui/components/src/main/kotlin/com/getcode/ui/components/ListItem.kt
@@ -33,10 +33,10 @@ fun ListItem(
 ) {
     Row(
         modifier = modifier
-            .clickable { onClick() }
-            .padding(CodeTheme.dimens.grid.x5)
             .fillMaxWidth()
-            .wrapContentHeight(),
+            .wrapContentHeight()
+            .clickable { onClick() }
+            .padding(CodeTheme.dimens.grid.x5),
         verticalAlignment = CenterVertically
     ) {
         if (icon != null) {

--- a/ui/components/src/main/kotlin/com/getcode/ui/components/OnWindowFocusedRequester.kt
+++ b/ui/components/src/main/kotlin/com/getcode/ui/components/OnWindowFocusedRequester.kt
@@ -6,10 +6,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.platform.LocalWindowInfo
-import kotlinx.coroutines.flow.distinctUntilChanged
 import timber.log.Timber
 
 @Composable
@@ -20,19 +18,15 @@ fun OnWindowFocusedRequester(
     val windowInfo = LocalWindowInfo.current
     var focusRequested by rememberSaveable { mutableStateOf(false) }
     LaunchedEffect(windowInfo.isWindowFocused) {
-        snapshotFlow { windowInfo.isWindowFocused }
-            .distinctUntilChanged()
-            .collect { isWindowFocused ->
-                if (isWindowFocused && !focusRequested) {
-                    try {
-                        focusRequested = true
-                        focusRequester.requestFocus()
-                    } catch (ex: IllegalStateException) {
-                        // One case observed in staging. For some reason reported "FocusRequester is not
-                        // initialized."
-                        Timber.e(ex, "Failed to set focus to text field")
-                    }
-                }
+        if (windowInfo.isWindowFocused && !focusRequested) {
+            try {
+                focusRequested = true
+                focusRequester.requestFocus()
+            } catch (ex: IllegalStateException) {
+                // One case observed in staging. For some reason reported "FocusRequester is not
+                // initialized."
+                Timber.e(ex, "Failed to set focus to text field")
             }
+        }
     }
 }

--- a/ui/components/src/main/kotlin/com/getcode/ui/components/SlideToConfirm.kt
+++ b/ui/components/src/main/kotlin/com/getcode/ui/components/SlideToConfirm.kt
@@ -216,7 +216,7 @@ fun SlideToConfirm(
                 // If they don't, the confirmation was rejected — reset.
                 delay(200)
                 if (!currentIsLoading) {
-                    composeScope.launch { swipeState.animateTo(Anchor.Start) }
+                    swipeState.animateTo(Anchor.Start)
                 }
             }
     }

--- a/ui/components/src/main/kotlin/com/getcode/ui/components/text/SectionHeader.kt
+++ b/ui/components/src/main/kotlin/com/getcode/ui/components/text/SectionHeader.kt
@@ -8,12 +8,12 @@ import androidx.compose.ui.Modifier
 import com.getcode.theme.CodeTheme
 
 @Composable
-fun SectionHeader(title: String) {
+fun SectionHeader(title: String, modifier: Modifier = Modifier) {
     Text(
         text = title.uppercase(),
         style = CodeTheme.typography.textSmall,
         color = CodeTheme.colors.textSecondary,
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .padding(
                 start = CodeTheme.dimens.inset,

--- a/ui/navigation/src/main/kotlin/com/getcode/navigation/flow/FlowDismissStyle.kt
+++ b/ui/navigation/src/main/kotlin/com/getcode/navigation/flow/FlowDismissStyle.kt
@@ -1,7 +1,7 @@
 package com.getcode.navigation.flow
 
-import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.staticCompositionLocalOf
 
 enum class FlowDismissStyle { Default, BackArrow, Close }
 
-val LocalFlowDismissStyle = compositionLocalOf { FlowDismissStyle.Default }
+val LocalFlowDismissStyle = staticCompositionLocalOf { FlowDismissStyle.Default }

--- a/ui/navigation/src/main/kotlin/com/getcode/ui/utils/DisableSheetGestures.kt
+++ b/ui/navigation/src/main/kotlin/com/getcode/ui/utils/DisableSheetGestures.kt
@@ -4,7 +4,7 @@ import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -19,7 +19,7 @@ import androidx.lifecycle.repeatOnLifecycle
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
-val LocalSheetGesturesState = compositionLocalOf<(Boolean) -> Unit> { {  } }
+val LocalSheetGesturesState = staticCompositionLocalOf<(Boolean) -> Unit> { {  } }
 
 @Composable
 fun DisableSheetGestures(


### PR DESCRIPTION
## Summary

- **Modifier chain ordering**: ListItem — move clickable before padding so click area does not extend into padding; TileButton — move clip before background so background respects clip shape
- **Missing modifier param**: Add modifier: Modifier = Modifier to SectionHeader and both TokenSelectionPill overloads
- **staticCompositionLocalOf**: Convert LocalFlowDismissStyle and LocalSheetGesturesState — values rarely change, no need for recomposition tracking
- **Remove nested scope in SlideToConfirm**: composeScope.launch inside LaunchedEffect is redundant — already in a coroutine
- **Remove double-observation in OnWindowFocusedRequester**: LaunchedEffect(windowInfo.isWindowFocused) already restarts on change, snapshotFlow on the same value is redundant