### PR TITLE
revert: Coil 3.5.0 — requires Kotlin 2.4.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,7 +41,7 @@ compose-view-models = "2.10.0"
 compose-paging = "3.5.0"
 compose-webview = "2.0.3"
 compose-accompanist = "0.36.0"
-compose-coil = "3.5.0"
+compose-coil = "3.4.0"
 
 hilt = "2.59.2"
 hilt-jetpack = "1.3.0"


### PR DESCRIPTION
## Summary
Reverts #882. Coil 3.5.0 declares a transitive dependency on kotlin-stdlib:2.4.0, which causes Hilt to fail:

> [Hilt] Provided Metadata instance has version 2.4.0, while maximum supported version is 2.3.0

The Kotlin 2.4.0 ecosystem is not ready yet:
- **KSP** needs [google/ksp#2981](https://github.com/google/ksp/pull/2981) (still open)
- **Hilt/Dagger** 2.59.2 (latest) does not support Kotlin 2.4.0 metadata

Staying on Coil 3.4.0 until KSP and Hilt ship Kotlin 2.4.0 support.