### PR TITLE
fix(streaming): stop reporting retryable ClosedSendChannelException to Bugsnag

### DIFF
--- a/services/opencode/src/main/kotlin/com/getcode/opencode/internal/bidi/OpenStream.kt
+++ b/services/opencode/src/main/kotlin/com/getcode/opencode/internal/bidi/OpenStream.kt
@@ -124,9 +124,8 @@ fun <Request, Response, StreamRef> openBidirectionalStream(
             } catch (e: Exception) {
                 trace(
                     tag = tag,
-                    message = "Failed to send initial request",
+                    message = "Failed to send initial request: ${e.message}",
                     type = TraceType.Error,
-                    error = e
                 )
                 collectionJob.cancel()
                 requestChannel.close()


### PR DESCRIPTION
The initial-request send in openBidirectionalStream already treats ClosedSendChannelException as retryable, but the trace() call was passing `error = e` which routed through ErrorUtils → Bugsnag.notify(). Inline the message instead so the retry path no longer produces false-positive Bugsnag warnings.