### PR TITLE
fix(compose): replace SharingStarted.Eagerly with WhileSubscribed in ViewModels

### DIFF
--- a/apps/flipcash/app/src/main/kotlin/com/flipcash/app/internal/ui/HomeViewModel.kt
+++ b/apps/flipcash/app/src/main/kotlin/com/flipcash/app/internal/ui/HomeViewModel.kt
@@ -31,7 +31,7 @@ internal class HomeViewModel @Inject constructor(
     private val _requireBiometrics = MutableStateFlow<Boolean?>(null)
     val requireBiometrics = _requireBiometrics.stateIn(
         viewModelScope,
-        started = SharingStarted.Eagerly,
+        started = SharingStarted.WhileSubscribed(5_000),
         initialValue = null
     )
 

--- a/apps/flipcash/features/lab/src/main/kotlin/com/flipcash/app/lab/internal/LabsScreenViewModel.kt
+++ b/apps/flipcash/features/lab/src/main/kotlin/com/flipcash/app/lab/internal/LabsScreenViewModel.kt
@@ -3,27 +3,17 @@ package com.flipcash.app.lab.internal
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.flipcash.app.userflags.UserFlagsCoordinator
-import com.flipcash.services.user.AuthState
-import com.flipcash.services.user.UserManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import javax.inject.Inject
 
 @HiltViewModel
 class LabsScreenViewModel @Inject constructor(
-    userManager: UserManager,
     userFlags: UserFlagsCoordinator,
 ) : ViewModel() {
 
-    val isLoggedIn = userManager
-        .state.map { it.authState }
-        .filterIsInstance<AuthState.Ready>()
-        .map { true }
-        .stateIn(viewModelScope, started = SharingStarted.Eagerly, initialValue = false)
-
     val isStaff = userFlags.resolvedFlags.map { it.isStaff.effectiveValue }
-        .stateIn(viewModelScope, started = SharingStarted.Eagerly, initialValue = false)
+        .stateIn(viewModelScope, started = SharingStarted.WhileSubscribed(5_000), initialValue = false)
 }


### PR DESCRIPTION
## Summary
- **HomeViewModel**: `SharingStarted.Eagerly` on a `MutableStateFlow` wrapper is a no-op — switched to `WhileSubscribed(5_000)`
- **LabsScreenViewModel**: upstreams are hot singleton `StateFlow`s, no benefit from eager sharing in `viewModelScope` — switched to `WhileSubscribed(5_000)`
- Removed unused `isLoggedIn` property and its imports (`UserManager`, `AuthState`, `filterIsInstance`) — dead code, never consumed