### PR TITLE
fix: catch ActivityNotFoundException when opening email app

### DIFF
--- a/apps/flipcash/core/src/main/kotlin/com/flipcash/app/core/android/IntentUtils.kt
+++ b/apps/flipcash/core/src/main/kotlin/com/flipcash/app/core/android/IntentUtils.kt
@@ -24,7 +24,7 @@ object IntentUtils {
 
     fun tweet(message: String) = Intent(Intent.ACTION_VIEW).apply {
         val url = Linkify.tweet(message)
-        setData(url.toUri())
+        data = url.toUri()
         flags = Intent.FLAG_ACTIVITY_NEW_TASK
     }
 
@@ -57,7 +57,7 @@ object IntentUtils {
     }
 
     fun appStoreListing(packageName: String) = Intent(Intent.ACTION_VIEW).apply {
-        setData(Uri.parse("https://play.google.com/store/apps/details?id=$packageName"))
+        data = "https://play.google.com/store/apps/details?id=$packageName".toUri()
         flags = Intent.FLAG_ACTIVITY_NEW_TASK
     }
 

--- a/apps/flipcash/core/src/main/res/values/strings.xml
+++ b/apps/flipcash/core/src/main/res/values/strings.xml
@@ -367,10 +367,11 @@
 
     <string name="title_verificationFlow">Verify Your Phone Number And Email To Continue</string>
     <string name="subtitle_verificationFlowForOnramp">This will allow you to add funds from your debit card</string>
-    "
 
     <string name="title_email">Email</string>
     <string name="action_openMail">Open Mail</string>
+    <string name="error_title_noEmailAppFound">No email app found on this device</string>
+    <string name="error_description_noEmailAppFound">Please install an email app to receive your verification email</string>
     <string name="title_checkYourInbox">Check your inbox</string>
     <string name="subtitle_linkSentToEmail">Tap the link we sent to</string>
     <string name="subtitle_didntGetEmail">Didn\'t get an email?</string>

--- a/apps/flipcash/features/contact-verification/src/main/kotlin/com/flipcash/app/contact/verification/email/EmailMagicLinkScreen.kt
+++ b/apps/flipcash/features/contact-verification/src/main/kotlin/com/flipcash/app/contact/verification/email/EmailMagicLinkScreen.kt
@@ -12,11 +12,15 @@ import com.flipcash.app.analytics.Analytics
 import com.flipcash.app.analytics.rememberAnalytics
 import com.flipcash.app.contact.verification.internal.email.EmailMagicLinkScreen
 import com.flipcash.app.contact.verification.internal.email.EmailVerificationViewModel
+import android.content.ActivityNotFoundException
+import android.widget.Toast
+import androidx.compose.ui.platform.LocalResources
 import com.flipcash.app.core.android.IntentUtils
 import com.flipcash.app.core.verification.VerificationResult
 import com.flipcash.app.core.verification.VerificationStep
 import com.flipcash.app.core.verification.email.EmailDeeplinkOrigin
 import com.flipcash.features.contact.verification.R
+import com.getcode.manager.BottomBarManager
 import com.getcode.navigation.flow.flowSharedViewModel
 import com.getcode.navigation.flow.rememberFlowNavigator
 import com.getcode.ui.components.AppBarWithTitle
@@ -59,12 +63,20 @@ fun EmailMagicLinkContent(
         viewModel.dispatchEvent(EmailVerificationViewModel.Event.OnDataProvided(email, code))
     }
 
+    val resources = LocalResources.current
     val context = LocalContext.current
     LaunchedEffect(viewModel) {
         viewModel.eventFlow
             .filterIsInstance<EmailVerificationViewModel.Event.OpenMailApp>()
             .onEach {
-                context.startActivity(IntentUtils.emailApp())
+                try {
+                    context.startActivity(IntentUtils.emailApp())
+                } catch (_: ActivityNotFoundException) {
+                    BottomBarManager.showError(
+                        title = resources.getString(R.string.error_title_noEmailAppFound),
+                        message = resources.getString(R.string.error_description_noEmailAppFound),
+                    )
+                }
             }.launchIn(this)
     }
 


### PR DESCRIPTION
Devices without a default email app crash when the user taps 'Open Mail' during email verification. Catches the exception and shows a toast instead.

Fixes Bugsnag 6a3f422fd7a912dd24962554