### PR TITLE
feat(direct-send,messenger): add no-balance guard to send and chat entry points

### DIFF
--- a/apps/flipcash/features/direct-send/build.gradle.kts
+++ b/apps/flipcash/features/direct-send/build.gradle.kts
@@ -21,5 +21,6 @@ dependencies {
     implementation(project(":apps:flipcash:shared:featureflags"))
     implementation(project(":apps:flipcash:shared:permissions"))
     implementation(project(":apps:flipcash:shared:contacts"))
+    implementation(project(":apps:flipcash:shared:tokens"))
     implementation(project(":services:flipcash"))
 }

--- a/apps/flipcash/features/direct-send/src/main/kotlin/com/flipcash/app/directsend/internal/SendFlowViewModel.kt
+++ b/apps/flipcash/features/direct-send/src/main/kotlin/com/flipcash/app/directsend/internal/SendFlowViewModel.kt
@@ -12,8 +12,10 @@ import com.flipcash.app.core.send.SendStep
 import com.flipcash.app.featureflags.FeatureFlag
 import com.flipcash.app.featureflags.FeatureFlagController
 import com.flipcash.app.permissions.PickedContact
+import com.flipcash.app.tokens.TokenCoordinator
 import com.flipcash.features.directsend.R
 import com.flipcash.services.user.UserManager
+import com.getcode.manager.BottomBarAction
 import com.getcode.manager.BottomBarManager
 import com.getcode.util.resources.ResourceHelper
 import com.getcode.view.BaseViewModel
@@ -37,6 +39,7 @@ internal class SendFlowViewModel @Inject constructor(
     private val userManager: UserManager,
     featureFlags: FeatureFlagController,
     private val contactCoordinator: ContactCoordinator,
+    private val tokenCoordinator: TokenCoordinator,
     private val resources: ResourceHelper,
 ) : BaseViewModel<SendFlowViewModel.State, SendFlowViewModel.Event>(
     initialState = State(),
@@ -72,6 +75,7 @@ internal class SendFlowViewModel @Inject constructor(
 
         data class NavigateToChat(val contact: DeviceContact) : Event
         data class NavigateToDirectSend(val contact: DeviceContact) : Event
+        data object NavigateToDiscovery : Event
     }
 
     private val messengerEnabled = featureFlags.observe(FeatureFlag.Messenger)
@@ -159,6 +163,21 @@ internal class SendFlowViewModel @Inject constructor(
                     if (messengerEnabled.value) {
                         dispatchEvent(Event.NavigateToChat(contact))
                     } else {
+                        if (!tokenCoordinator.hasGiveableBalance()) {
+                            BottomBarManager.showInfo(
+                                title = resources.getString(R.string.title_noBalanceYet),
+                                message = resources.getString(R.string.description_noBalanceYet),
+                                actions = listOf(
+                                    BottomBarAction(
+                                        text = resources.getString(R.string.action_discoverCurrencies)
+                                    ) {
+                                        dispatchEvent(Event.NavigateToDiscovery)
+                                    },
+                                ),
+                                showCancel = true,
+                            )
+                            return@onEach
+                        }
                         dispatchEvent(Event.NavigateToDirectSend(contact))
                     }
                 } else {
@@ -253,6 +272,7 @@ internal class SendFlowViewModel @Inject constructor(
                 is Event.SendInvite -> { state -> state }
                 is Event.NavigateToChat -> { state -> state }
                 is Event.NavigateToDirectSend -> { state -> state }
+                is Event.NavigateToDiscovery -> { state -> state }
             }
         }
     }

--- a/apps/flipcash/features/direct-send/src/main/kotlin/com/flipcash/app/directsend/internal/screens/ContactListScreen.kt
+++ b/apps/flipcash/features/direct-send/src/main/kotlin/com/flipcash/app/directsend/internal/screens/ContactListScreen.kt
@@ -53,6 +53,7 @@ import coil3.request.ImageRequest
 import coil3.request.crossfade
 import com.flipcash.app.contacts.device.DeviceContact
 import com.flipcash.app.core.AppRoute
+import com.flipcash.app.core.extensions.openAsSheet
 import com.flipcash.app.core.send.SendResult
 import com.flipcash.app.core.send.SendStep
 import com.flipcash.app.directsend.internal.ContactListItem
