### PR TITLE
fix(bugsnag): filter "payment is a no-op" InvalidIntent from reporting

### DIFF
--- a/services/opencode/src/main/kotlin/com/getcode/opencode/model/core/errors/Errors.kt
+++ b/services/opencode/src/main/kotlin/com/getcode/opencode/model/core/errors/Errors.kt
@@ -115,7 +115,16 @@ sealed class SubmitIntentError(
     override val cause: Throwable? = null
 ) : CodeServerError(message, cause) {
     data class InvalidIntent(private val reasons: List<String>) :
-        SubmitIntentError(message = reasons.joinToString()), NotifiableError
+        SubmitIntentError(message = reasons.joinToString()), ConditionallyNotifiable {
+        val isPaymentNoOp: Boolean
+            get() = reasons.any { it.contains("payment is a no-op") }
+
+        val isExpected: Boolean
+            get() = isPaymentNoOp
+
+        override val isNotifiable: Boolean
+            get() = !isExpected
+    }
 
     data class Signature(private val details: List<String> = emptyList()) :
         SubmitIntentError(message = buildString {

--- a/services/opencode/src/test/kotlin/com/getcode/opencode/model/core/errors/SubmitIntentErrorTest.kt
+++ b/services/opencode/src/test/kotlin/com/getcode/opencode/model/core/errors/SubmitIntentErrorTest.kt
@@ -240,6 +240,22 @@ class SubmitIntentErrorTest {
     }
 
     @Test
+    fun invalidIntentWithPaymentNoOpIsNotNotifiable() {
+        val error = SubmitIntentError.InvalidIntent(listOf("payment is a no-op"))
+        assertTrue(error.isPaymentNoOp)
+        assertTrue(error.isExpected)
+        assertFalse(error.isNotifiable)
+    }
+
+    @Test
+    fun invalidIntentWithOtherReasonIsNotifiable() {
+        val error = SubmitIntentError.InvalidIntent(listOf("bad amount"))
+        assertFalse(error.isPaymentNoOp)
+        assertFalse(error.isExpected)
+        assertTrue(error.isNotifiable)
+    }
+
+    @Test
     fun otherWrausesCause() {
         val cause = RuntimeException("root cause")
         val error = SubmitIntentError.Other(cause)


### PR DESCRIPTION
## Summary
- `SubmitIntentError.InvalidIntent` with reason "payment is a no-op" was being reported to Bugsnag despite being an expected server response
- Changed `InvalidIntent` from `NotifiableError` to `ConditionallyNotifiable`, matching the `StaleState` pattern — "payment is a no-op" is treated as expected and suppressed; other reasons remain notifiable
- Added unit tests for both cases