### PR TITLE
fix(compose): add contentType to heterogeneous lazy lists

### DIFF
--- a/apps/flipcash/features/lab/src/main/kotlin/com/flipcash/app/lab/internal/LabsScreenContent.kt
+++ b/apps/flipcash/features/lab/src/main/kotlin/com/flipcash/app/lab/internal/LabsScreenContent.kt
@@ -55,10 +55,10 @@ internal fun LabsScreenContent(viewModel: LabsScreenViewModel) {
             ).sheetResignmentBehavior(state),
         contentPadding = PaddingValues(bottom = CodeTheme.dimens.grid.x3),
     ) {
-        item {
+        item(contentType = "section_header") {
             SectionHeader(stringResource(R.string.title_settingsSectionFeatures))
         }
-        items(betaFlags, key = { it.flag.key }) { feature ->
+        items(betaFlags, key = { it.flag.key }, contentType = { "feature_flag" }) { feature ->
             if (feature.flag.isOptionFlag) {
                 SettingsOptionRow(
                     title = feature.flag.title,
@@ -87,7 +87,7 @@ internal fun LabsScreenContent(viewModel: LabsScreenViewModel) {
         }
 
         if (betaFlags.isEmpty()) {
-            item {
+            item(contentType = "empty_state") {
                 Box {
                     Column(
                         modifier = Modifier.align(Alignment.Center),
@@ -113,8 +113,8 @@ internal fun LabsScreenContent(viewModel: LabsScreenViewModel) {
             }
         }
 
-        item { SectionHeader(stringResource(R.string.title_settingsSectionHomeScreen)) }
-        item {
+        item(contentType = "section_header") { SectionHeader(stringResource(R.string.title_settingsSectionHomeScreen)) }
+        item(contentType = "list_item") {
             ListItem(
                 headline = stringResource(R.string.title_settingsButtonOrder),
                 icon = painterResource(R.drawable.ic_bottom_navigation),
@@ -124,8 +124,8 @@ internal fun LabsScreenContent(viewModel: LabsScreenViewModel) {
         }
 
         if (isStaff) {
-            item { SectionHeader(stringResource(R.string.title_settingsSectionDeveloper)) }
-            item {
+            item(contentType = "section_header") { SectionHeader(stringResource(R.string.title_settingsSectionDeveloper)) }
+            item(contentType = "list_item") {
                 ListItem(
                     headline = stringResource(R.string.subtitle_settingsUserFlags),
                     icon = rememberVectorPainter(Icons.Default.Token),

--- a/apps/flipcash/features/myaccount/src/main/kotlin/com/flipcash/app/myaccount/internal/UserProfileScreenContent.kt
+++ b/apps/flipcash/features/myaccount/src/main/kotlin/com/flipcash/app/myaccount/internal/UserProfileScreenContent.kt
@@ -32,8 +32,8 @@ internal fun UserProfileScreenContent(
 ) {
     LazyColumn(modifier = Modifier.fillMaxSize()) {
         // Display Name section
-        item { SectionHeader(stringResource(R.string.title_sectionDisplayName)) }
-        item {
+        item(contentType = "section_header") { SectionHeader(stringResource(R.string.title_sectionDisplayName)) }
+        item(contentType = "profile_value") {
             val name = state.displayName
             if (!name.isNullOrEmpty()) {
                 ProfileValueRow(value = name)
@@ -51,8 +51,8 @@ internal fun UserProfileScreenContent(
         }
 
         // Phone section
-        item { SectionHeader(stringResource(R.string.title_sectionPhone)) }
-        item {
+        item(contentType = "section_header") { SectionHeader(stringResource(R.string.title_sectionPhone)) }
+        item(contentType = "contact_method") {
             if (state.phoneNumber != null) {
                 ContactMethodRow(
                     value = state.phoneNumber,
@@ -71,8 +71,8 @@ internal fun UserProfileScreenContent(
         }
 
         // Email section
-        item { SectionHeader(stringResource(R.string.title_sectionEmail)) }
-        item {
+        item(contentType = "section_header") { SectionHeader(stringResource(R.string.title_sectionEmail)) }
+        item(contentType = "contact_method") {
             if (state.emailAddress != null) {
                 ContactMethodRow(
                     value = state.emailAddress,
@@ -89,9 +89,9 @@ internal fun UserProfileScreenContent(
         }
 
         // Social Accounts section
-        item { SectionHeader(stringResource(R.string.title_sectionSocialAccounts)) }
+        item(contentType = "section_header") { SectionHeader(stringResource(R.string.title_sectionSocialAccounts)) }
         if (state.socialAccounts.isEmpty()) {
-            item {
+            item(contentType = "empty_state") {
                 Text(
                     text = stringResource(R.string.subtitle_noSocialAccounts),
                     style = CodeTheme.typography.textMedium,
@@ -103,7 +103,7 @@ internal fun UserProfileScreenContent(
                 )
             }
         } else {
-            items(state.socialAccounts, key = { (it as? SocialAccount.TwitterX)?.id ?: it }) { account ->
+            items(state.socialAccounts, key = { (it as? SocialAccount.TwitterX)?.id ?: it }, contentType = { "social_account" }) { account ->
                 when (account) {
                     is SocialAccount.TwitterX -> SocialAccountRow(
                         account = account,

--- a/apps/flipcash/features/userflags/src/main/kotlin/com/flipcash/app/userflags/internal/UserFlagsEditor.kt
+++ b/apps/flipcash/features/userflags/src/main/kotlin/com/flipcash/app/userflags/internal/UserFlagsEditor.kt
@@ -74,19 +74,21 @@ private fun UserFlagsEditor(
                     contentPadding = PaddingValues(bottom = CodeTheme.dimens.grid.x3),
                 ) {
                     // Read-only section
-                    item { SectionHeader("Read-Only") }
+                    item(contentType = "section_header") { SectionHeader("Read-Only") }
                     items(
                         items = state.readOnlyEntries,
                         key = { it.label },
+                        contentType = { "read_only_row" },
                     ) { entry ->
                         ReadOnlyRow(entry)
                     }
 
                     // Editable section
-                    item { SectionHeader("Overridable") }
+                    item(contentType = "section_header") { SectionHeader("Overridable") }
                     items(
                         items = state.editableEntries,
                         key = { it.field.label },
+                        contentType = { "editable_row" },
                     ) { entry ->
                         EditableRow(
                             modifier = Modifier.fillMaxWidth(),

--- a/apps/flipcash/shared/tokens/src/main/kotlin/com/flipcash/app/tokens/ui/TokenList.kt
+++ b/apps/flipcash/shared/tokens/src/main/kotlin/com/flipcash/app/tokens/ui/TokenList.kt
@@ -82,18 +82,19 @@ fun TokenList(
             state = listState
         ) {
             if (tokens != null && tokens.isEmpty() && emptyState != null) {
-                item {
+                item(contentType = "empty_state") {
                     emptyState()
                 }
             } else {
                 header?.let { content ->
-                    item {
+                    item(contentType = "header") {
                         content()
                     }
                 }
                 items(
                     items = filteredTokens.orEmpty(),
-                    key = { item -> item.token.address.base58() }) { item ->
+                    key = { item -> item.token.address.base58() },
+                    contentType = { "token_row" }) { item ->
                     TokenBalanceRow(
                         modifier = Modifier
                             .fillParentMaxWidth()
@@ -113,7 +114,7 @@ fun TokenList(
                             Fiat(0.0, cashReserves.rate.currency)
                         )
                     ) {
-                        item {
+                        item(contentType = "reserves") {
                             it(Mint.usdf, cashReserves)
                             HorizontalDivider(
                                 modifier = Modifier.padding(bottom = CodeTheme.dimens.inset),
@@ -124,7 +125,7 @@ fun TokenList(
                 }
 
                 footer?.let {
-                    item {
+                    item(contentType = "footer") {
                         Box(modifier = Modifier.alpha(if (footerSettled) 1f else 0f)) {
                             it(false)
                         }


### PR DESCRIPTION
## Summary
- Adds `contentType` to 4 heterogeneous `LazyColumn` lists so Compose can reuse compositions only between items of the same type
- **UserProfileScreenContent**: section headers, profile values, contact methods, empty state, social accounts
- **UserFlagsEditor**: section headers, read-only rows, editable rows
- **LabsScreenContent**: section headers, feature flags, empty state, list items
- **TokenList**: empty state, header, token rows, reserves, footer