### PR TITLE
chore(onboarding): skip contact permission screen during onboarding

### DIFF
--- a/apps/flipcash/core/src/main/kotlin/com/flipcash/app/core/AppRoute.kt
+++ b/apps/flipcash/core/src/main/kotlin/com/flipcash/app/core/AppRoute.kt
@@ -72,7 +72,7 @@ sealed interface AppRoute : NavKey, Parcelable {
         val seed: String? = null,
         val fromDeeplink: Boolean = false,
         val resumeAt: ResumePoint = ResumePoint.Login,
-        val skipContacts: Boolean = false,
+        val skipContacts: Boolean = true,
     ) : AppRoute, FlowRoute {
         enum class Phase { Account, Permissions }
         enum class ResumePoint { Login, AccessKey, AccessKeyThenPurchase, PostAccessKey }
@@ -86,7 +86,10 @@ sealed interface AppRoute : NavKey, Parcelable {
                         listOf(OnboardingStep.Start(), OnboardingStep.AccessKey, OnboardingStep.Purchase)
                     ResumePoint.PostAccessKey -> emptyList()
                 }
-                Phase.Permissions -> listOf(OnboardingStep.ContactPermission, OnboardingStep.NotificationPermission)
+                Phase.Permissions -> buildList {
+                    if (!skipContacts) add(OnboardingStep.ContactPermission)
+                    add(OnboardingStep.NotificationPermission)
+                }
             }
     }
 

--- a/apps/flipcash/features/login/src/main/kotlin/com/flipcash/app/login/OnboardingFlowScreen.kt
+++ b/apps/flipcash/features/login/src/main/kotlin/com/flipcash/app/login/OnboardingFlowScreen.kt
@@ -233,7 +233,7 @@ private fun AccountPhaseFlowHost(
 
 internal fun resolvePostAccountRoute(
     result: OnboardingResult,
-    skipContacts: Boolean = false,
+    skipContacts: Boolean = true,
 ): AppRoute? {
     val permissionsRoute = AppRoute.OnboardingFlow(
         phase = AppRoute.OnboardingFlow.Phase.Permissions,

--- a/apps/flipcash/features/login/src/test/kotlin/com/flipcash/app/login/OnboardingRoutingTest.kt
+++ b/apps/flipcash/features/login/src/test/kotlin/com/flipcash/app/login/OnboardingRoutingTest.kt
@@ -18,7 +18,7 @@ class OnboardingRoutingTest {
         )
         val flow = assertIs<AppRoute.OnboardingFlow>(route)
         assertEquals(AppRoute.OnboardingFlow.Phase.Permissions, flow.phase)
-        assertEquals(false, flow.skipContacts)
+        assertEquals(true, flow.skipContacts)
     }
 
     // -- LoggedIn routes to permissions --
@@ -30,7 +30,7 @@ class OnboardingRoutingTest {
         )
         val flow = assertIs<AppRoute.OnboardingFlow>(route)
         assertEquals(AppRoute.OnboardingFlow.Phase.Permissions, flow.phase)
-        assertEquals(false, flow.skipContacts)
+        assertEquals(true, flow.skipContacts)
     }
 
     // -- skipContacts is forwarded --
@@ -39,11 +39,11 @@ class OnboardingRoutingTest {
     fun `skipContacts is forwarded to permissions route`() {
         val route = resolvePostAccountRoute(
             result = OnboardingResult.ProceedToVerification,
-            skipContacts = true,
+            skipContacts = false,
         )
         val flow = assertIs<AppRoute.OnboardingFlow>(route)
         assertEquals(AppRoute.OnboardingFlow.Phase.Permissions, flow.phase)
-        assertEquals(true, flow.skipContacts)
+        assertEquals(false, flow.skipContacts)
     }
 
     // -- Completed (no-op) --


### PR DESCRIPTION
Flip skipContacts default to true and make initialStack respect the flag so the contact permission step is no longer shown. All supporting code is preserved for easy re-enablement by reverting the default.