@@ -123,6 +124,14 @@ internal fun ContactListScreen() {
                         displayName = contact.displayName,
                     )
                 )
+            }
+    }
+
+    LaunchedEffect(viewModel) {
+        viewModel.eventFlow
+            .filterIsInstance<SendFlowViewModel.Event.NavigateToDiscovery>()
+            .collect {
+                navigator.openAsSheet(AppRoute.Token.Discovery)
             }
     }
 

--- a/apps/flipcash/features/messenger/src/main/kotlin/com/flipcash/app/messenger/MessengerScreen.kt
+++ b/apps/flipcash/features/messenger/src/main/kotlin/com/flipcash/app/messenger/MessengerScreen.kt
@@ -12,6 +12,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.flipcash.app.contacts.device.DeviceContact
 import com.flipcash.app.core.AppRoute
+import com.flipcash.app.core.extensions.openAsSheet
 import com.flipcash.app.messenger.internal.ChatViewModel
 import com.flipcash.app.messenger.internal.screens.MessengerScreen
 import com.getcode.navigation.core.LocalCodeNavigator
@@ -38,6 +39,14 @@ fun MessengerScreen(e164: String, displayName: String) {
                     e164 = contact.e164,
                     displayName = contact.displayName,
                 ))
+            }
+    }
+
+    LaunchedEffect(viewModel) {
+        viewModel.eventFlow
+            .filterIsInstance<ChatViewModel.Event.NavigateToDiscovery>()
+            .collect {
+                navigator.openAsSheet(AppRoute.Token.Discovery)
             }
     }
 

--- a/apps/flipcash/features/messenger/src/main/kotlin/com/flipcash/app/messenger/internal/ChatViewModel.kt
+++ b/apps/flipcash/features/messenger/src/main/kotlin/com/flipcash/app/messenger/internal/ChatViewModel.kt
@@ -23,6 +23,7 @@ import com.flipcash.shared.amountentry.AmountEntryDelegate
 import com.flipcash.shared.amountentry.AmountEntryStyle
 import com.flipcash.shared.chat.ActiveTypist
 import com.flipcash.shared.chat.ChatCoordinator
+import com.getcode.manager.BottomBarAction
 import com.getcode.manager.BottomBarManager
 import com.getcode.opencode.controllers.TransactionController
 import com.getcode.opencode.exchange.Exchange
