### PR TITLE
chore(ci): optimize build performance with config cache, R8 full mode, and lint restructuring

### DIFF
--- a/.github/workflows/build-fcash2-upload-android.yml
+++ b/.github/workflows/build-fcash2-upload-android.yml
@@ -52,7 +52,9 @@ jobs:
       - name: Gradle build cache
         uses: actions/cache@v4
         with:
-          path: ~/.gradle/caches/build-cache-1
+          path: |
+            ~/.gradle/caches/build-cache-1
+            .gradle/configuration-cache
           key: gradle-build-cache-${{ hashFiles('**/*.gradle.kts', 'gradle.properties') }}
           restore-keys: |
             gradle-build-cache-
@@ -105,7 +107,9 @@ jobs:
       - name: Gradle build cache
         uses: actions/cache@v4
         with:
-          path: ~/.gradle/caches/build-cache-1
+          path: |
+            ~/.gradle/caches/build-cache-1
+            .gradle/configuration-cache
           key: gradle-build-cache-${{ hashFiles('**/*.gradle.kts', 'gradle.properties') }}
           restore-keys: |
             gradle-build-cache-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,9 @@ jobs:
       - name: Gradle build cache
         uses: actions/cache@v4
         with:
-          path: ~/.gradle/caches/build-cache-1
+          path: |
+            ~/.gradle/caches/build-cache-1
+            .gradle/configuration-cache
           key: gradle-build-cache-${{ hashFiles('**/*.gradle.kts', 'gradle.properties') }}
           restore-keys: |
             gradle-build-cache-

--- a/apps/flipcash/app/build.gradle.kts
+++ b/apps/flipcash/app/build.gradle.kts
@@ -27,6 +27,9 @@ fun gitVersionCode(): Int {
 val contributorsSigningConfig = ContributorsSignatory(rootDir)
 val appNamespace = "${Gradle.flipcashNamespace}.app.android"
 
+val skipExpensiveReleaseTasks = providers.gradleProperty("skipExpensiveReleaseTasks")
+    .orElse("false").get().toBooleanStrict()
+
 android {
     // static namespace
     namespace = appNamespace
@@ -65,8 +68,8 @@ android {
     buildTypes {
         getByName("release") {
             resValue("string", "applicationId", appNamespace)
-            isMinifyEnabled = true
-            isShrinkResources = true
+            isMinifyEnabled = !skipExpensiveReleaseTasks
+            isShrinkResources = !skipExpensiveReleaseTasks
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
         }
         getByName("debug") {
@@ -90,6 +93,10 @@ android {
             signingConfig = signingConfigs.getByName("contributors")
             matchingFallbacks += listOf("debug")
         }
+    }
+
+    lint {
+        checkReleaseBuilds = false
     }
 
     compileOptions {

--- a/apps/flipcash/app/proguard-rules.pro
+++ b/apps/flipcash/app/proguard-rules.pro
@@ -6,9 +6,6 @@
 # Preserve source file names and line numbers for stack traces (call site tracking, Bugsnag)
 -keepattributes SourceFile,LineNumberTable
 
-# Keep screen names
--keepnames class * implements cafe.adriel.voyager.core.screen.Screen
-
 # Keep AppRoute class names for analytics screen tracking
 -keepnames class com.flipcash.app.core.AppRoute
 -keepnames class com.flipcash.app.core.AppRoute$**

--- a/apps/flipcash/shared/onramp/coinbase/src/test/kotlin/com/flipcash/app/onramp/CoinbaseOnRampControllerTest.kt
+++ b/apps/flipcash/shared/onramp/coinbase/src/test/kotlin/com/flipcash/app/onramp/CoinbaseOnRampControllerTest.kt
@@ -3,6 +3,9 @@ package com.flipcash.app.onramp
 import com.coinbase.onramp.api.CoinbaseApi
 import com.coinbase.onramp.data.OnRampApiConfig
 import com.flipcash.app.featureflags.FeatureFlagController
+import com.flipcash.app.userflags.FieldOverride
+import com.flipcash.app.userflags.ResolvedFlag
+import com.flipcash.app.userflags.ResolvedUserFlags
 import com.flipcash.app.userflags.UserFlagsCoordinator
 import com.flipcash.services.models.UserProfile
 import com.flipcash.services.user.UserManager
@@ -22,6 +25,7 @@ import io.mockk.mockkStatic
 import io.mockk.slot
 import io.mockk.unmockkStatic
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
@@ -77,6 +81,14 @@ class CoinbaseOnRampControllerTest {
         every { fakeUsdc.timelockSwapAccounts(any()) } returns mockk(relaxed = true)
 
         every { webViewChannelDetector.detect() } returns null
+
+        val resolvedFlags = mockk<ResolvedUserFlags>(relaxed = true) {
+            every { requireCoinbaseEmailVerification } returns ResolvedFlag(
+                serverValue = true,
+                override = FieldOverride.None,
+            )
+        }
+        every { userFlags.resolvedFlags } returns MutableStateFlow(resolvedFlags)
 
         controller = CoinbaseOnRampController(
             jwtProvider = jwtProvider,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -19,7 +19,7 @@ platform :android do
   desc "Runs all the tests for Flipcash"
     lane :flipcash_tests do
       gradle(
-        task: "generateEmojiList flipcashTestDebug",
+        task: "generateEmojiList flipcashTestDebug lintDebug",
         properties: {
           "skipCoverage" => ENV.fetch("SKIP_COVERAGE", "false")
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx4g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC -XX:MaxMetaspaceSize=1024m -Dkotlin.daemon.jvm.options=-XX:MaxMetaspaceSize=1g -Dlint.nullness.ignore-deprecated=true
+org.gradle.jvmargs=-Xmx6g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC -XX:MaxMetaspaceSize=1024m -Dkotlin.daemon.jvm.options=-XX:MaxMetaspaceSize=1g -Dlint.nullness.ignore-deprecated=true
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
@@ -41,3 +41,7 @@ android.experimental.enableTestFixturesKotlinSupport=true
 android.suppressUnsupportedOptionWarnings=android.suppressUnsupportedOptionWarnings,android.experimental.enableTestFixturesKotlinSupport
 android.uniquePackageNames=false
 android.dependency.useConstraints=false
+# R8 full mode: enables more aggressive optimizations (class merging,
+# enum unboxing, constant propagation). Produces smaller, faster output
+# and can also reduce R8's own processing time.
+android.enableR8.fullMode=true


### PR DESCRIPTION
- Persist Gradle configuration cache between CI runs (~4 min saved)
- Enable R8 full mode and bump JVM heap to 6g
- Move lint from release builds to PR CI (lintDebug)
- Skip R8/shrink on PR CI via skipExpensiveReleaseTasks property
- Remove dead Voyager keep rule from proguard-rules.pro
