### PR TITLE
fix: add distinctUntilChanged before flatMapLatest on stateFlow-derived flows

### DIFF
--- a/apps/flipcash/features/direct-send/src/main/kotlin/com/flipcash/app/directsend/internal/SendFlowViewModel.kt
+++ b/apps/flipcash/features/direct-send/src/main/kotlin/com/flipcash/app/directsend/internal/SendFlowViewModel.kt
@@ -36,6 +36,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.filterNotNull
@@ -182,7 +183,7 @@ internal class SendFlowViewModel @Inject constructor(
 
         combine(
             contactCoordinator.state,
-            stateFlow.map { it.searchState }.flatMapLatest { snapshotFlow { it.text } }
+            stateFlow.map { it.searchState }.distinctUntilChanged().flatMapLatest { snapshotFlow { it.text } }
         ) { contactState, searchText ->
             generateListItems(contactState, searchText.toString())
         }.onEach { items ->

--- a/apps/flipcash/features/transactions/src/main/kotlin/com/flipcash/app/transactions/internal/TransactionHistoryViewModel.kt
+++ b/apps/flipcash/features/transactions/src/main/kotlin/com/flipcash/app/transactions/internal/TransactionHistoryViewModel.kt
@@ -21,6 +21,7 @@ import com.getcode.solana.keys.PublicKey
 import com.getcode.util.resources.ResourceHelper
 import com.getcode.view.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.launchIn
@@ -131,6 +132,7 @@ class TransactionHistoryViewModel @Inject constructor(
     }
 
     val transactions = stateFlow.mapNotNull { it.mint }
+        .distinctUntilChanged()
         .flatMapLatest { mint -> feedCoordinator.transactions(mint) }
 
     companion object {

--- a/apps/flipcash/shared/tokens/src/main/kotlin/com/flipcash/app/tokens/ui/TokenInfoViewModel.kt
+++ b/apps/flipcash/shared/tokens/src/main/kotlin/com/flipcash/app/tokens/ui/TokenInfoViewModel.kt
@@ -224,6 +224,7 @@ class TokenInfoViewModel @Inject constructor(
         eventFlow
             .filterIsInstance<Event.OnBalanceUpdated>()
             .mapNotNull { stateFlow.value.mint }
+            .distinctUntilChanged()
             .flatMapLatest { mint ->
                 accountController.observeHasAccountFor(mint)
             }


### PR DESCRIPTION
## Summary

- Adds `distinctUntilChanged()` before `flatMapLatest` in `TransactionHistoryViewModel`, `TokenInfoViewModel`, and `SendFlowViewModel` to prevent unnecessary flow restarts when unrelated state changes re-emit the same derived value
- Fixes transaction history screen flashing/jumping in a loading loop when viewing token history