@@ -110,6 +111,7 @@ internal class ChatViewModel @Inject constructor(
         data object SendMessage : Event
 
         data class NavigateToAmountEntry(val contact: DeviceContact) : Event
+        data object NavigateToDiscovery : Event
 
         data object OnConfirmRequested : Event
         data class OnSendRequested(
@@ -284,6 +286,21 @@ internal class ChatViewModel @Inject constructor(
         eventFlow.filterIsInstance<Event.OnSendCash>()
             .mapNotNull { stateFlow.value.chattingWith }
             .onEach { contact ->
+                if (!tokenCoordinator.hasGiveableBalance()) {
+                    BottomBarManager.showInfo(
+                        title = resources.getString(R.string.title_noBalanceYet),
+                        message = resources.getString(R.string.description_noBalanceYet),
+                        actions = listOf(
+                            BottomBarAction(
+                                text = resources.getString(R.string.action_discoverCurrencies)
+                            ) {
+                                dispatchEvent(Event.NavigateToDiscovery)
+                            },
+                        ),
+                        showCancel = true,
+                    )
+                    return@onEach
+                }
                 dispatchEvent(Event.NavigateToAmountEntry(contact))
             }.launchIn(viewModelScope)
 
@@ -427,6 +444,7 @@ internal class ChatViewModel @Inject constructor(
                 }
                 is Event.SendMessage -> { state -> state }
                 is Event.NavigateToAmountEntry -> { state -> state.copy(sendProgress = LoadingSuccessState()) }
+                is Event.NavigateToDiscovery -> { state -> state }
                 is Event.OnConfirmRequested -> { state -> state }
                 is Event.OnSendRequested -> { state -> state }
                 is Event.SendStateUpdated -> { state ->

--- a/apps/flipcash/features/scanner/src/main/kotlin/com/flipcash/app/scanner/internal/Scanner.kt
+++ b/apps/flipcash/features/scanner/src/main/kotlin/com/flipcash/app/scanner/internal/Scanner.kt
@@ -22,7 +22,6 @@ import com.flipcash.features.scanner.R
 import com.getcode.libs.code.detection.CodeScanResult
 import com.getcode.manager.BottomBarManager
 import com.getcode.navigation.core.LocalCodeNavigator
-import com.getcode.opencode.model.financial.orZero
 import com.getcode.ui.biometrics.LocalBiometricsState
 import com.getcode.ui.components.OnLifecycleEvent
 import com.getcode.ui.scanner.CodeScanner
@@ -87,8 +86,7 @@ internal fun Scanner() {
             when (it) {
                 ScannerDecorItem.Give -> {
                     // only allow navigation to give when there is something to give
-                    val hasBalance = state.giveableBalance.orZero().isPositive
-                    if (!hasBalance) {
+                    if (!state.hasGiveableBalance) {
                         BottomBarManager.showInfo(
                             title = context.getString(R.string.title_noBalanceYet),
                             message = context.getString(R.string.description_noBalanceYet),

--- a/apps/flipcash/shared/session/src/main/kotlin/com/flipcash/app/session/SessionController.kt
+++ b/apps/flipcash/shared/session/src/main/kotlin/com/flipcash/app/session/SessionController.kt
@@ -4,7 +4,6 @@ import androidx.compose.runtime.staticCompositionLocalOf
 import com.flipcash.app.core.bill.Bill
 import com.flipcash.app.core.bill.BillState
 import com.flipcash.app.session.BillDeterminationResult.ActedUpon
-import com.getcode.opencode.model.financial.Fiat
 import com.getcode.opencode.model.financial.Token
 import com.getcode.solana.keys.Mint
 import com.getcode.ui.core.RestrictionType
@@ -34,7 +33,7 @@ interface SessionController {
 
 data class SessionState(
     val vibrateOnScan: Boolean = false,
-    val giveableBalance: Fiat? = null,
+    val hasGiveableBalance: Boolean = false,
     val logScanTimes: Boolean = false,
     val showNetworkOffline: Boolean = false,
     val autoStartCamera: Boolean? = true,

--- a/apps/flipcash/shared/session/src/main/kotlin/com/flipcash/app/session/internal/RealSessionController.kt
+++ b/apps/flipcash/shared/session/src/main/kotlin/com/flipcash/app/session/internal/RealSessionController.kt
@@ -193,10 +193,9 @@ class RealSessionController @Inject constructor(
             .launchIn(scope)
 
         tokenCoordinator.tokenBalances
-            .map { tokens -> tokens.filterNot { it.isReserves } }
-            .map { tokens -> tokens.map { it.balance } }
-            .map { balances -> balances.sum() }
-            .onEach { balance -> _state.update { it.copy(giveableBalance = balance) } }
+            .map { tokenCoordinator.hasGiveableBalance() }
+            .distinctUntilChanged()
+            .onEach { hasBalance -> _state.update { it.copy(hasGiveableBalance = hasBalance) } }
             .launchIn(scope)
 
         tokenCoordinator.tokens

--- a/apps/flipcash/shared/tokens/src/main/kotlin/com/flipcash/app/tokens/TokenCoordinator.kt
+++ b/apps/flipcash/shared/tokens/src/main/kotlin/com/flipcash/app/tokens/TokenCoordinator.kt
@@ -183,6 +183,12 @@ class TokenCoordinator @Inject constructor(
 
     // region Public API — Balances
 
+    fun hasGiveableBalance(): Boolean =
+        _state.value.balances
+            .filterKeys { it != Mint.usdf }
+            .values
+            .any { it.isPositive }
+
     fun balanceForToken(token: Token): Fiat = _state.value.balances[token.address] ?: Fiat.Zero
 
     fun balanceForToken(tokenAddress: Mint): Flow<Fiat> =


### PR DESCRIPTION
Show "No Balance Yet" dialog when tapping a Flipcash contact (messenger off) or pressing "Send Cash" in chat with zero balance, matching the existing scanner behavior. Centralizes giveable balance logic in TokenCoordinator.hasGiveableBalance() and reuses it in SessionController.