### PR TITLE
feat(ui): add CornerBasedShape.inset() and use for concentric SlideToConfirm thumb

### DIFF
--- a/apps/flipcash/app/build.gradle.kts
+++ b/apps/flipcash/app/build.gradle.kts
@@ -199,6 +199,7 @@ dependencies {
     implementation(project(":apps:flipcash:features:bill-customization"))
     implementation(project(":apps:flipcash:features:currency-creator"))
     implementation(project(":apps:flipcash:features:direct-send"))
+    implementation(project(":apps:flipcash:features:messenger"))
     implementation(project(":apps:flipcash:features:invite"))
     implementation(project(":apps:flipcash:features:discovery"))
     implementation(project(":apps:flipcash:features:userflags"))

--- a/apps/flipcash/app/src/main/kotlin/com/flipcash/app/internal/ui/navigation/AppScreenContent.kt
+++ b/apps/flipcash/app/src/main/kotlin/com/flipcash/app/internal/ui/navigation/AppScreenContent.kt
@@ -99,7 +99,7 @@ fun appEntryProvider(
         MessengerScreen(key.e164, key.displayName)
     }
     annotatedEntry<AppRoute.Messaging.AmountEntry> { key ->
-        ChatAmountEntryScreen(key.e164)
+        ChatAmountEntryScreen(key.e164, key.displayName)
     }
 
     // Tokens

--- a/apps/flipcash/app/src/main/kotlin/com/flipcash/app/internal/ui/navigation/AppScreenContent.kt
+++ b/apps/flipcash/app/src/main/kotlin/com/flipcash/app/internal/ui/navigation/AppScreenContent.kt
@@ -31,6 +31,8 @@ import com.flipcash.app.currency.RegionSelectionScreen
 import com.flipcash.app.deposit.DepositFlowScreen
 import com.flipcash.app.directsend.SendFlowScreen
 import com.flipcash.app.invite.InviteContactScreen
+import com.flipcash.app.messenger.MessengerScreen
+import com.flipcash.app.messenger.ChatAmountEntryScreen
 import com.flipcash.app.discovery.TokenDiscoveryScreen
 import com.flipcash.app.internal.ui.navigation.decorators.rememberNavMessagingEntryDecorator
 import com.flipcash.app.lab.LabsScreen
@@ -91,6 +93,14 @@ fun appEntryProvider(
     annotatedEntry<AppRoute.Sheets.Wallet> { BalanceScreen() }
     annotatedEntry<AppRoute.Sheets.ShareApp> { ShareAppScreen() }
     annotatedEntry<AppRoute.Sheets.Menu> { MenuScreen() }
+
+    // Messaging
+    annotatedEntry<AppRoute.Messaging.Chat> { key ->
+        MessengerScreen(key.e164, key.displayName)
+    }
+    annotatedEntry<AppRoute.Messaging.AmountEntry> { key ->
+        ChatAmountEntryScreen(key.e164)
+    }
 
     // Tokens
     annotatedEntry<AppRoute.Token.Info> { key ->

--- a/apps/flipcash/core/src/main/kotlin/com/flipcash/app/core/AppRoute.kt
+++ b/apps/flipcash/core/src/main/kotlin/com/flipcash/app/core/AppRoute.kt
@@ -23,6 +23,7 @@ import com.getcode.opencode.exchange.VerifiedFiat
 import com.getcode.opencode.internal.solana.model.SwapId
 import com.getcode.opencode.model.financial.Fiat
 import com.getcode.solana.keys.Mint
+import com.getcode.solana.keys.PublicKey
 import com.getcode.ui.core.RestrictionType
 import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.Serializable
@@ -241,6 +242,22 @@ sealed interface AppRoute : NavKey, Parcelable {
         data object Lab : Menu
         @Serializable
         data object NavBarSettings : Menu, com.getcode.navigation.Sheet, com.getcode.navigation.WrapContentSheet
+    }
+
+    @Serializable
+    @Parcelize
+    sealed interface Messaging : AppRoute {
+        @Serializable
+        data class Chat(
+            val e164: String,
+            val displayName: String,
+        ) : Messaging
+
+        @Serializable
+        data class AmountEntry(
+            val e164: String,
+            val displayName: String,
+        ) : Messaging
     }
 
     @Serializable

--- a/apps/flipcash/core/src/main/kotlin/com/flipcash/app/core/send/SendStep.kt
+++ b/apps/flipcash/core/src/main/kotlin/com/flipcash/app/core/send/SendStep.kt
@@ -2,7 +2,6 @@ package com.flipcash.app.core.send
 
 import android.os.Parcelable
 import com.getcode.navigation.flow.FlowStep
-import com.getcode.opencode.model.financial.Fiat
 import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.Serializable
 
@@ -23,18 +22,11 @@ sealed interface SendStep : FlowStep, Parcelable {
     @Parcelize
     @Serializable
     data object ContactList : SendStep
-
-    @Parcelize
-    @Serializable
-    data class AmountEntry(
-        val e164: String,
-        val displayName: String,
-    ) : SendStep
 }
 
 @Serializable
 sealed interface SendResult : Parcelable {
     @Parcelize
     @Serializable
-    data class Sent(val amount: Fiat) : SendResult
+    data class Sent(val amount: com.getcode.opencode.model.financial.Fiat) : SendResult
 }

--- a/apps/flipcash/core/src/main/res/values/strings.xml
+++ b/apps/flipcash/core/src/main/res/values/strings.xml
@@ -746,4 +746,7 @@
     <string name="error_title_cashFailedToSend">Something Went Wrong</string>
     <string name="error_description_cashFailedToSend">We were unable to send your cash. Please try again</string>
     <string name="action_swipeToSend">Swipe to Send</string>
+
+    <string name="action_sendCash">Send Cash</string>
+    <string name="action_sendMessage">Send Message</string>
 </resources>

--- a/apps/flipcash/features/direct-send/build.gradle.kts
+++ b/apps/flipcash/features/direct-send/build.gradle.kts
@@ -13,10 +13,7 @@ dependencies {
     testImplementation(libs.robolectric)
 
     implementation(libs.kotlin.stdlib)
-    implementation(project(":apps:flipcash:shared:amount-entry"))
     implementation(project(":apps:flipcash:shared:analytics"))
-    implementation(project(":apps:flipcash:shared:session"))
-    implementation(project(":apps:flipcash:shared:tokens"))
     implementation(project(":libs:datetime"))
     implementation(project(":libs:logging"))
     implementation(project(":libs:messaging"))
@@ -24,6 +21,5 @@ dependencies {
     implementation(project(":apps:flipcash:shared:featureflags"))
     implementation(project(":apps:flipcash:shared:permissions"))
     implementation(project(":apps:flipcash:shared:contacts"))
-    implementation(project(":services:opencode"))
     implementation(project(":services:flipcash"))
 }

--- a/apps/flipcash/features/direct-send/src/main/kotlin/com/flipcash/app/directsend/SendFlowScreen.kt
+++ b/apps/flipcash/features/direct-send/src/main/kotlin/com/flipcash/app/directsend/SendFlowScreen.kt
@@ -8,33 +8,18 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation3.runtime.NavEntry
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entryProvider
-import com.flipcash.app.core.AppRoute
 import com.flipcash.app.core.send.SendResult
 import com.flipcash.app.core.send.SendStep
-import com.flipcash.app.core.tokens.TokenPurpose
-import com.flipcash.app.core.ui.TokenSelectionPill
 import com.flipcash.app.directsend.internal.SendFlowViewModel
 import com.flipcash.app.directsend.internal.screens.ContactListScreen
 import com.flipcash.app.directsend.internal.screens.ContactsPermissionGateScreen
 import com.flipcash.app.directsend.internal.screens.PhoneGateLandingScreen
-import com.flipcash.features.directsend.R
-import com.flipcash.shared.amountentry.AmountEntryScreen
-import com.getcode.manager.BottomBarManager
 import com.getcode.navigation.annotatedEntry
 import com.getcode.navigation.flow.FlowExitReason
 import com.getcode.navigation.flow.FlowHost
-import com.getcode.navigation.flow.LocalOuterCodeNavigator
 import com.getcode.navigation.flow.flowSharedViewModel
-import com.getcode.navigation.flow.rememberFlowNavigator
 import com.getcode.navigation.results.NavResultStateRegistry
 import com.getcode.navigation.scenes.LocalBottomSheetDismissDispatcher
-import com.getcode.opencode.model.financial.Fiat
-import com.getcode.ui.components.AppBarDefaults
-import com.getcode.ui.components.AppBarWithTitle
-import com.getcode.util.resources.LocalResources
-import kotlinx.coroutines.flow.filterIsInstance
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
 
 @Composable
 fun SendFlowScreen(resultStateRegistry: NavResultStateRegistry) {
@@ -72,69 +57,7 @@ private fun sendEntryProvider(): (NavKey) -> NavEntry<NavKey> {
             SyncStep(it)
             ContactListScreen()
         }
-        annotatedEntry<SendStep.AmountEntry> { step ->
-            SyncStep(step)
-            SendAmountEntryScreen()
-        }
     }
-}
-
-@Composable
-private fun SendAmountEntryScreen() {
-    val flowNavigator = rememberFlowNavigator<SendStep, SendResult>()
-    val sharedVm = flowSharedViewModel<SendFlowViewModel>()
-    val sharedState by sharedVm.stateFlow.collectAsStateWithLifecycle()
-    val resources = LocalResources.current
-    val outerNavigator = LocalOuterCodeNavigator.current
-
-    LaunchedEffect(sharedState.resolveState) {
-        if (sharedState.resolveState is SendFlowViewModel.ResolveState.Failed) {
-            BottomBarManager.showAlert(
-                title = resources.getString(R.string.error_title_contactNotOnFlipcash),
-                message = resources.getString(R.string.error_description_contactNotOnFlipcash),
-                onDismiss = { flowNavigator.back() }
-            )
-        }
-    }
-
-    LaunchedEffect(sharedVm) {
-        sharedVm.eventFlow
-            .filterIsInstance<SendFlowViewModel.Event.SendComplete>()
-            .onEach { event ->
-                val displayName = sharedState.resolveState.contact?.displayName
-                    ?: resources.getString(R.string.subtitle_yourSelectedRecipient)
-                BottomBarManager.showInfo(
-                    title = resources.getString(R.string.prompt_title_fundsSentToContact),
-                    message = resources.getString(
-                        R.string.prompt_description_fundsSentToContact,
-                        event.amount.formatted(rule = Fiat.FormattingRule.Truncated),
-                        displayName,
-                    ),
-                    onDismiss = { flowNavigator.back() }
-                )
-            }.launchIn(this)
-    }
-
-    AmountEntryScreen(
-        controller = sharedVm.amountDelegate,
-        onConfirm = { sharedVm.dispatchEvent(SendFlowViewModel.Event.OnConfirmRequested) },
-        onChangeCurrency = { outerNavigator.push(AppRoute.Main.RegionSelection) },
-        appBar = {
-            AppBarWithTitle(
-                isInModal = true,
-                title = {
-                    TokenSelectionPill(sharedState.token) {
-                        flowNavigator.navigate(
-                            AppRoute.Sheets.TokenSelection(TokenPurpose.Select)
-                        )
-                    }
-                },
-                leftIcon = {
-                    AppBarDefaults.UpNavigation { flowNavigator.back() }
-                },
-            )
-        },
-    )
 }
 
 @Composable

--- a/apps/flipcash/features/direct-send/src/main/kotlin/com/flipcash/app/directsend/internal/SendFlowViewModel.kt
+++ b/apps/flipcash/features/direct-send/src/main/kotlin/com/flipcash/app/directsend/internal/SendFlowViewModel.kt
@@ -71,7 +71,10 @@ internal class SendFlowViewModel @Inject constructor(
         data class SendInvite(val contact: DeviceContact) : Event
 
         data class NavigateToChat(val contact: DeviceContact) : Event
+        data class NavigateToDirectSend(val contact: DeviceContact) : Event
     }
+
+    private val messengerEnabled = featureFlags.observe(FeatureFlag.Messenger)
 
     init {
         combine(
@@ -153,7 +156,11 @@ internal class SendFlowViewModel @Inject constructor(
             .map { it.contact }
             .onEach { (contact, isOnFlipcash) ->
                 if (isOnFlipcash) {
-                    dispatchEvent(Event.NavigateToChat(contact))
+                    if (messengerEnabled.value) {
+                        dispatchEvent(Event.NavigateToChat(contact))
+                    } else {
+                        dispatchEvent(Event.NavigateToDirectSend(contact))
+                    }
                 } else {
                     dispatchEvent(Event.SendInvite(contact))
                 }
@@ -245,6 +252,7 @@ internal class SendFlowViewModel @Inject constructor(
                 is Event.OnContactClicked -> { state -> state }
                 is Event.SendInvite -> { state -> state }
                 is Event.NavigateToChat -> { state -> state }
+                is Event.NavigateToDirectSend -> { state -> state }
             }
         }
     }

--- a/apps/flipcash/features/direct-send/src/main/kotlin/com/flipcash/app/directsend/internal/SendFlowViewModel.kt
+++ b/apps/flipcash/features/direct-send/src/main/kotlin/com/flipcash/app/directsend/internal/SendFlowViewModel.kt
@@ -9,47 +9,27 @@ import com.flipcash.app.contacts.ContactCoordinator.ContactState
 import com.flipcash.app.contacts.device.DeviceContact
 import com.flipcash.app.contacts.device.PickedContactData
 import com.flipcash.app.core.send.SendStep
-import com.flipcash.app.core.ui.ConfirmationStyle
 import com.flipcash.app.featureflags.FeatureFlag
 import com.flipcash.app.featureflags.FeatureFlagController
 import com.flipcash.app.permissions.PickedContact
-import com.flipcash.app.tokens.TokenCoordinator
 import com.flipcash.features.directsend.R
-import com.flipcash.shared.amountentry.AmountEntryDelegate
-import com.flipcash.shared.amountentry.AmountEntryStyle
 import com.flipcash.services.user.UserManager
 import com.getcode.manager.BottomBarManager
-import com.getcode.opencode.controllers.TransactionController
-import com.getcode.opencode.exchange.Exchange
-import com.getcode.opencode.exchange.VerifiedFiatCalculator
-import com.getcode.opencode.model.core.errors.ComputeVerifiedFiatError
-import com.getcode.opencode.model.financial.Fiat
-import com.getcode.opencode.model.financial.SendLimit
-import com.getcode.opencode.model.financial.Token
-import com.getcode.solana.keys.PublicKey
 import com.getcode.util.resources.ResourceHelper
 import com.getcode.view.BaseViewModel
 import com.getcode.view.LoadingSuccessState
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterIsInstance
-import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.take
-import kotlinx.coroutines.launch
 import javax.inject.Inject
-import kotlin.math.min
 import kotlin.time.Duration.Companion.seconds
 
 @HiltViewModel
@@ -58,46 +38,10 @@ internal class SendFlowViewModel @Inject constructor(
     featureFlags: FeatureFlagController,
     private val contactCoordinator: ContactCoordinator,
     private val resources: ResourceHelper,
-    private val exchange: Exchange,
-    private val verifiedFiatCalculator: VerifiedFiatCalculator,
-    private val transactionController: TransactionController,
-    private val tokenCoordinator: TokenCoordinator,
 ) : BaseViewModel<SendFlowViewModel.State, SendFlowViewModel.Event>(
     initialState = State(),
     updateStateForEvent = updateStateForEvent,
 ) {
-    private val maxAmountFlow = combine(
-        transactionController.limits,
-        tokenCoordinator.observeSelectedTokenMint()
-            .flatMapLatest { mint -> tokenCoordinator.balanceForToken(mint) },
-        exchange.observePreferredRate(),
-    ) { limits, balance, rate ->
-        val balanceInLocal = balance.convertingTo(rate)
-        val sendLimit = limits?.sendLimitFor(rate.currency) ?: SendLimit.Zero
-        Fiat(min(sendLimit.nextTransaction, balanceInLocal.toDouble()), rate.currency)
-    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
-
-    val amountDelegate = AmountEntryDelegate(
-        exchange = exchange,
-        scope = viewModelScope,
-        style = AmountEntryStyle(
-            actionLabel = resources.getString(R.string.action_swipeToSend),
-            actionStyle = ConfirmationStyle.Slide,
-            infoHint = { resources.getString(R.string.subtitle_sendHint, it) },
-            overMaxHint = { resources.getString(R.string.subtitle_sendHintLimitExceeded, it) },
-        ),
-        loadingState = stateFlow.map { it.sendProgress }
-            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), LoadingSuccessState()),
-        maxAmount = maxAmountFlow,
-    )
-
-    sealed interface ResolveState {
-        val contact: DeviceContact? get() = null
-        data object Idle : ResolveState
-        data class Pending(override val contact: DeviceContact) : ResolveState
-        data class Resolved(override val contact: DeviceContact, val authority: PublicKey) : ResolveState
-        data class Failed(override val contact: DeviceContact) : ResolveState
-    }
 
     data class State @OptIn(ExperimentalMaterial3Api::class) constructor(
         val steps: List<SendStep> = listOf(SendStep.ContactList),
@@ -106,10 +50,6 @@ internal class SendFlowViewModel @Inject constructor(
         val isPickerMode: Boolean = false,
         val contactSyncState: LoadingSuccessState = LoadingSuccessState(),
         val listItems: List<ContactListItem> = emptyList(),
-        val sendProgress: LoadingSuccessState = LoadingSuccessState(),
-        val resolveState: ResolveState = ResolveState.Idle,
-        val token: Token? = null,
-        val limits: com.getcode.opencode.model.financial.Limits? = null,
     )
 
     sealed interface Event {
@@ -129,36 +69,11 @@ internal class SendFlowViewModel @Inject constructor(
         data class OnContactClicked(val contact: ContactListItem.ContactRow) : Event
         data class ContactRemoved(val e164: String) : Event
         data class SendInvite(val contact: DeviceContact) : Event
-        data class SendCashToContact(val contact: DeviceContact) : Event
 
-        data class NavigateToAmountEntry(
-            val e164: String,
-            val displayName: String,
-        ) : Event
-
-        data class ResolveCompleted(val contact: DeviceContact, val authority: PublicKey) : Event
-        data class ResolveFailed(val e164: String) : Event
-
-        data object OnConfirmRequested : Event
-
-        data class OnSendRequested(
-            val amount: Fiat,
-            val token: Token,
-            val destinationOwner: PublicKey,
-        ) : Event
-        data class SendStateUpdated(
-            val loading: Boolean = false,
-            val success: Boolean = false,
-        ) : Event
-        data class SendComplete(val amount: Fiat) : Event
-
-        data class TokenUpdated(val token: Token) : Event
-        data class LimitsChanged(val limits: com.getcode.opencode.model.financial.Limits?) : Event
+        data class NavigateToChat(val contact: DeviceContact) : Event
     }
 
     init {
-        // --- Steps & contact flow ---
-
         combine(
             userManager.state,
             featureFlags.observe(FeatureFlag.PhoneNumberSend),
@@ -238,30 +153,9 @@ internal class SendFlowViewModel @Inject constructor(
             .map { it.contact }
             .onEach { (contact, isOnFlipcash) ->
                 if (isOnFlipcash) {
-                    dispatchEvent(Event.SendCashToContact(contact))
+                    dispatchEvent(Event.NavigateToChat(contact))
                 } else {
                     dispatchEvent(Event.SendInvite(contact))
-                }
-            }.launchIn(viewModelScope)
-
-        eventFlow
-            .filterIsInstance<Event.SendCashToContact>()
-            .map { it.contact }
-            .flatMapLatest { contact ->
-                flow {
-                    dispatchEvent(Event.NavigateToAmountEntry(
-                        e164 = contact.e164,
-                        displayName = contact.displayName,
-                    ))
-
-                    contactCoordinator.resolve(contact.e164)
-                        .onSuccess { authority ->
-                            dispatchEvent(Event.ResolveCompleted(contact, authority))
-                        }
-                        .onFailure {
-                            dispatchEvent(Event.ResolveFailed(contact.e164))
-                        }
-                    emit(Unit)
                 }
             }.launchIn(viewModelScope)
 
@@ -292,149 +186,6 @@ internal class SendFlowViewModel @Inject constructor(
                 )
             }
             .launchIn(viewModelScope)
-
-        // --- Amount entry ---
-
-        tokenCoordinator.observeSelectedTokenMint()
-            .flatMapLatest { mint ->
-                tokenCoordinator.tokenBalances.map { tokens ->
-                    tokens.find { it.token.address == mint }
-                }
-            }
-            .filterNotNull()
-            .onEach { tokenWithBalance ->
-                dispatchEvent(Event.TokenUpdated(tokenWithBalance.token))
-            }.launchIn(viewModelScope)
-
-        exchange.observePreferredRate()
-            .onEach { rate ->
-                val currency = exchange.getCurrency(rate.currency.name)
-                if (currency != null) {
-                    amountDelegate.onCurrencyChanged(currency)
-                }
-            }.launchIn(viewModelScope)
-
-        transactionController.limits
-            .onEach { dispatchEvent(Event.LimitsChanged(it)) }
-            .launchIn(viewModelScope)
-
-        eventFlow.filterIsInstance<Event.OnConfirmRequested>()
-            .onEach { onConfirmRequested() }
-            .launchIn(viewModelScope)
-
-        // --- Send ---
-
-        eventFlow.filterIsInstance<Event.OnSendRequested>()
-            .onEach { (amount, token, destination) ->
-                viewModelScope.launch {
-                    val owner = userManager.accountCluster ?: return@launch
-                    val rate = exchange.preferredRate
-
-                    dispatchEvent(Event.SendStateUpdated(loading = true))
-
-                    val source = owner.withTimelockForToken(token)
-
-                    val balance = tokenCoordinator.balanceForToken(token)
-                    val verifiedFiat = verifiedFiatCalculator.compute(
-                        amount = amount,
-                        token = token,
-                        balance = balance,
-                        rate = rate,
-                    ).getOrElse { error ->
-                        dispatchEvent(Event.SendStateUpdated())
-                        val (title, message) = when (error) {
-                            is ComputeVerifiedFiatError.AmountBelowMinimum -> {
-                                R.string.error_title_amountTooSmall to R.string.error_description_amountTooSmall
-                            }
-                            else -> {
-                                R.string.error_title_staleRates to R.string.error_description_staleRates
-                            }
-                        }
-                        BottomBarManager.showAlert(
-                            title = resources.getString(title),
-                            message = resources.getString(message),
-                        )
-                        return@launch
-                    }
-
-                    transactionController.directTransfer(
-                        amount = verifiedFiat,
-                        token = token,
-                        source = source,
-                        destinationOwner = destination,
-                    ).fold(
-                        onSuccess = {
-                            Result.success(verifiedFiat)
-                        },
-                        onFailure = { Result.failure(it) }
-                    ).onSuccess { amount ->
-                        dispatchEvent(Event.SendStateUpdated(success = true))
-                        delay(400)
-                        dispatchEvent(
-                            Dispatchers.Main,
-                            Event.SendComplete(amount.localFiat.nativeAmount)
-                        )
-                    }.onFailure {
-                        dispatchEvent(Event.SendStateUpdated())
-                        BottomBarManager.showError(
-                            title = resources.getString(R.string.error_title_cashFailedToSend),
-                            message = resources.getString(R.string.error_description_cashFailedToSend),
-                        )
-                    }
-                }
-            }.launchIn(viewModelScope)
-    }
-
-    private fun checkBalanceLimit(): Boolean {
-        val amount = amountDelegate.state.value.enteredAmount
-        val token = stateFlow.value.token ?: return false
-        val rate = exchange.preferredRate
-        val entered = Fiat(amount, rate.currency)
-        val balance = tokenCoordinator.balanceForToken(token)
-        val balanceInLocal = balance.convertingTo(rate)
-        val isOverBalance = entered.valueGreaterThan(balanceInLocal)
-        if (isOverBalance) {
-            BottomBarManager.showAlert(
-                resources.getString(R.string.error_title_insufficientFunds),
-                resources.getString(R.string.error_description_insufficientFunds),
-            )
-        }
-        return isOverBalance
-    }
-
-    private fun checkSendLimit(): Boolean {
-        val amount = amountDelegate.state.value.enteredAmount
-        val currency = amountDelegate.state.value.currency
-        val sendLimit =
-            currency.code?.let { stateFlow.value.limits?.sendLimitFor(it) } ?: SendLimit.Zero
-        val isOverLimit = amount > sendLimit.nextTransaction
-        if (isOverLimit) {
-            BottomBarManager.showAlert(
-                resources.getString(R.string.error_title_sendLimitReached),
-                resources.getString(R.string.error_description_sendLimitReached),
-            )
-        }
-        return isOverLimit
-    }
-
-    private fun onConfirmRequested() {
-        if (checkBalanceLimit() || checkSendLimit()) return
-
-        val enteredAmount = amountDelegate.state.value.enteredAmount
-        if (enteredAmount <= 0) return
-
-        val token = stateFlow.value.token ?: return
-        val rate = exchange.preferredRate
-        val amount = Fiat(enteredAmount, rate.currency)
-
-        val resolve = stateFlow.value.resolveState
-        if (resolve is ResolveState.Resolved) {
-            dispatchEvent(Event.OnSendRequested(
-                amount = amount,
-                token = token,
-                destinationOwner = resolve.authority,
-            ))
-        }
     }
 
     private fun generateListItems(
@@ -493,38 +244,7 @@ internal class SendFlowViewModel @Inject constructor(
                 is Event.OnItemsPopulated -> { state -> state.copy(listItems = event.items) }
                 is Event.OnContactClicked -> { state -> state }
                 is Event.SendInvite -> { state -> state }
-                is Event.SendCashToContact -> { state ->
-                    state.copy(resolveState = ResolveState.Pending(event.contact))
-                }
-                is Event.NavigateToAmountEntry -> { state -> state.copy(sendProgress = LoadingSuccessState()) }
-                is Event.ResolveCompleted -> { state ->
-                    state.copy(resolveState = ResolveState.Resolved(event.contact, event.authority))
-                }
-                is Event.ResolveFailed -> { state ->
-                    val contact = state.resolveState.contact
-                    if (contact != null) {
-                        state.copy(resolveState = ResolveState.Failed(contact))
-                    } else {
-                        state
-                    }
-                }
-                is Event.OnConfirmRequested -> { state -> state }
-                is Event.OnSendRequested -> { state -> state }
-                is Event.SendStateUpdated -> { state ->
-                    state.copy(
-                        sendProgress = LoadingSuccessState(
-                            event.loading,
-                            event.success,
-                        )
-                    )
-                }
-                is Event.SendComplete -> { state -> state }
-                is Event.TokenUpdated -> { state ->
-                    state.copy(token = event.token)
-                }
-                is Event.LimitsChanged -> { state ->
-                    state.copy(limits = event.limits)
-                }
+                is Event.NavigateToChat -> { state -> state }
             }
         }
     }

--- a/apps/flipcash/features/direct-send/src/main/kotlin/com/flipcash/app/directsend/internal/screens/ContactListScreen.kt
+++ b/apps/flipcash/features/direct-send/src/main/kotlin/com/flipcash/app/directsend/internal/screens/ContactListScreen.kt
@@ -266,52 +266,12 @@ private fun ContactList(
                         index == items.lastIndex ||
                                 items[index + 1] is ContactListItem.Header
 
-                    if (isPickerMode) {
-                        Column(modifier = Modifier.animateItem()) {
-                            SwipeActionRow(
-                                actions = listOf(
-                                    SwipeAction(
-                                        background = CodeTheme.colors.error,
-                                        onTriggered = { onItemDismissed(item) },
-                                    ) {
-                                        Icon(
-                                            imageVector = Icons.Rounded.PersonRemove,
-                                            contentDescription = null,
-                                            tint = Color.White,
-                                            modifier = Modifier.requiredSize(CodeTheme.dimens.staticGrid.x5),
-                                        )
-                                    }
-                                ),
-                                stateKey = item.contact.e164,
-                            ) {
-                                ContactRowItem(
-                                    contact = item.contact,
-                                    isOnFlipcash = item.isOnFlipcash,
-                                    showDivider = false,
-                                    onClick = { onItemClick(item) },
-                                )
-                            }
-                            if (!isLastInSection) {
-                                HorizontalDivider(
-                                    color = CodeTheme.colors.divider,
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .height(1.dp)
-                                        .padding(
-                                            start = CodeTheme.dimens.inset + CodeTheme.dimens.staticGrid.x8 + CodeTheme.dimens.grid.x3,
-                                            end = CodeTheme.dimens.inset,
-                                        ),
-                                )
-                            }
-                        }
-                    } else {
-                        ContactRowItem(
-                            contact = item.contact,
-                            isOnFlipcash = item.isOnFlipcash,
-                            showDivider = !isLastInSection,
-                        ) {
-                            onItemClick(item)
-                        }
+                    ContactRowItem(
+                        contact = item.contact,
+                        isOnFlipcash = item.isOnFlipcash,
+                        showDivider = !isLastInSection,
+                    ) {
+                        onItemClick(item)
                     }
                 }
             }

--- a/apps/flipcash/features/direct-send/src/main/kotlin/com/flipcash/app/directsend/internal/screens/ContactListScreen.kt
+++ b/apps/flipcash/features/direct-send/src/main/kotlin/com/flipcash/app/directsend/internal/screens/ContactListScreen.kt
@@ -73,11 +73,13 @@ import com.getcode.ui.components.SearchInput
 import com.getcode.ui.components.SwipeAction
 import com.getcode.ui.components.SwipeActionRow
 import androidx.compose.foundation.clickable
+import com.flipcash.app.contacts.ui.ContactAvatar
 import com.getcode.ui.core.verticalScrollStateGradient
 import com.getcode.ui.theme.CodeCircularProgressIndicator
 import com.getcode.ui.theme.CodeScaffold
 import com.getcode.view.LoadingSuccessState
 import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.map
 
 
 @Composable
@@ -98,12 +100,13 @@ internal fun ContactListScreen() {
 
     LaunchedEffect(viewModel) {
         viewModel.eventFlow
-            .filterIsInstance<SendFlowViewModel.Event.NavigateToAmountEntry>()
-            .collect { event ->
-                flowNavigator.navigateTo(
-                    SendStep.AmountEntry(
-                        e164 = event.e164,
-                        displayName = event.displayName,
+            .filterIsInstance<SendFlowViewModel.Event.NavigateToChat>()
+            .map { it.contact }
+            .collect { contact ->
+                flowNavigator.navigate(
+                    AppRoute.Messaging.Chat(
+                        e164 = contact.e164,
+                        displayName = contact.displayName,
                     )
                 )
             }
@@ -410,61 +413,6 @@ private fun ContactRowItem(
             )
         }
     }
-}
-
-@Composable
-private fun ContactAvatar(
-    photoUri: String?,
-    displayName: String,
-    modifier: Modifier = Modifier,
-) {
-    Box(
-        modifier = modifier.background(
-            Brush.linearGradient(CodeTheme.colors.contactAvatar.colors)
-        )
-    ) {
-        if (photoUri != null) {
-            var isError by rememberSaveable(photoUri) { mutableStateOf(false) }
-            if (!isError) {
-                val context = LocalContext.current
-                val request = remember(photoUri) {
-                    ImageRequest.Builder(context)
-                        .crossfade(true)
-                        .data(photoUri.toUri())
-                        .build()
-                }
-                AsyncImage(
-                    modifier = Modifier.matchParentSize(),
-                    model = request,
-                    contentDescription = null,
-                    onError = { isError = true },
-                )
-            }
-            if (isError) {
-                InitialsText(displayName)
-            }
-        } else {
-            InitialsText(displayName)
-        }
-    }
-}
-
-@Composable
-private fun BoxScope.InitialsText(displayName: String) {
-    val initials = remember(displayName) {
-        displayName.split(" ")
-            .take(2)
-            .mapNotNull { it.firstOrNull()?.uppercaseChar() }
-            .joinToString("")
-            .ifEmpty { "?" }
-    }
-    Text(
-        modifier = Modifier.align(Alignment.Center),
-        text = initials,
-        style = CodeTheme.typography.textSmall,
-        color = CodeTheme.colors.textSecondary,
-        textAlign = TextAlign.Center,
-    )
 }
 
 @Preview

--- a/apps/flipcash/features/direct-send/src/main/kotlin/com/flipcash/app/directsend/internal/screens/ContactListScreen.kt
+++ b/apps/flipcash/features/direct-send/src/main/kotlin/com/flipcash/app/directsend/internal/screens/ContactListScreen.kt
@@ -112,6 +112,20 @@ internal fun ContactListScreen() {
             }
     }
 
+    LaunchedEffect(viewModel) {
+        viewModel.eventFlow
+            .filterIsInstance<SendFlowViewModel.Event.NavigateToDirectSend>()
+            .map { it.contact }
+            .collect { contact ->
+                flowNavigator.navigate(
+                    AppRoute.Messaging.AmountEntry(
+                        e164 = contact.e164,
+                        displayName = contact.displayName,
+                    )
+                )
+            }
+    }
+
     val accessHandle = rememberContactAccessHandle(
         isPickerMode = state.isPickerMode,
     ) { result ->

--- a/apps/flipcash/features/lab/src/main/kotlin/com/flipcash/app/lab/internal/LabsScreenContent.kt
+++ b/apps/flipcash/features/lab/src/main/kotlin/com/flipcash/app/lab/internal/LabsScreenContent.kt
@@ -63,31 +63,33 @@ internal fun LabsScreenContent(viewModel: LabsScreenViewModel) {
             )
         }
         items(betaFlags, key = { it.flag.key }, contentType = { "feature_flag" }) { feature ->
-            if (feature.flag.isOptionFlag) {
-                SettingsOptionRow(
-                    title = feature.flag.title,
-                    subtitle = feature.flag.message,
-                    options = feature.flag.options,
-                    selectedOption = feature.selectedOption ?: feature.flag.defaultOption,
-                    onOptionSelected = { optionKey ->
-                        betaFlagsController.setOption(feature.flag, optionKey)
-                    },
-                )
-            } else {
-                SettingsSwitchRow(
-                    title = feature.flag.title,
-                    subtitle = feature.flag.message,
-                    checked = feature.enabled
-                ) {
-                    betaFlagsController.set(feature.flag, !feature.enabled)
+            Column(modifier = Modifier.animateItem()) {
+                if (feature.flag.isOptionFlag) {
+                    SettingsOptionRow(
+                        title = feature.flag.title,
+                        subtitle = feature.flag.message,
+                        options = feature.flag.options,
+                        selectedOption = feature.selectedOption ?: feature.flag.defaultOption,
+                        onOptionSelected = { optionKey ->
+                            betaFlagsController.setOption(feature.flag, optionKey)
+                        },
+                    )
+                } else {
+                    SettingsSwitchRow(
+                        title = feature.flag.title,
+                        subtitle = feature.flag.message,
+                        checked = feature.enabled
+                    ) {
+                        betaFlagsController.set(feature.flag, !feature.enabled)
+                    }
                 }
-            }
 
-            HorizontalDivider(
-                modifier = Modifier.padding(horizontal = CodeTheme.dimens.inset),
-                color = CodeTheme.colors.divider,
-                thickness = 0.5.dp
-            )
+                HorizontalDivider(
+                    modifier = Modifier.padding(horizontal = CodeTheme.dimens.inset),
+                    color = CodeTheme.colors.divider,
+                    thickness = 0.5.dp
+                )
+            }
         }
 
         if (betaFlags.isEmpty()) {

--- a/apps/flipcash/features/messenger/build.gradle.kts
+++ b/apps/flipcash/features/messenger/build.gradle.kts
@@ -1,0 +1,20 @@
+plugins {
+    alias(libs.plugins.flipcash.android.feature)
+}
+
+android {
+    namespace = "${Gradle.flipcashNamespace}.features.messenger"
+}
+
+dependencies {
+    implementation(project(":apps:flipcash:shared:chat"))
+    implementation(project(":apps:flipcash:shared:amount-entry"))
+    implementation(project(":apps:flipcash:shared:contacts"))
+    implementation(project(":apps:flipcash:shared:tokens"))
+    implementation(project(":libs:messaging"))
+    implementation(project(":services:flipcash"))
+    implementation(project(":services:opencode"))
+    implementation(project(":libs:datetime"))
+    implementation(libs.compose.paging)
+    implementation(libs.bundles.haze)
+}

--- a/apps/flipcash/features/messenger/src/main/kotlin/com/flipcash/app/messenger/ChatAmountEntryScreen.kt
+++ b/apps/flipcash/features/messenger/src/main/kotlin/com/flipcash/app/messenger/ChatAmountEntryScreen.kt
@@ -22,11 +22,17 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 
 @Composable
-fun ChatAmountEntryScreen(e164: String) {
+fun ChatAmountEntryScreen(e164: String, displayName: String) {
     val viewModel = flowScopedViewModel<ChatViewModel>(e164)
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
     val navigator = LocalCodeNavigator.current
     val resources = LocalResources.current
+
+    LaunchedEffect(Unit) {
+        if (state.chattingWith == null) {
+            viewModel.dispatchEvent(ChatViewModel.Event.OnChatOpened(e164, displayName))
+        }
+    }
 
     LaunchedEffect(state.resolveState) {
         if (state.resolveState is ChatViewModel.ResolveState.Failed) {

--- a/apps/flipcash/features/messenger/src/main/kotlin/com/flipcash/app/messenger/ChatAmountEntryScreen.kt
+++ b/apps/flipcash/features/messenger/src/main/kotlin/com/flipcash/app/messenger/ChatAmountEntryScreen.kt
@@ -1,0 +1,77 @@
+package com.flipcash.app.messenger
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.flipcash.app.core.AppRoute
+import com.flipcash.app.core.tokens.TokenPurpose
+import com.flipcash.app.core.ui.TokenSelectionPill
+import com.flipcash.app.messenger.internal.ChatViewModel
+import com.flipcash.features.messenger.R
+import com.flipcash.shared.amountentry.AmountEntryScreen
+import com.getcode.manager.BottomBarManager
+import com.getcode.navigation.core.LocalCodeNavigator
+import com.getcode.navigation.extensions.flowScopedViewModel
+import com.getcode.opencode.model.financial.Fiat
+import com.getcode.ui.components.AppBarDefaults
+import com.getcode.ui.components.AppBarWithTitle
+import com.getcode.util.resources.LocalResources
+import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+
+@Composable
+fun ChatAmountEntryScreen(e164: String) {
+    val viewModel = flowScopedViewModel<ChatViewModel>(e164)
+    val state by viewModel.stateFlow.collectAsStateWithLifecycle()
+    val navigator = LocalCodeNavigator.current
+    val resources = LocalResources.current
+
+    LaunchedEffect(state.resolveState) {
+        if (state.resolveState is ChatViewModel.ResolveState.Failed) {
+            BottomBarManager.showAlert(
+                title = resources.getString(R.string.error_title_contactNotOnFlipcash),
+                message = resources.getString(R.string.error_description_contactNotOnFlipcash),
+                onDismiss = { navigator.pop() }
+            )
+        }
+    }
+
+    LaunchedEffect(viewModel) {
+        viewModel.eventFlow
+            .filterIsInstance<ChatViewModel.Event.SendComplete>()
+            .onEach { event ->
+                BottomBarManager.showInfo(
+                    title = resources.getString(R.string.prompt_title_fundsSentToContact),
+                    message = resources.getString(
+                        R.string.prompt_description_fundsSentToContact,
+                        event.amount.formatted(rule = Fiat.FormattingRule.Truncated),
+                        state.chattingWith?.displayName ?: resources.getString(R.string.subtitle_yourSelectedRecipient),
+                    ),
+                    onDismiss = { navigator.pop() }
+                )
+            }.launchIn(this)
+    }
+
+    AmountEntryScreen(
+        controller = viewModel.amountDelegate,
+        onConfirm = { viewModel.dispatchEvent(ChatViewModel.Event.OnConfirmRequested) },
+        onChangeCurrency = { navigator.push(AppRoute.Main.RegionSelection) },
+        appBar = {
+            AppBarWithTitle(
+                isInModal = true,
+                title = {
+                    TokenSelectionPill(state.token) {
+                        navigator.push(
+                            AppRoute.Sheets.TokenSelection(TokenPurpose.Select)
+                        )
+                    }
+                },
+                leftIcon = {
+                    AppBarDefaults.UpNavigation { navigator.pop() }
+                },
+            )
+        },
+    )
+}

--- a/apps/flipcash/features/messenger/src/main/kotlin/com/flipcash/app/messenger/MessengerScreen.kt
+++ b/apps/flipcash/features/messenger/src/main/kotlin/com/flipcash/app/messenger/MessengerScreen.kt
@@ -1,0 +1,45 @@
+package com.flipcash.app.messenger
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.flipcash.app.contacts.device.DeviceContact
+import com.flipcash.app.core.AppRoute
+import com.flipcash.app.messenger.internal.ChatViewModel
+import com.flipcash.app.messenger.internal.screens.MessengerScreen
+import com.getcode.navigation.core.LocalCodeNavigator
+import com.getcode.navigation.extensions.flowScopedViewModel
+import com.getcode.theme.CodeTheme
+import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.map
+
+@Composable
+fun MessengerScreen(e164: String, displayName: String) {
+    val viewModel = flowScopedViewModel<ChatViewModel>(e164)
+    val navigator = LocalCodeNavigator.current
+
+    LaunchedEffect(Unit) {
+        viewModel.dispatchEvent(ChatViewModel.Event.OnChatOpened(e164, displayName))
+    }
+
+    LaunchedEffect(viewModel) {
+        viewModel.eventFlow
+            .filterIsInstance<ChatViewModel.Event.NavigateToAmountEntry>()
+            .map { it.contact }
+            .collect { contact ->
+                navigator.push(AppRoute.Messaging.AmountEntry(
+                    e164 = contact.e164,
+                    displayName = contact.displayName,
+                ))
+            }
+    }
+
+    MessengerScreen(viewModel)
+}

--- a/apps/flipcash/features/messenger/src/main/kotlin/com/flipcash/app/messenger/internal/ChatViewModel.kt
+++ b/apps/flipcash/features/messenger/src/main/kotlin/com/flipcash/app/messenger/internal/ChatViewModel.kt
@@ -1,0 +1,446 @@
+package com.flipcash.app.messenger.internal
+
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.clearText
+import androidx.lifecycle.viewModelScope
+import androidx.paging.PagingData
+import androidx.paging.cachedIn
+import androidx.paging.flatMap
+import androidx.paging.insertSeparators
+import com.flipcash.app.contacts.ContactCoordinator
+import com.flipcash.app.contacts.device.DeviceContact
+import com.flipcash.app.core.extensions.onResult
+import com.flipcash.app.core.ui.ConfirmationStyle
+import com.flipcash.app.messenger.internal.screens.components.ChatListItem
+import com.flipcash.app.messenger.internal.screens.components.SeparatorConfig
+import com.flipcash.app.tokens.TokenCoordinator
+import com.flipcash.features.messenger.R
+import com.flipcash.services.models.chat.ChatId
+import com.flipcash.services.models.chat.MessageContent
+import com.flipcash.services.models.chat.TypingState
+import com.flipcash.services.user.UserManager
+import com.flipcash.shared.amountentry.AmountEntryDelegate
+import com.flipcash.shared.amountentry.AmountEntryStyle
+import com.flipcash.shared.chat.ActiveTypist
+import com.flipcash.shared.chat.ChatCoordinator
+import com.getcode.manager.BottomBarManager
+import com.getcode.opencode.controllers.TransactionController
+import com.getcode.opencode.exchange.Exchange
+import com.getcode.opencode.exchange.VerifiedFiatCalculator
+import com.getcode.opencode.model.core.errors.ComputeVerifiedFiatError
+import com.getcode.opencode.model.financial.Fiat
+import com.getcode.opencode.model.financial.SendLimit
+import com.getcode.opencode.model.financial.Token
+import com.getcode.solana.keys.PublicKey
+import com.getcode.util.DateUtils
+import com.getcode.util.resources.ResourceHelper
+import com.getcode.utils.trace
+import com.getcode.view.BaseViewModel
+import com.getcode.view.LoadingSuccessState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import kotlin.math.min
+import kotlin.time.Instant
+
+@HiltViewModel
+internal class ChatViewModel @Inject constructor(
+    private val chatCoordinator: ChatCoordinator,
+    private val contactCoordinator: ContactCoordinator,
+    private val transactionController: TransactionController,
+    private val tokenCoordinator: TokenCoordinator,
+    private val exchange: Exchange,
+    private val verifiedFiatCalculator: VerifiedFiatCalculator,
+    private val userManager: UserManager,
+    private val resources: ResourceHelper,
+) : BaseViewModel<ChatViewModel.State, ChatViewModel.Event>(
+    initialState = State(),
+    updateStateForEvent = updateStateForEvent,
+) {
+
+    sealed interface ResolveState {
+        data object Pending : ResolveState
+        data class Resolved(val authority: PublicKey) : ResolveState
+        data object Failed : ResolveState
+    }
+
+    sealed interface UserState {
+        data object Reading: UserState
+        data object Typing: UserState
+    }
+
+    data class State(
+        val chatId: ChatId? = null,
+        val chattingWith: DeviceContact? = null,
+        val userState: UserState = UserState.Reading,
+        val chatInputState: TextFieldState = TextFieldState(),
+        val typists: Set<ActiveTypist> = emptySet(),
+        val resolveState: ResolveState = ResolveState.Pending,
+        val sendProgress: LoadingSuccessState = LoadingSuccessState(),
+        val token: Token? = null,
+        val limits: com.getcode.opencode.model.financial.Limits? = null,
+    )
+
+    sealed interface Event {
+        data class OnChatOpened(val e164: String, val displayName: String) : Event
+        data class OnContactFound(val contact: DeviceContact): Event
+        data class ChatFound(val chatId: ChatId) : Event
+        data object OnSendCash: Event
+        data object OnStartMessageInput: Event
+        data object OnStopMessageInput: Event
+        data class TypistsUpdated(val typists: Set<ActiveTypist>) : Event
+        data class ResolveCompleted(val authority: PublicKey) : Event
+        data object ResolveFailed : Event
+
+        data object SendMessage : Event
+
+        data class NavigateToAmountEntry(val contact: DeviceContact) : Event
+
+        data object OnConfirmRequested : Event
+        data class OnSendRequested(
+            val amount: Fiat,
+            val token: Token,
+            val destinationOwner: PublicKey,
+        ) : Event
+        data class SendStateUpdated(
+            val loading: Boolean = false,
+            val success: Boolean = false,
+        ) : Event
+        data class SendComplete(val amount: Fiat) : Event
+
+        data class TokenUpdated(val token: Token) : Event
+        data class LimitsChanged(val limits: com.getcode.opencode.model.financial.Limits?) : Event
+    }
+
+    private val separatorConfig = SeparatorConfig.TimeGap()
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val messages: Flow<PagingData<ChatListItem>> = stateFlow
+        .map { it.chatId }
+        .filterNotNull()
+        .distinctUntilChanged()
+        .flatMapLatest { chatId ->
+            chatCoordinator.observeMessagesPaged(chatId)
+        }
+        .map { pagingData ->
+            pagingData.flatMap { message ->
+                message.content.mapIndexed { index, content ->
+                    ChatListItem.ContentBubble(
+                        messageId = message.messageId,
+                        contentIndex = index,
+                        content = content,
+                        isFromSelf = message.isFromSelf,
+                        timestamp = message.timestamp,
+                    )
+                }
+            }.insertSeparators { before: ChatListItem.ContentBubble?, after: ChatListItem.ContentBubble? ->
+                if (before == null) return@insertSeparators null
+                if (after == null || separatorConfig.shouldSeparate(before.timestamp, after.timestamp)) {
+                    ChatListItem.DateSeparator(formatDateLabel(before.timestamp))
+                } else null
+            }
+        }.cachedIn(viewModelScope)
+
+    private val maxAmountFlow = combine(
+        transactionController.limits,
+        tokenCoordinator.observeSelectedTokenMint()
+            .flatMapLatest { mint -> tokenCoordinator.balanceForToken(mint) },
+        exchange.observePreferredRate(),
+    ) { limits, balance, rate ->
+        val balanceInLocal = balance.convertingTo(rate)
+        val sendLimit = limits?.sendLimitFor(rate.currency) ?: SendLimit.Zero
+        Fiat(min(sendLimit.nextTransaction, balanceInLocal.toDouble()), rate.currency)
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
+
+    val amountDelegate = AmountEntryDelegate(
+        exchange = exchange,
+        scope = viewModelScope,
+        style = AmountEntryStyle(
+            actionLabel = resources.getString(R.string.action_swipeToSend),
+            actionStyle = ConfirmationStyle.Slide,
+            infoHint = { resources.getString(R.string.subtitle_sendHint, it) },
+            overMaxHint = { resources.getString(R.string.subtitle_sendHintLimitExceeded, it) },
+        ),
+        loadingState = stateFlow.map { it.sendProgress }
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), LoadingSuccessState()),
+        maxAmount = maxAmountFlow,
+    )
+
+    init {
+        eventFlow
+            .filterIsInstance<Event.OnChatOpened>()
+            .map { (e164, _) -> contactCoordinator.lookupContact(e164) }
+            .onResult(
+                onSuccess = { contact ->
+                    dispatchEvent(Event.OnContactFound(contact))
+                },
+                onError = {
+                    // TODO:
+                }
+            ).launchIn(viewModelScope)
+
+        eventFlow
+            .filterIsInstance<Event.OnContactFound>()
+            .map { it.contact }
+            .map {
+                contactCoordinator.resolve(it.e164)
+            }.onResult(
+                onSuccess = {
+                    dispatchEvent(Event.ResolveCompleted(it))
+                },
+                onError = {
+                    dispatchEvent(Event.ResolveFailed)
+                }
+            ).launchIn(viewModelScope)
+
+        stateFlow
+            .mapNotNull { it.chattingWith }
+            .map { chatCoordinator.getChatId(it) }
+            .onResult(
+                onSuccess = { chatId ->
+                    trace("chatID found => $chatId")
+                    dispatchEvent(Event.ChatFound(chatId))
+                },
+                onError = {
+                    // TODO:
+                }
+            ).launchIn(viewModelScope)
+
+        stateFlow.map { it.chatId }
+
+            .filterNotNull()
+
+            .onEach { chatCoordinator.loadMessages(it) }
+            .launchIn(viewModelScope)
+
+        // Observe typing indicators once chatId is known
+        stateFlow.map { it.chatId }
+            .filterNotNull()
+            .flatMapLatest { chatId -> chatCoordinator.observeTypingIndicators(chatId) }
+            .onEach { typists -> dispatchEvent(Event.TypistsUpdated(typists)) }
+            .launchIn(viewModelScope)
+
+        // Send text message
+        eventFlow.filterIsInstance<Event.SendMessage>()
+            .map { stateFlow.value.chatInputState }
+            .mapNotNull { textInput ->
+                val textToSend = textInput.text.toString()
+                val chatId = stateFlow.value.chatId ?: return@mapNotNull null
+                stateFlow.value.chatInputState.clearText()
+                chatCoordinator.sendMessage(chatId, textToSend)
+            }.onResult(
+                onSuccess = {
+                    trace("message sent successfully")
+                },
+                onError = {
+                    trace("message failed to send - ${it.localizedMessage}")
+                }
+            )
+            .launchIn(viewModelScope)
+
+        // Token observation
+        tokenCoordinator.observeSelectedTokenMint()
+            .flatMapLatest { mint ->
+                tokenCoordinator.tokenBalances.map { tokens ->
+                    tokens.find { it.token.address == mint }
+                }
+            }
+            .filterNotNull()
+            .onEach { tokenWithBalance ->
+                dispatchEvent(Event.TokenUpdated(tokenWithBalance.token))
+            }.launchIn(viewModelScope)
+
+        exchange.observePreferredRate()
+            .onEach { rate ->
+                val currency = exchange.getCurrency(rate.currency.name)
+                if (currency != null) {
+                    amountDelegate.onCurrencyChanged(currency)
+                }
+            }.launchIn(viewModelScope)
+
+        transactionController.limits
+            .onEach { dispatchEvent(Event.LimitsChanged(it)) }
+            .launchIn(viewModelScope)
+
+        eventFlow.filterIsInstance<Event.OnConfirmRequested>()
+            .onEach { onConfirmRequested() }
+            .launchIn(viewModelScope)
+
+        eventFlow.filterIsInstance<Event.OnSendCash>()
+            .mapNotNull { stateFlow.value.chattingWith }
+            .onEach { contact ->
+                dispatchEvent(Event.NavigateToAmountEntry(contact))
+            }.launchIn(viewModelScope)
+
+        // Send cash
+        eventFlow.filterIsInstance<Event.OnSendRequested>()
+            .onEach { (amount, token, destination) ->
+                viewModelScope.launch {
+                    val owner = userManager.accountCluster ?: return@launch
+                    val rate = exchange.preferredRate
+
+                    dispatchEvent(Event.SendStateUpdated(loading = true))
+
+                    val source = owner.withTimelockForToken(token)
+
+                    val balance = tokenCoordinator.balanceForToken(token)
+                    val verifiedFiat = verifiedFiatCalculator.compute(
+                        amount = amount,
+                        token = token,
+                        balance = balance,
+                        rate = rate,
+                    ).getOrElse { error ->
+                        dispatchEvent(Event.SendStateUpdated())
+                        val (title, message) = when (error) {
+                            is ComputeVerifiedFiatError.AmountBelowMinimum -> {
+                                R.string.error_title_amountTooSmall to R.string.error_description_amountTooSmall
+                            }
+                            else -> {
+                                R.string.error_title_staleRates to R.string.error_description_staleRates
+                            }
+                        }
+                        BottomBarManager.showAlert(
+                            title = resources.getString(title),
+                            message = resources.getString(message),
+                        )
+                        return@launch
+                    }
+
+                    transactionController.directTransfer(
+                        amount = verifiedFiat,
+                        token = token,
+                        source = source,
+                        destinationOwner = destination,
+                    ).fold(
+                        onSuccess = {
+                            Result.success(verifiedFiat)
+                        },
+                        onFailure = { Result.failure(it) }
+                    ).onSuccess { amount ->
+                        dispatchEvent(Event.SendStateUpdated(success = true))
+                        delay(400)
+                        dispatchEvent(
+                            Dispatchers.Main,
+                            Event.SendComplete(amount.localFiat.nativeAmount)
+                        )
+                    }.onFailure {
+                        dispatchEvent(Event.SendStateUpdated())
+                        BottomBarManager.showError(
+                            title = resources.getString(R.string.error_title_cashFailedToSend),
+                            message = resources.getString(R.string.error_description_cashFailedToSend),
+                        )
+                    }
+                }
+            }.launchIn(viewModelScope)
+    }
+
+    private fun checkBalanceLimit(): Boolean {
+        val amount = amountDelegate.state.value.enteredAmount
+        val token = stateFlow.value.token ?: return false
+        val rate = exchange.preferredRate
+        val entered = Fiat(amount, rate.currency)
+        val balance = tokenCoordinator.balanceForToken(token)
+        val balanceInLocal = balance.convertingTo(rate)
+        val isOverBalance = entered.valueGreaterThan(balanceInLocal)
+        if (isOverBalance) {
+            BottomBarManager.showAlert(
+                resources.getString(R.string.error_title_insufficientFunds),
+                resources.getString(R.string.error_description_insufficientFunds),
+            )
+        }
+        return isOverBalance
+    }
+
+    private fun checkSendLimit(): Boolean {
+        val amount = amountDelegate.state.value.enteredAmount
+        val currency = amountDelegate.state.value.currency
+        val sendLimit =
+            currency.code?.let { stateFlow.value.limits?.sendLimitFor(it) } ?: SendLimit.Zero
+        val isOverLimit = amount > sendLimit.nextTransaction
+        if (isOverLimit) {
+            BottomBarManager.showAlert(
+                resources.getString(R.string.error_title_sendLimitReached),
+                resources.getString(R.string.error_description_sendLimitReached),
+            )
+        }
+        return isOverLimit
+    }
+
+    private fun onConfirmRequested() {
+        if (checkBalanceLimit() || checkSendLimit()) return
+
+        val enteredAmount = amountDelegate.state.value.enteredAmount
+        if (enteredAmount <= 0) return
+
+        val token = stateFlow.value.token ?: return
+        val rate = exchange.preferredRate
+        val amount = Fiat(enteredAmount, rate.currency)
+
+        val resolve = stateFlow.value.resolveState
+        if (resolve is ResolveState.Resolved) {
+            dispatchEvent(Event.OnSendRequested(
+                amount = amount,
+                token = token,
+                destinationOwner = resolve.authority,
+            ))
+        }
+    }
+
+    companion object {
+        private fun formatDateLabel(instant: Instant): String {
+            return DateUtils.getDateWithToday(instant.toEpochMilliseconds())
+        }
+
+        val updateStateForEvent: (Event) -> ((State) -> State) = { event ->
+            when (event) {
+                is Event.OnChatOpened -> { state -> state }
+                is Event.OnContactFound -> { state ->
+                    state.copy(
+                        chattingWith = event.contact
+                    )
+                }
+                is Event.ChatFound -> { state -> state.copy(chatId = event.chatId) }
+                Event.OnSendCash -> { state -> state }
+                Event.OnStartMessageInput -> { state -> state.copy(userState = UserState.Typing) }
+                Event.OnStopMessageInput -> { state -> state.copy(userState = UserState.Reading) }
+                is Event.TypistsUpdated -> { state -> state.copy(typists = event.typists) }
+                is Event.ResolveCompleted -> { state ->
+                    state.copy(resolveState = ResolveState.Resolved(event.authority))
+                }
+                is Event.ResolveFailed -> { state ->
+                    state.copy(resolveState = ResolveState.Failed)
+                }
+                is Event.SendMessage -> { state -> state }
+                is Event.NavigateToAmountEntry -> { state -> state.copy(sendProgress = LoadingSuccessState()) }
+                is Event.OnConfirmRequested -> { state -> state }
+                is Event.OnSendRequested -> { state -> state }
+                is Event.SendStateUpdated -> { state ->
+                    state.copy(
+                        sendProgress = LoadingSuccessState(
+                            event.loading,
+                            event.success,
+                        )
+                    )
+                }
+                is Event.SendComplete -> { state -> state }
+                is Event.TokenUpdated -> { state -> state.copy(token = event.token) }
+                is Event.LimitsChanged -> { state -> state.copy(limits = event.limits) }
+            }
+        }
+    }
+}

--- a/apps/flipcash/features/messenger/src/main/kotlin/com/flipcash/app/messenger/internal/screens/MessengerScreen.kt
+++ b/apps/flipcash/features/messenger/src/main/kotlin/com/flipcash/app/messenger/internal/screens/MessengerScreen.kt
@@ -1,0 +1,264 @@
+package com.flipcash.app.messenger.internal.screens
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.paging.compose.collectAsLazyPagingItems
+import com.flipcash.app.contacts.device.DeviceContact
+import com.flipcash.app.contacts.ui.ContactAvatar
+import com.flipcash.app.messenger.internal.ChatViewModel
+import com.flipcash.app.messenger.internal.screens.components.MessageList
+import com.flipcash.app.messenger.internal.screens.components.SeparatorConfig
+import com.flipcash.features.messenger.R
+import com.getcode.navigation.core.CodeNavigator
+import com.getcode.navigation.core.LocalCodeNavigator
+import com.getcode.theme.CodeTheme
+import com.getcode.ui.components.AppBarDefaults
+import com.getcode.ui.components.AppBarWithTitle
+import com.getcode.ui.components.chat.ChatInput
+import com.getcode.ui.core.debugBounds
+import com.getcode.ui.core.drawWithGradient
+import com.getcode.ui.core.measured
+import com.getcode.ui.theme.ButtonState
+import com.getcode.ui.theme.CodeButton
+import com.getcode.ui.utils.rememberKeyboardController
+import dev.chrisbanes.haze.HazeState
+import dev.chrisbanes.haze.hazeSource
+
+@Composable
+internal fun MessengerScreen(viewModel: ChatViewModel) {
+    val state by viewModel.stateFlow.collectAsStateWithLifecycle()
+    val messages = viewModel.messages.collectAsLazyPagingItems()
+    val navigator = LocalCodeNavigator.current
+
+    ChatInputScaffold(
+        topBar = { ChatTopBar(navigator, state.chattingWith) },
+        bottomBar = {
+            UserControlBottomBar(
+                state = state,
+                dispatch = viewModel::dispatchEvent,
+            )
+        },
+    ) { overlapPadding ->
+        MessageList(
+            modifier = Modifier
+                .fillMaxSize(),
+            contentPadding = overlapPadding,
+            messages = messages,
+            separatorConfig = SeparatorConfig.TimeGap(),
+        )
+    }
+}
+
+@Composable
+private fun ChatTopBar(
+    navigator: CodeNavigator,
+    chattingWith: DeviceContact?,
+) {
+    var titleHeight by remember { mutableStateOf(0.dp) }
+    Box {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(titleHeight)
+                .drawWithGradient(
+                    color = CodeTheme.colors.background,
+                    startY = { size.height * 1.5f },
+                    endY = { size.height * 0.25f }
+                )
+        )
+    AppBarWithTitle(
+        modifier = Modifier.measured { titleHeight = it.height },
+        leftIcon = {
+            AppBarDefaults.UpNavigation { navigator.pop() }
+        },
+        rightContents = {
+            AppBarDefaults.Overflow {
+                // TODO:
+            }
+        },
+        title = {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(CodeTheme.dimens.grid.x2),
+            ) {
+                ContactAvatar(
+                    modifier = Modifier
+                        .border(
+                            CodeTheme.dimens.border,
+                            CodeTheme.colors.divider,
+                            CircleShape
+                        )
+                        .size(CodeTheme.dimens.staticGrid.x8)
+                        .clip(CircleShape),
+                    photoUri = chattingWith?.photoUri,
+                    displayName = chattingWith?.displayName.orEmpty(),
+                )
+                Text(
+                    modifier = Modifier.weight(1f),
+                    text = chattingWith?.displayName.orEmpty(),
+                    style = CodeTheme.typography.textMedium,
+                    color = CodeTheme.colors.textMain,
+                )
+            }
+        }
+    )
+        }
+}
+
+@Composable
+private fun UserControlBottomBar(
+    state: ChatViewModel.State,
+    dispatch: (ChatViewModel.Event) -> Unit,
+) {
+    val keyboard = rememberKeyboardController()
+    val focusRequester = remember { FocusRequester() }
+    var buttonHeight by remember { mutableStateOf(0.dp) }
+    val fadeMultiplier by animateFloatAsState(
+        when (state.userState) {
+            ChatViewModel.UserState.Reading -> 0.20f
+            ChatViewModel.UserState.Typing -> 0.9f
+        }
+    )
+    Box(
+        modifier = Modifier
+            .fillMaxWidth(),
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(buttonHeight)
+                .drawWithGradient(
+                    color = CodeTheme.colors.background,
+                    startY = { 0f },
+                    endY = { size.height * fadeMultiplier }
+                ),
+        )
+        AnimatedContent(
+            modifier = Modifier
+                .measured { buttonHeight = it.height }
+                .padding(horizontal = CodeTheme.dimens.inset)
+                .padding(vertical = CodeTheme.dimens.grid.x3)
+                .navigationBarsPadding(),
+            targetState = state.userState,
+            transitionSpec = {
+                when (targetState) {
+                    ChatViewModel.UserState.Typing ->
+                        slideInVertically { it } + fadeIn() togetherWith fadeOut()
+
+                    ChatViewModel.UserState.Reading ->
+                        fadeIn() togetherWith slideOutVertically { it } + fadeOut()
+                }
+            },
+        ) { s ->
+            when (s) {
+                ChatViewModel.UserState.Reading -> {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(CodeTheme.dimens.grid.x2),
+                    ) {
+                        CodeButton(
+                            modifier = Modifier.weight(1f),
+                            buttonState = ButtonState.Filled,
+                            text = stringResource(R.string.action_sendCash),
+                        ) { dispatch(ChatViewModel.Event.OnSendCash) }
+                        CodeButton(
+                            modifier = Modifier.weight(1f),
+                            buttonState = ButtonState.Filled10,
+                            text = stringResource(R.string.action_sendMessage),
+                        ) { dispatch(ChatViewModel.Event.OnStartMessageInput) }
+                    }
+                }
+
+                ChatViewModel.UserState.Typing -> {
+                    ChatInput(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .border(
+                                CodeTheme.dimens.border,
+                                CodeTheme.colors.divider,
+                                CodeTheme.shapes.medium,
+                            ),
+                        focusRequester = focusRequester,
+                        hint = "Message",
+                        state = state.chatInputState,
+                        onSendMessage = { dispatch(ChatViewModel.Event.SendMessage) },
+                    )
+
+                    LaunchedEffect(Unit) {
+                        focusRequester.requestFocus()
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ChatInputScaffold(
+    topBar: @Composable () -> Unit = {},
+    bottomBar: @Composable () -> Unit = {},
+    content: @Composable (PaddingValues) -> Unit,
+) {
+    val density = LocalDensity.current
+    var topBarHeight by remember { mutableStateOf(0.dp) }
+    var bottomBarHeight by remember { mutableStateOf(0.dp) }
+
+    Box {
+        content(
+            PaddingValues(
+                top = topBarHeight,
+                bottom = bottomBarHeight,
+            )
+        )
+        Box(
+            modifier = Modifier
+                .align(Alignment.TopCenter)
+                .onSizeChanged { topBarHeight = with(density) { it.height.toDp() } }
+        ) {
+            topBar()
+        }
+        Box(
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .onSizeChanged { bottomBarHeight = with(density) { it.height.toDp() } }
+                .imePadding()
+        ) {
+            bottomBar()
+        }
+    }
+}

--- a/apps/flipcash/features/messenger/src/main/kotlin/com/flipcash/app/messenger/internal/screens/components/MessageBubble.kt
+++ b/apps/flipcash/features/messenger/src/main/kotlin/com/flipcash/app/messenger/internal/screens/components/MessageBubble.kt
@@ -1,0 +1,151 @@
+package com.flipcash.app.messenger.internal.screens.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.unit.dp
+import androidx.paging.compose.LazyPagingItems
+import com.flipcash.services.models.chat.MessageContent
+import com.getcode.theme.CodeTheme
+import com.getcode.theme.extraSmall
+import com.getcode.ui.core.addIf
+
+internal enum class BubblePosition { Solo, First, Middle, Last }
+
+@Composable
+internal fun ContentBubble(
+    item: ChatListItem.ContentBubble,
+    position: BubblePosition,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = if (item.isFromSelf) Arrangement.End else Arrangement.Start,
+    ) {
+        when (val content = item.content) {
+            is MessageContent.Text -> TextBubble(
+                text = content.text,
+                isFromSelf = item.isFromSelf,
+                position = position,
+            )
+        }
+    }
+}
+
+@Composable
+private fun TextBubble(
+    text: String,
+    isFromSelf: Boolean,
+    position: BubblePosition,
+) {
+    val bubble = if (isFromSelf) {
+        CodeTheme.colors.chat.outgoingBubble
+    } else {
+        CodeTheme.colors.chat.incomingBubble
+    }
+    val shape = bubbleShape(position, isFromSelf)
+    Box(
+        modifier = Modifier
+            .widthIn(max = 280.dp)
+            .clip(shape)
+            .addIf(bubble.hasBorder) {
+                Modifier.border(1.dp, bubble.border, shape)
+            }
+            .background(bubble.background)
+            .padding(horizontal = 16.dp, vertical = 10.dp),
+    ) {
+        Text(
+            text = text,
+            style = CodeTheme.typography.textSmall,
+            color = CodeTheme.colors.textMain,
+        )
+    }
+}
+
+@Composable
+private fun bubbleShape(position: BubblePosition, isFromSelf: Boolean): Shape {
+    val l = CodeTheme.shapes.medium.topStart
+    val s = CodeTheme.shapes.extraSmall.topStart
+    // RoundedCornerShape(topStart, topEnd, bottomEnd, bottomStart)
+    return when (position) {
+        BubblePosition.Solo -> RoundedCornerShape(l)
+        BubblePosition.First -> if (isFromSelf) {
+            // Top of group, outgoing: bottom-end connects to next below
+            RoundedCornerShape(topStart = l, topEnd = l, bottomEnd = s, bottomStart = l)
+        } else {
+            RoundedCornerShape(topStart = l, topEnd = l, bottomEnd = l, bottomStart = s)
+        }
+        BubblePosition.Middle -> if (isFromSelf) {
+            RoundedCornerShape(topStart = l, topEnd = s, bottomEnd = s, bottomStart = l)
+        } else {
+            RoundedCornerShape(topStart = s, topEnd = l, bottomEnd = l, bottomStart = s)
+        }
+        BubblePosition.Last -> if (isFromSelf) {
+            // Bottom of group, outgoing: top-end connects to item above
+            RoundedCornerShape(topStart = l, topEnd = s, bottomEnd = l, bottomStart = l)
+        } else {
+            RoundedCornerShape(topStart = s, topEnd = l, bottomEnd = l, bottomStart = l)
+        }
+    }
+}
+
+internal fun bubblePositionOf(
+    index: Int,
+    item: ChatListItem.ContentBubble,
+    messages: LazyPagingItems<ChatListItem>,
+    config: SeparatorConfig,
+): BubblePosition {
+    // index+1 = visually above (older), index-1 = visually below (newer)
+    val above = if (index + 1 < messages.itemCount) {
+        messages.peek(index + 1) as? ChatListItem.ContentBubble
+    } else null
+    val below = if (index > 0) {
+        messages.peek(index - 1) as? ChatListItem.ContentBubble
+    } else null
+
+    val groupedAbove = above != null &&
+            above.isFromSelf == item.isFromSelf &&
+            config.isGrouped(item.timestamp, above.timestamp)
+
+    val groupedBelow = below != null &&
+            below.isFromSelf == item.isFromSelf &&
+            config.isGrouped(item.timestamp, below.timestamp)
+
+    return when {
+        groupedAbove && groupedBelow -> BubblePosition.Middle
+        groupedAbove -> BubblePosition.Last   // bottom of visual group
+        groupedBelow -> BubblePosition.First  // top of visual group
+        else -> BubblePosition.Solo
+    }
+}
+
+@Composable
+internal fun DateSeparatorRow(
+    label: String,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(vertical = CodeTheme.dimens.grid.x2),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = label,
+            style = CodeTheme.typography.caption,
+            color = CodeTheme.colors.textSecondary,
+        )
+    }
+}

--- a/apps/flipcash/features/messenger/src/main/kotlin/com/flipcash/app/messenger/internal/screens/components/MessageList.kt
+++ b/apps/flipcash/features/messenger/src/main/kotlin/com/flipcash/app/messenger/internal/screens/components/MessageList.kt
@@ -1,0 +1,161 @@
+package com.flipcash.app.messenger.internal.screens.components
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.snapshots.Snapshot
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.unit.Dp
+import androidx.paging.compose.LazyPagingItems
+import androidx.paging.compose.itemKey
+import com.flipcash.services.models.chat.MessageContent
+import androidx.compose.ui.unit.dp
+import com.getcode.theme.CodeTheme
+import com.getcode.ui.core.drawWithGradient
+import com.getcode.ui.core.verticalScrollStateGradient
+import com.getcode.ui.utils.sheetResignmentBehavior
+import com.getcode.util.toLocalDate
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Instant
+
+sealed interface SeparatorConfig {
+    val groupingWindow: Duration
+
+    fun shouldSeparate(before: Instant, after: Instant): Boolean
+    fun isGrouped(a: Instant, b: Instant): Boolean =
+        (a - b).absoluteValue <= groupingWindow
+
+    data object DayOnly : SeparatorConfig {
+        override val groupingWindow: Duration = 60.seconds
+        override fun shouldSeparate(before: Instant, after: Instant): Boolean =
+            before.toLocalDate() != after.toLocalDate()
+    }
+
+    data class TimeGap(
+        val gap: Duration = 3.hours,
+        override val groupingWindow: Duration = 60.seconds,
+    ) : SeparatorConfig {
+        override fun shouldSeparate(before: Instant, after: Instant): Boolean =
+            before.toLocalDate() != after.toLocalDate()
+                    || (before - after).absoluteValue > gap
+    }
+}
+
+internal sealed interface ChatListItem {
+    val itemKey: Any
+
+    data class DateSeparator(val label: String) : ChatListItem {
+        override val itemKey: Any = "sep-$label"
+    }
+
+    data class ContentBubble(
+        val messageId: Long,
+        val contentIndex: Int,
+        val content: MessageContent,
+        val isFromSelf: Boolean,
+        val timestamp: Instant,
+    ) : ChatListItem {
+        override val itemKey: Any = "$messageId-$contentIndex"
+    }
+}
+
+
+@Composable
+internal fun MessageList(
+    modifier: Modifier = Modifier,
+    contentPadding: PaddingValues,
+    messages: LazyPagingItems<ChatListItem>,
+    separatorConfig: SeparatorConfig,
+) {
+    val listAlpha by animateFloatAsState(
+        targetValue = if (messages.itemCount > 0) 1f else 0f,
+        label = "messageListAlpha",
+    )
+
+    val listState = rememberLazyListState()
+    LazyColumn(
+        modifier = modifier
+            .alpha(listAlpha)
+            .sheetResignmentBehavior(listState),
+        state = listState,
+        reverseLayout = true,
+        contentPadding = PaddingValues(
+            top = CodeTheme.dimens.grid.x2 + contentPadding.calculateTopPadding(),
+            bottom = CodeTheme.dimens.grid.x2 + contentPadding.calculateBottomPadding(),
+            start = CodeTheme.dimens.inset,
+            end = CodeTheme.dimens.inset,
+        ),
+        verticalArrangement = Arrangement.Top,
+    ) {
+        items(
+            count = messages.itemCount,
+            key = messages.itemKey { it.itemKey }
+        ) { index ->
+            val item = messages[index] ?: return@items
+            val bottomSpacing = bottomSpacingFor(index, item, messages, separatorConfig)
+
+            Box(modifier = Modifier.padding(bottom = bottomSpacing)) {
+                when (item) {
+                    is ChatListItem.DateSeparator -> DateSeparatorRow(item.label)
+                    is ChatListItem.ContentBubble -> ContentBubble(
+                        item = item,
+                        position = bubblePositionOf(index, item, messages, separatorConfig),
+                    )
+                }
+            }
+        }
+    }
+
+    // opts out of the list maintaining
+    // scroll position when adding elements before the first item
+    // we are checking first visible item index to ensure
+    // the list doesn't shift when viewing scroll back
+    Snapshot.withoutReadObservation {
+        if (listState.firstVisibleItemIndex == 0) {
+            listState.requestScrollToItem(
+                index = listState.firstVisibleItemIndex,
+                scrollOffset = listState.firstVisibleItemScrollOffset
+            )
+        }
+    }
+}
+
+@Composable
+private fun bottomSpacingFor(
+    index: Int,
+    item: ChatListItem,
+    messages: LazyPagingItems<ChatListItem>,
+    config: SeparatorConfig,
+): Dp {
+    val tight = CodeTheme.dimens.grid.x1
+    val normal = CodeTheme.dimens.grid.x2
+    val wide = CodeTheme.dimens.grid.x3
+    // index-1 is the item below (newer) in reverseLayout
+    val itemBelow = (if (index > 0) messages.peek(index - 1) else null) ?: return tight
+
+    // Separator adjacent → normal gap
+    if (item is ChatListItem.DateSeparator || itemBelow is ChatListItem.DateSeparator) {
+        return normal
+    }
+
+    val current = item as? ChatListItem.ContentBubble ?: return tight
+    val below = itemBelow as? ChatListItem.ContentBubble ?: return tight
+
+    return when {
+        // Different sender → wide
+        current.isFromSelf != below.isFromSelf -> wide
+        // Same sender, outside grouping window → normal
+        !config.isGrouped(current.timestamp, below.timestamp) -> normal
+        // Same sender, close together → tight
+        else -> tight
+    }
+}

--- a/apps/flipcash/shared/chat/build.gradle.kts
+++ b/apps/flipcash/shared/chat/build.gradle.kts
@@ -12,8 +12,11 @@ dependencies {
 
     implementation(libs.bundles.kotlinx.serialization)
 
+    implementation(libs.androidx.paging.runtime)
+
     implementation(project(":apps:flipcash:shared:persistence:sources"))
     implementation(project(":apps:flipcash:shared:persistence:db"))
+    implementation(project(":apps:flipcash:shared:contacts"))
     implementation(project(":services:flipcash"))
     implementation(project(":libs:network:connectivity:public"))
     implementation(libs.androidx.lifecycle.process)

--- a/apps/flipcash/shared/chat/src/main/kotlin/com/flipcash/shared/chat/ChatCoordinator.kt
+++ b/apps/flipcash/shared/chat/src/main/kotlin/com/flipcash/shared/chat/ChatCoordinator.kt
@@ -2,10 +2,14 @@
 
 package com.flipcash.shared.chat
 
-import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
+import androidx.paging.Pager
+import androidx.paging.PagingConfig
+import androidx.paging.PagingData
+import androidx.paging.map
+import com.flipcash.app.contacts.device.DeviceContact
 import com.flipcash.app.persistence.sources.ChatMemberDataSource
 import com.flipcash.app.persistence.sources.ChatMessageDataSource
 import com.flipcash.app.persistence.sources.ChatMetadataDataSource
@@ -138,8 +142,24 @@ class ChatCoordinator @Inject constructor(
 
     // region Public API
 
+    fun getChatId(contact: DeviceContact): Result<ChatId> {
+        // TODO:
+        return Result.success(ChatId("b7e8cc8ac48cf661b1a32b09dfd4561c7c230c3b3c5cd65a85cc55381442ea0f"))
+    }
+
     fun observeMessages(chatId: ChatId): Flow<List<ChatMessage>> {
         return messageDataSource.observeMessages(chatId)
+    }
+
+    fun observeMessagesPaged(chatId: ChatId): Flow<PagingData<ChatMessage>> {
+        messageDataSource.setActiveChatId(chatId)
+        return Pager(
+            config = PagingConfig(pageSize = 50),
+        ) {
+            messageDataSource.observe()
+        }.flow.map { page ->
+            page.map { entity -> messageDataSource.toChatMessage(entity) }
+        }
     }
 
     fun observeTypingIndicators(chatId: ChatId): Flow<Set<ActiveTypist>> {
@@ -153,10 +173,11 @@ class ChatCoordinator @Inject constructor(
             }
     }
 
-    suspend fun sendMessage(chatId: ChatId, content: List<MessageContent>): Result<ChatMessage> {
+    suspend fun sendMessage(chatId: ChatId, content: String): Result<ChatMessage> {
         val senderId = userManager.accountId
             ?: return Result.failure(IllegalStateException("Cannot send message without an account"))
 
+        val content = listOf(MessageContent.Text(content))
         val (_, clientMessageId) = messageDataSource.insertPending(
             chatId = chatId,
             content = content,

--- a/apps/flipcash/shared/contacts/src/main/kotlin/com/flipcash/app/contacts/ContactCoordinator.kt
+++ b/apps/flipcash/shared/contacts/src/main/kotlin/com/flipcash/app/contacts/ContactCoordinator.kt
@@ -192,6 +192,12 @@ class ContactCoordinator @Inject constructor(
         return resolverController.resolve(ContactMethod.Phone(e164))
     }
 
+    fun lookupContact(e164: String): Result<DeviceContact> {
+        val contact = _state.value.contacts[e164]
+            ?: return Result.failure(NoSuchElementException("No contact found for $e164"))
+        return Result.success(contact)
+    }
+
     /**
      * Ensures the user's verified phone number is linked for payment, calling the
      * server RPC at most once per account lifetime (persisted via DataStore).

--- a/apps/flipcash/shared/contacts/src/main/kotlin/com/flipcash/app/contacts/ui/ContactAvatar.kt
+++ b/apps/flipcash/shared/contacts/src/main/kotlin/com/flipcash/app/contacts/ui/ContactAvatar.kt
@@ -1,0 +1,78 @@
+package com.flipcash.app.contacts.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.TextAlign
+import androidx.core.net.toUri
+import coil3.compose.AsyncImage
+import coil3.request.ImageRequest
+import coil3.request.crossfade
+import com.getcode.theme.CodeTheme
+
+
+@Composable
+fun ContactAvatar(
+    photoUri: String?,
+    displayName: String,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier.background(
+            Brush.linearGradient(CodeTheme.colors.contactAvatar.colors)
+        )
+    ) {
+        if (photoUri != null) {
+            var isError by rememberSaveable(photoUri) { mutableStateOf(false) }
+            if (!isError) {
+                val context = LocalContext.current
+                val request = remember(photoUri) {
+                    ImageRequest.Builder(context)
+                        .crossfade(true)
+                        .data(photoUri.toUri())
+                        .build()
+                }
+                AsyncImage(
+                    modifier = Modifier.matchParentSize(),
+                    model = request,
+                    contentDescription = null,
+                    onError = { isError = true },
+                )
+            }
+            if (isError) {
+                InitialsText(displayName)
+            }
+        } else {
+            InitialsText(displayName)
+        }
+    }
+}
+
+@Composable
+private fun BoxScope.InitialsText(displayName: String) {
+    val initials = remember(displayName) {
+        displayName.split(" ")
+            .take(2)
+            .mapNotNull { it.firstOrNull()?.uppercaseChar() }
+            .joinToString("")
+            .ifEmpty { "?" }
+    }
+    Text(
+        modifier = Modifier.align(Alignment.Center),
+        text = initials,
+        style = CodeTheme.typography.textSmall,
+        color = CodeTheme.colors.textSecondary,
+        textAlign = TextAlign.Center,
+    )
+}

--- a/apps/flipcash/shared/featureflags/src/main/kotlin/com/flipcash/app/featureflags/FeatureFlag.kt
+++ b/apps/flipcash/shared/featureflags/src/main/kotlin/com/flipcash/app/featureflags/FeatureFlag.kt
@@ -190,6 +190,17 @@ sealed interface FeatureFlag<T: Any> {
     }
 
     @FeatureFlagMarker
+    data object Messenger : FeatureFlag<Boolean> {
+        override val key: String = "messenger_enabled"
+        override val default: Boolean = false
+        override val launched: Boolean = false
+        override val visible: Boolean = true
+        override val persistLogOut: Boolean = false
+        /** Messenger only makes sense when [PhoneNumberSend] is enabled at runtime. */
+        val requiredFlag: FeatureFlag<Boolean> get() = PhoneNumberSend
+    }
+
+    @FeatureFlagMarker
     data object NavBar : FeatureFlag<NavBarConfig> {
         override val key: String = "nav_bar_config"
         override val default: NavBarConfig = NavBarConfig.Default
@@ -230,6 +241,7 @@ val FeatureFlag<*>.title: String
         FeatureFlag.BackgroundReset -> "Background Reset"
         FeatureFlag.ContactPickerMode -> "Contact Picker Mode"
         FeatureFlag.PhoneNumberSend -> "Phone Number Send"
+        FeatureFlag.Messenger -> "Messenger"
         FeatureFlag.NavBar -> "Navigation Bar"
     }
 
@@ -253,6 +265,7 @@ val FeatureFlag<*>.message: String
         FeatureFlag.BackgroundReset -> "Automatically returns the app to the camera screen after a period of inactivity with the app in the background"
         FeatureFlag.ContactPickerMode -> "When enabled, contacts will be accessed via the system contact picker instead of requesting full READ_CONTACTS permission"
         FeatureFlag.PhoneNumberSend -> "When enabled, you'll gain the ability to send cash directly to contacts via phone number"
+        FeatureFlag.Messenger -> "When enabled, tapping a contact will open the chat messenger instead of navigating directly to send"
         FeatureFlag.NavBar -> "Customize the order and labels of navigation bar buttons"
     }
 

--- a/apps/flipcash/shared/featureflags/src/main/kotlin/com/flipcash/app/featureflags/internal/InternalFeatureFlagController.kt
+++ b/apps/flipcash/shared/featureflags/src/main/kotlin/com/flipcash/app/featureflags/internal/InternalFeatureFlagController.kt
@@ -98,6 +98,12 @@ internal class InternalFeatureFlagController @Inject constructor(
 
     override fun observe(): StateFlow<List<BetaFeature>> = betaFlags.data.map { prefs ->
         FeatureFlag.availableEntries
+            .filter { flag ->
+                if (flag is FeatureFlag.Messenger) {
+                    val req = flag.requiredFlag
+                    prefs[req.booleanPreferenceKey] ?: req.defaultEnabled
+                } else true
+            }
             .map { flag ->
                 if (flag.isOptionFlag) {
                     val option = prefs[flag.optionPreferenceKey] ?: flag.defaultOption

--- a/apps/flipcash/shared/persistence/db/src/main/kotlin/com/flipcash/app/persistence/dao/ChatMessageDao.kt
+++ b/apps/flipcash/shared/persistence/db/src/main/kotlin/com/flipcash/app/persistence/dao/ChatMessageDao.kt
@@ -1,5 +1,6 @@
 package com.flipcash.app.persistence.dao
 
+import androidx.paging.PagingSource
 import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
@@ -13,6 +14,9 @@ interface ChatMessageDao {
 
     @Query("SELECT * FROM chat_messages WHERE chat_id_hex = :chatIdHex ORDER BY timestamp_epoch_ms ASC")
     fun observeMessages(chatIdHex: String): Flow<List<ChatMessageEntity>>
+
+    @Query("SELECT * FROM chat_messages WHERE chat_id_hex = :chatIdHex ORDER BY timestamp_epoch_ms DESC")
+    fun observeMessagesPaged(chatIdHex: String): PagingSource<Int, ChatMessageEntity>
 
     @Query("SELECT * FROM chat_messages WHERE chat_id_hex = :chatIdHex ORDER BY timestamp_epoch_ms DESC LIMIT 1")
     suspend fun getLatest(chatIdHex: String): ChatMessageEntity?

--- a/apps/flipcash/shared/persistence/sources/src/main/kotlin/com/flipcash/app/persistence/sources/ChatMessageDataSource.kt
+++ b/apps/flipcash/shared/persistence/sources/src/main/kotlin/com/flipcash/app/persistence/sources/ChatMessageDataSource.kt
@@ -1,16 +1,21 @@
 package com.flipcash.app.persistence.sources
 
+import androidx.paging.PagingSource
 import com.flipcash.app.persistence.FlipcashDatabase
+import com.flipcash.app.persistence.entities.ChatMessageEntity
 import com.flipcash.app.persistence.sources.mapper.chat.ChatEntityMapper
 import com.flipcash.services.models.chat.ChatId
 import com.flipcash.services.models.chat.ChatMessage
 import com.flipcash.services.models.chat.ClientMessageId
 import com.flipcash.app.persistence.entities.MessageStatus
 import com.flipcash.services.models.chat.MessageContent
+import com.flipcash.services.persistence.PagingDataSource
+import com.flipcash.services.user.UserManager
 import com.getcode.opencode.model.core.ID
 import com.getcode.opencode.model.core.RandomId
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -23,18 +28,64 @@ data class PendingMessage(
 @Singleton
 class ChatMessageDataSource @Inject constructor(
     private val mapper: ChatEntityMapper,
-) {
+    private val userManager: UserManager,
+) : PagingDataSource<Long, ChatMessage, List<ChatMessage>, Int, ChatMessageEntity> {
 
     private val db: FlipcashDatabase?
         get() = FlipcashDatabase.getInstance()
 
+    private var activeChatId: ChatId? = null
+
+    fun setActiveChatId(chatId: ChatId) {
+        activeChatId = chatId
+    }
+
+    // region PagingDataSource
+
+    override fun observe(): PagingSource<Int, ChatMessageEntity> {
+        val id = activeChatId ?: return emptyPagingSource()
+        return db?.chatMessageDao()?.observeMessagesPaged(mapper.chatIdHex(id))
+            ?: emptyPagingSource()
+    }
+
+    override suspend fun getById(id: Long): ChatMessage? {
+        val hex = activeChatId?.let { mapper.chatIdHex(it) } ?: return null
+        return db?.chatMessageDao()?.getLatest(hex)?.let { toChatMessage(it) }
+    }
+
+    override suspend fun get(): List<ChatMessage> {
+        val hex = activeChatId?.let { mapper.chatIdHex(it) } ?: return emptyList()
+        return db?.chatMessageDao()?.observeMessages(hex)
+            ?.firstOrNull()
+            ?.map { toChatMessage(it) }
+            ?: emptyList()
+    }
+
+    override suspend fun getMostRecent(): ChatMessage? {
+        val hex = activeChatId?.let { mapper.chatIdHex(it) } ?: return null
+        return getLatest(hex)
+    }
+
+    override suspend fun query(whereClause: String): List<ChatMessage> = emptyList()
+
+    override suspend fun upsert(value: List<ChatMessage>) {
+        val chatId = activeChatId ?: return
+        upsert(chatId, value)
+    }
+
+    override suspend fun clear() {
+        db?.chatMessageDao()?.deleteAll()
+    }
+
+    // endregion
+
     fun observeMessages(chatId: ChatId): Flow<List<ChatMessage>> =
         db?.chatMessageDao()?.observeMessages(mapper.chatIdHex(chatId))?.map { entities ->
-            entities.map { mapper.toMessage(it) }
+            entities.map { toChatMessage(it) }
         } ?: emptyFlow()
 
     suspend fun getLatest(chatIdHex: String): ChatMessage? =
-        db?.chatMessageDao()?.getLatest(chatIdHex)?.let { mapper.toMessage(it) }
+        db?.chatMessageDao()?.getLatest(chatIdHex)?.let { toChatMessage(it) }
 
     suspend fun upsert(chatId: ChatId, messages: List<ChatMessage>) {
         val hex = mapper.chatIdHex(chatId)
@@ -55,7 +106,7 @@ class ChatMessageDataSource @Inject constructor(
         )
         db?.chatMessageDao()?.upsert(entity)
         return PendingMessage(
-            message = mapper.toMessage(entity),
+            message = mapper.toMessage(entity).copy(isFromSelf = true),
             clientMessageId = clientMessageId,
         )
     }
@@ -76,7 +127,15 @@ class ChatMessageDataSource @Inject constructor(
         )
     }
 
-    suspend fun clear() {
-        db?.chatMessageDao()?.deleteAll()
+    fun toChatMessage(entity: ChatMessageEntity): ChatMessage {
+        val message = mapper.toMessage(entity)
+        val selfId = userManager.accountId
+        return message.copy(isFromSelf = selfId != null && message.senderId == selfId)
+    }
+
+    private fun emptyPagingSource() = object : PagingSource<Int, ChatMessageEntity>() {
+        override fun getRefreshKey(state: androidx.paging.PagingState<Int, ChatMessageEntity>): Int? = null
+        override suspend fun load(params: LoadParams<Int>): LoadResult<Int, ChatMessageEntity> =
+            LoadResult.Error(Exception("Database not initialized"))
     }
 }

--- a/apps/flipcash/shared/persistence/sources/src/main/kotlin/com/flipcash/app/persistence/sources/mediator/ChatMessageRemoteMediator.kt
+++ b/apps/flipcash/shared/persistence/sources/src/main/kotlin/com/flipcash/app/persistence/sources/mediator/ChatMessageRemoteMediator.kt
@@ -1,0 +1,54 @@
+package com.flipcash.app.persistence.sources.mediator
+
+import androidx.paging.ExperimentalPagingApi
+import androidx.paging.LoadType
+import androidx.paging.PagingState
+import androidx.paging.RemoteMediator
+import com.flipcash.app.persistence.entities.ChatMessageEntity
+import com.flipcash.app.persistence.sources.ChatMessageDataSource
+import com.flipcash.services.controllers.ChatMessagingController
+import com.flipcash.services.models.QueryOptions
+import com.flipcash.services.models.chat.ChatId
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+@OptIn(ExperimentalPagingApi::class)
+class ChatMessageRemoteMediator(
+    private val chatId: ChatId,
+    private val controller: ChatMessagingController,
+    private val dataSource: ChatMessageDataSource,
+) : RemoteMediator<Int, ChatMessageEntity>() {
+
+    override suspend fun initialize(): InitializeAction {
+        return InitializeAction.SKIP_INITIAL_REFRESH
+    }
+
+    override suspend fun load(
+        loadType: LoadType,
+        state: PagingState<Int, ChatMessageEntity>,
+    ): MediatorResult {
+        return try {
+            when (loadType) {
+                LoadType.REFRESH -> Unit
+                LoadType.PREPEND -> return MediatorResult.Success(endOfPaginationReached = true)
+                LoadType.APPEND -> Unit
+            }
+
+            val queryOptions = QueryOptions(
+                limit = state.config.pageSize,
+                descending = true,
+            )
+
+            val messages = controller.getMessages(chatId, queryOptions)
+                .getOrNull().orEmpty()
+
+            withContext(Dispatchers.IO) {
+                dataSource.upsert(chatId, messages)
+            }
+
+            MediatorResult.Success(endOfPaginationReached = messages.size < state.config.pageSize)
+        } catch (e: Exception) {
+            MediatorResult.Error(e)
+        }
+    }
+}

--- a/apps/flipcash/shared/theme/src/main/kotlin/com/flipcash/app/theme/internal/FlipcashDesignSystem.kt
+++ b/apps/flipcash/shared/theme/src/main/kotlin/com/flipcash/app/theme/internal/FlipcashDesignSystem.kt
@@ -11,6 +11,8 @@ import com.getcode.theme.BrandDark
 import com.getcode.theme.BrandIndicator
 import com.getcode.theme.BrandMuted
 import com.getcode.theme.BrandOverlay
+import com.getcode.theme.Bubble
+import com.getcode.theme.ChatColors
 import com.getcode.theme.ColorScheme
 import com.getcode.theme.DesignSystem
 import com.getcode.theme.Error
@@ -60,6 +62,17 @@ object Flipcash2ColorSpec {
         ),
         stops = listOf(0f, 1f)
     )
+
+    val chatColors = ChatColors(
+        incomingBubble = Bubble(
+            background = Color.White.copy(alpha = 0.02f),
+            border = Color.White.copy(alpha = 0.03f),
+        ),
+        outgoingBubble = Bubble(
+            background = Color.White.copy(alpha = 0.08f),
+            border = Color.White.copy(alpha = 0.03f),
+        )
+    )
 }
 
 private val colors = with(Flipcash2ColorSpec) {
@@ -104,6 +117,7 @@ private val colors = with(Flipcash2ColorSpec) {
         scrim = Black40,
         accessKey = accessKey,
         contactAvatar = contactAvatar,
+        chat = chatColors,
     )
 }
 @Composable

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -91,7 +91,7 @@ bugsnag = "6.26.0"
 bugsnag-agp = "8.2.0"
 bugsnag-gradle-plugin = "1.1.0"
 rinku = "1.6.0"
-haze = "1.7.2"
+haze = "2.0.0-alpha02"
 cloudy = "0.5.0"
 phantom-connect-kmp = "2.0.2-1.0.0"
 vico = "3.2.2"
@@ -265,6 +265,7 @@ eddsa = { module = "net.i2p.crypto:eddsa", version = "0.3.0" }
 cloudy = { module = "com.github.skydoves:cloudy", version.ref = "cloudy" }
 fingerprint-pro = { module = "com.fingerprint.android:pro", version = "2.4.0" }
 haze = { module = "dev.chrisbanes.haze:haze", version.ref = "haze" }
+haze-blur = { module = "dev.chrisbanes.haze:haze-blur", version.ref = "haze" }
 haze-materials = { module = "dev.chrisbanes.haze:haze-materials", version.ref = "haze" }
 phantom-connect = { module = "dev.bmcreations:phantom-connect", version.ref = "phantom-connect-kmp" }
 phantom-connect-wallet = { module = "dev.bmcreations:phantom-connect-wallet", version.ref = "phantom-connect-kmp" }
@@ -313,7 +314,7 @@ androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling", vers
 compose = ["compose-ui", "compose-foundation", "compose-material", "compose-material-icons-extended", "compose-animation", "compose-activities"]
 hilt = ["hilt-android", "javax-inject"]
 hilt-compiler = ["hilt-android-compiler", "hilt-compiler"]
-haze = ["haze", "haze-materials"]
+haze = ["haze", "haze-blur"]
 room = ["androidx-room-runtime", "androidx-room-ktx", "androidx-room-paging"]
 firebase = ["firebase-messaging", "firebase-installations"]
 kotlinx-serialization = ["kotlinx-serialization-core", "kotlinx-serialization-json"]

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/models/chat/ChatId.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/models/chat/ChatId.kt
@@ -1,6 +1,13 @@
 package com.flipcash.services.models.chat
 
+import com.getcode.utils.base58
+
 data class ChatId(val bytes: ByteArray) {
+
+    constructor(bytes: List<Byte>): this(bytes.toByteArray())
+    @OptIn(ExperimentalStdlibApi::class)
+    constructor(hex: String): this(hex.hexToByteArray())
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is ChatId) return false
@@ -9,5 +16,5 @@ data class ChatId(val bytes: ByteArray) {
 
     override fun hashCode(): Int = bytes.contentHashCode()
 
-    override fun toString(): String = "ChatId(${bytes.size} bytes)"
+    override fun toString(): String = bytes.base58
 }

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/models/chat/ChatMessage.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/models/chat/ChatMessage.kt
@@ -9,4 +9,5 @@ data class ChatMessage(
     val content: List<MessageContent>,
     val timestamp: Instant,
     val unreadSeq: Long,
+    val isFromSelf: Boolean = false,
 )

--- a/services/flipcash/src/test/kotlin/com/flipcash/services/models/chat/ChatIdTest.kt
+++ b/services/flipcash/src/test/kotlin/com/flipcash/services/models/chat/ChatIdTest.kt
@@ -1,9 +1,9 @@
 package com.flipcash.services.models.chat
 
+import com.getcode.utils.base58
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
-import kotlin.test.assertTrue
 
 class ChatIdTest {
 
@@ -29,9 +29,10 @@ class ChatIdTest {
     }
 
     @Test
-    fun `toString includes byte size`() {
-        val id = ChatId(ByteArray(32))
-        assertTrue(id.toString().contains("32 bytes"))
+    fun `toString returns base58 encoding`() {
+        val bytes = byteArrayOf(1, 2, 3, 4, 5)
+        val id = ChatId(bytes)
+        assertEquals(bytes.base58, id.toString())
     }
 
     @Test

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -95,6 +95,7 @@ include(
     ":apps:flipcash:features:advanced",
     ":apps:flipcash:features:currency-creator",
     ":apps:flipcash:features:direct-send",
+    ":apps:flipcash:features:messenger",
     ":apps:flipcash:features:invite",
     ":apps:flipcash:features:device-logs",
     ":apps:flipcash:features:myaccount",

--- a/ui/components/src/main/kotlin/com/getcode/ui/components/CircularIconButton.kt
+++ b/ui/components/src/main/kotlin/com/getcode/ui/components/CircularIconButton.kt
@@ -14,8 +14,10 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.getcode.ui.components.AppBarDefaults.IconSize
 import androidx.compose.foundation.clickable
+import com.getcode.theme.CodeTheme
 
-private val ButtonSize = 40.dp
+private val ButtonSize: Dp
+    @Composable get() = CodeTheme.dimens.staticGrid.x8
 private val ButtonBackground = Color.White.copy(alpha = 0.1f)
 
 

--- a/ui/components/src/main/kotlin/com/getcode/ui/components/SearchInput.kt
+++ b/ui/components/src/main/kotlin/com/getcode/ui/components/SearchInput.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import com.getcode.theme.CodeTheme
 import com.getcode.theme.White50
+import com.getcode.ui.core.unboundedClickable
 
 @Composable
 fun SearchInput(
@@ -39,17 +40,14 @@ fun SearchInput(
         placeholderStyle = CodeTheme.typography.textMedium,
         trailingIcon = {
             if (state.text.isNotEmpty()) {
-                IconButton(
-                    onClick = {
+                Icon(
+                    modifier = Modifier.unboundedClickable {
                         state.clearText()
-                    },
-                ) {
-                    Icon(
-                        imageVector = Icons.Outlined.Close,
-                        contentDescription = null,
-                        tint = White50,
-                    )
-                }
+                    }.padding(end = CodeTheme.dimens.grid.x3),
+                    imageVector = Icons.Outlined.Close,
+                    contentDescription = null,
+                    tint = White50,
+                )
             }
         },
         maxLines = 1,

--- a/ui/components/src/main/kotlin/com/getcode/ui/components/SearchInput.kt
+++ b/ui/components/src/main/kotlin/com/getcode/ui/components/SearchInput.kt
@@ -32,7 +32,7 @@ fun SearchInput(
                 modifier = Modifier.padding(start = CodeTheme.dimens.grid.x3),
                 imageVector = Icons.Filled.Search,
                 contentDescription = null,
-                tint = CodeTheme.colors.textMain,
+                tint = CodeTheme.colors.textSecondary,
             )
         },
         placeholder = placeholder,

--- a/ui/components/src/main/kotlin/com/getcode/ui/components/SlideToConfirm.kt
+++ b/ui/components/src/main/kotlin/com/getcode/ui/components/SlideToConfirm.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.foundation.shape.CornerBasedShape
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
@@ -61,6 +62,7 @@ import com.getcode.theme.CodeTheme
 import com.getcode.theme.DesignSystem
 import com.getcode.theme.White20
 import com.getcode.theme.White50
+import com.getcode.theme.inset
 import com.getcode.ui.theme.CodeCircularProgressIndicator
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
@@ -99,8 +101,6 @@ private object Thumb {
     val Size: Dp
         @Composable get() = CodeTheme.dimens.grid.x12
     val Color = androidx.compose.ui.graphics.Color.White
-    val Shape: Shape
-        @Composable get() = CodeTheme.shapes.small
 }
 
 private object Track {
@@ -146,7 +146,6 @@ fun SlideToConfirm(
     modifier: Modifier = Modifier,
     trackShape: Shape = Track.Shape,
     trackColor: Color = Track.Color,
-    thumbShape: Shape = Thumb.Shape,
     enabled: Boolean = true,
     isLoading: Boolean = false,
     isSuccess: Boolean = false,
@@ -167,6 +166,7 @@ fun SlideToConfirm(
     val density = LocalDensity.current
     val thumbSize = Thumb.Size
     val horizontalPadding = CodeTheme.dimens.grid.x1
+    val thumbShape = (trackShape as? CornerBasedShape)?.inset(horizontalPadding) ?: trackShape
     val overhead = with(density) { (2 * horizontalPadding + thumbSize).toPx() }
 
     val swipeState = remember {
@@ -352,7 +352,7 @@ private fun Thumb(
     modifier: Modifier = Modifier,
     size: Dp = Thumb.Size,
     color: Color = Thumb.Color,
-    shape: Shape = Thumb.Shape,
+    shape: Shape = Track.Shape,
 ) {
     Box(
         modifier = modifier

--- a/ui/components/src/main/kotlin/com/getcode/ui/components/TextInput.kt
+++ b/ui/components/src/main/kotlin/com/getcode/ui/components/TextInput.kt
@@ -62,7 +62,7 @@ fun TextInput(
     minLines: Int = 1,
     maxLines: Int = 4,
     state: TextFieldState,
-    minHeight: Dp = 56.dp,
+    minHeight: Dp = 40.dp,
     contentPadding: PaddingValues = PaddingValues(),
     onStateChanged: () -> Unit = { },
     keyboardOptions: KeyboardOptions = KeyboardOptions(),

--- a/ui/components/src/main/kotlin/com/getcode/ui/components/TitleBar.kt
+++ b/ui/components/src/main/kotlin/com/getcode/ui/components/TitleBar.kt
@@ -243,7 +243,7 @@ private fun TopAppBarBase(
 
     val emptyLeftSlot = @Composable {
         Box(modifier = Modifier.padding(5.dp)) {
-            AppBarDefaults.UpNavigation() { }
+            AppBarDefaults.UpNavigation { }
         }
     }
     val leftSlot = @Composable {

--- a/ui/components/src/main/kotlin/com/getcode/ui/components/chat/ChatInput.kt
+++ b/ui/components/src/main/kotlin/com/getcode/ui/components/chat/ChatInput.kt
@@ -1,10 +1,14 @@
 package com.getcode.ui.components.chat
 
 import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.expandIn
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkOut
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.togetherWith
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
@@ -17,12 +21,13 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material.Icon
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.rounded.Send
+import androidx.compose.material.icons.rounded.KeyboardArrowUp
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -42,6 +47,10 @@ import com.getcode.theme.inputColors
 import com.getcode.ui.components.R
 import com.getcode.ui.components.TextInput
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.requiredSize
+import androidx.compose.material.icons.rounded.ArrowUpward
+import com.getcode.theme.extraSmall
 
 @Composable
 fun ChatInput(
@@ -50,111 +59,98 @@ fun ChatInput(
     hint: String = "",
     state: TextFieldState = rememberTextFieldState(),
     focusRequester: FocusRequester = remember { FocusRequester() },
-    sendCashEnabled: Boolean = false,
     onSendMessage: () -> Unit,
-    onSendCash: () -> Unit,
 ) {
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .height(IntrinsicSize.Min)
-            .padding(
-                start = CodeTheme.dimens.grid.x2,
-                top = CodeTheme.dimens.grid.x2,
-                bottom = CodeTheme.dimens.grid.x2,
-            ),
+            .height(IntrinsicSize.Min),
         horizontalArrangement = Arrangement.spacedBy(CodeTheme.dimens.grid.x2),
         verticalAlignment = Alignment.Bottom
     ) {
-        if (sendCashEnabled) {
-            Box(
-                modifier = Modifier
-                    .align(Alignment.Bottom)
-                    .border(width = 1.dp, color = Color.White, shape = CircleShape)
-                    .clip(CircleShape)
-                    .clickable { onSendCash() }
-                    .size(ChatInput_Size)
-                    .padding(8.dp),
-                contentAlignment = Alignment.Center,
-            ) {
-                Icon(
-                    modifier = Modifier
-                        .size(CodeTheme.dimens.staticGrid.x6),
-                    painter = painterResource(id = R.drawable.ic_kin_white),
-                    tint = Color.White,
-                    contentDescription = "Send message"
-                )
-            }
-        }
-
         TextInput(
             modifier = Modifier
                 .weight(1f)
+                .background(CodeTheme.colors.background, shape = CodeTheme.shapes.medium)
                 .focusRequester(focusRequester),
             minHeight = 40.dp,
             enabled = enabled,
             state = state,
             placeholder = hint,
-            shape = CodeTheme.shapes.extraLarge,
+            shape = CodeTheme.shapes.medium,
             keyboardOptions = KeyboardOptions.Default.copy(
                 capitalization = KeyboardCapitalization.Sentences
             ),
             contentPadding = PaddingValues(
-                start = 8.dp + CodeTheme.dimens.staticGrid.x2,
-                top = 8.dp,
-                end = 8.dp + CodeTheme.dimens.staticGrid.x2,
-                bottom = 8.dp
+                start = CodeTheme.dimens.staticGrid.x3,
+                top = CodeTheme.dimens.staticGrid.x2,
+                end = CodeTheme.dimens.staticGrid.x3,
+                bottom = CodeTheme.dimens.staticGrid.x2,
             ),
             colors = inputColors(
-                backgroundColor = Color.White,
-                textColor = CodeTheme.colors.background,
-                cursorColor = CodeTheme.colors.brand,
-            )
-        )
-        AnimatedContent(
-            targetState = true, // TODO: state.text.isNotEmpty(),
-            label = "show/hide send button",
-            transitionSpec = {
-                slideInHorizontally { it } togetherWith slideOutHorizontally { it }
-            }
-        ) { show ->
-            if (show) {
-                Box(
-                    modifier = Modifier
-                        .padding(end = CodeTheme.dimens.grid.x2)
-                        .size(ChatInput_Size)
-                        .align(Alignment.Bottom)
-                        .background(CodeTheme.colors.tertiary, shape = CircleShape)
-                        .clip(CircleShape)
-                        .clickable { onSendMessage() }
-                        .padding(8.dp),
-                    contentAlignment = Alignment.Center,
-                ) {
-                    Icon(
-                        modifier = Modifier
-                            .size(CodeTheme.dimens.staticGrid.x6),
-                        imageVector = Icons.AutoMirrored.Rounded.Send,
-                        tint = Color.White,
-                        contentDescription = "Send message"
-                    )
+                backgroundColor = Color(0xAD1E1E1E),
+                borderColor = Color.Transparent,
+                unfocusedBorderColor = Color.Transparent,
+            ),
+            trailingIcon = {
+                AnimatedContent(
+                    targetState = state.text.isNotEmpty(),
+                    label = "show/hide send button",
+                    transitionSpec = {
+                        fadeIn(spring()) togetherWith fadeOut(spring())
+                    }
+                ) { show ->
+                    if (show) {
+                        Icon(
+                            modifier = Modifier
+                                .padding(vertical = CodeTheme.dimens.grid.x1)
+                                .padding(end = CodeTheme.dimens.staticGrid.x2)
+                                .background(
+                                    Color.White,
+                                    shape = CodeTheme.shapes.extraSmall
+                                ).clip(CodeTheme.shapes.extraSmall)
+                                .clickable { onSendMessage() }
+                                .padding(CodeTheme.dimens.staticGrid.x1)
+                                .size(CodeTheme.dimens.staticGrid.x5),
+                            imageVector = Icons.Rounded.ArrowUpward,
+                            tint = Color.Black,
+                            contentDescription = "Send message"
+                        )
+                    } else {
+                        Spacer(Modifier.requiredSize(CodeTheme.dimens.staticGrid.x9))
+                    }
                 }
             }
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun Preview_ChatInput_Empty() {
+    DesignSystem {
+        Box(modifier = Modifier.background(Color(0xFF19191A))) {
+            ChatInput(
+                modifier = Modifier.padding(15.dp),
+                onSendMessage = {},
+            )
         }
     }
 }
 
-@OptIn(ExperimentalFoundationApi::class)
 @Preview
 @Composable
-private fun Preview_ChatInput() {
+private fun Preview_ChatInput_Typing() {
     DesignSystem {
-        ChatInput(
-            sendCashEnabled = true,
-            onSendMessage = {},
-            onSendCash = {}
-        )
+        Box(modifier = Modifier.background(Color(0xFF19191A))) {
+            ChatInput(
+                modifier = Modifier.padding(15.dp),
+                onSendMessage = {},
+                state = TextFieldState("That’s very kind of you. I ha")
+            )
+        }
     }
 }
 
-private val ChatInput_Size
-    @Composable get() = CodeTheme.dimens.grid.x8
+private val ChatInputButtonSize
+    @Composable get() = CodeTheme.dimens.staticGrid.x7

--- a/ui/theme/src/main/kotlin/com/getcode/theme/Color.kt
+++ b/ui/theme/src/main/kotlin/com/getcode/theme/Color.kt
@@ -98,3 +98,15 @@ data class GradientSpec(
         return 31 * colorsArray.contentHashCode() + stopsArray.contentHashCode()
     }
 }
+
+data class ChatColors(
+    val incomingBubble: Bubble,
+    val outgoingBubble: Bubble,
+)
+
+data class Bubble(
+    val background: Color,
+    val border: Color,
+) {
+    val hasBorder: Boolean get() = border != Color.Transparent && border != Color.Unspecified
+}

--- a/ui/theme/src/main/kotlin/com/getcode/theme/Shape.kt
+++ b/ui/theme/src/main/kotlin/com/getcode/theme/Shape.kt
@@ -1,11 +1,16 @@
 package com.getcode.theme
 
 import androidx.compose.foundation.shape.CornerBasedShape
+import androidx.compose.foundation.shape.CornerSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Shapes
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.max
 import com.getcode.view.shapes.TriangleCutShape
 
 internal val shapes = Shapes(
@@ -25,4 +30,23 @@ val Shapes.xxl: CornerBasedShape
 
 @Composable
 fun Shapes.receipt(step: Dp = CodeTheme.dimens.grid.x2) = TriangleCutShape(step)
+
+/**
+ * Returns a new [RoundedCornerShape] whose corners are concentric with this shape,
+ * inset by [inset]. Useful for nested rounded rectangles (e.g. a thumb inside a track)
+ * where the inner corners should run parallel to the outer ones.
+ */
+@Composable
+fun CornerBasedShape.inset(inset: Dp): RoundedCornerShape {
+    val density = LocalDensity.current
+    // Use a large reference size so percentage-based CornerSizes resolve to absolute values.
+    val ref = Size(10_000f, 10_000f)
+    fun CornerSize.shrink(): Dp = max(0.dp, with(density) { toPx(ref, this).toDp() } - inset)
+    return RoundedCornerShape(
+        topStart = topStart.shrink(),
+        topEnd = topEnd.shrink(),
+        bottomEnd = bottomEnd.shrink(),
+        bottomStart = bottomStart.shrink(),
+    )
+}
 

--- a/ui/theme/src/main/kotlin/com/getcode/theme/Theme.kt
+++ b/ui/theme/src/main/kotlin/com/getcode/theme/Theme.kt
@@ -59,6 +59,10 @@ internal val CodeDefaultColorScheme = ColorScheme(
     scrim = Black40,
     accessKey = CodeAccessKey,
     contactAvatar = CodeContactAvatar,
+    chat = ChatColors(
+        incomingBubble = Bubble(background = White10, border = Color.Transparent),
+        outgoingBubble = Bubble(background = BrandDark, border = Color.Transparent),
+    ),
 )
 
 @Composable
@@ -150,6 +154,7 @@ class ColorScheme(
     scrim: Color,
     accessKey: GradientSpec,
     contactAvatar: GradientSpec,
+    chat: ChatColors,
 ) {
     var brand by mutableStateOf(brand)
         private set
@@ -234,7 +239,8 @@ class ColorScheme(
         private set
     var contactAvatar by mutableStateOf(contactAvatar)
         private set
-
+    var chat by mutableStateOf(chat)
+        private set
 
     fun update(other: ColorScheme) {
         brand = other.brand
@@ -277,6 +283,7 @@ class ColorScheme(
         scrim = other.scrim
         accessKey = other.accessKey
         contactAvatar = other.contactAvatar
+        chat = other.chat
     }
 
     fun copy(): ColorScheme = ColorScheme(
@@ -320,6 +327,7 @@ class ColorScheme(
         scrim = scrim,
         accessKey = accessKey,
         contactAvatar = contactAvatar,
+        chat = chat,
     )
 }
 


### PR DESCRIPTION
Add a reusable Shape.inset(Dp) extension that computes concentric corner radii for nested rounded rectangles. Use it in SlideToConfirm so the thumb corners run parallel to the track.