### PR TITLE
fix: reset IME keyboard mode after sending a message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ serviceAccount.json
 # Maestro screenshot test artifacts
 maestro/screenshots/results/
 maestro/screenshots/diffs/
+
+docs/superpowers/

--- a/apps/flipcash/features/messenger/src/main/kotlin/com/flipcash/app/messenger/internal/ChatViewModel.kt
+++ b/apps/flipcash/features/messenger/src/main/kotlin/com/flipcash/app/messenger/internal/ChatViewModel.kt
@@ -2,6 +2,7 @@ package com.flipcash.app.messenger.internal
 
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.clearText
+import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
 import androidx.compose.runtime.snapshotFlow
 import androidx.lifecycle.viewModelScope
 import androidx.paging.PagingData
@@ -465,7 +466,7 @@ internal class ChatViewModel @Inject constructor(
                 val chatId = stateFlow.value.chatId ?: return@onEach
                 if (textToSend.isBlank()) return@onEach
 
-                stateFlow.value.chatInputState.clearText()
+                stateFlow.value.chatInputState.setTextAndPlaceCursorAtEnd("")
 
                 viewModelScope.launch {
                     chatCoordinator.sendMessage(chatId, textToSend)

--- a/apps/flipcash/features/messenger/src/main/kotlin/com/flipcash/app/messenger/internal/screens/MessengerScreen.kt
+++ b/apps/flipcash/features/messenger/src/main/kotlin/com/flipcash/app/messenger/internal/screens/MessengerScreen.kt
@@ -303,7 +303,10 @@ private fun UserControlBottomBar(
                             focusRequester = focusRequester,
                             hint = "Message",
                             state = state.chatInputState,
-                            onSendMessage = { dispatch(ChatViewModel.Event.SendMessage) },
+                            onSendMessage = {
+                            dispatch(ChatViewModel.Event.SendMessage)
+                            keyboard.restartInput()
+                        },
                         )
 
                         LaunchedEffect(Unit) {

--- a/ui/components/src/main/kotlin/com/getcode/ui/utils/Keyboard.kt
+++ b/ui/components/src/main/kotlin/com/getcode/ui/utils/Keyboard.kt
@@ -1,8 +1,10 @@
 package com.getcode.ui.utils
 
 import android.annotation.SuppressLint
+import android.content.Context
 import android.view.View
 import android.view.ViewTreeObserver
+import android.view.inputmethod.InputMethodManager
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.State
@@ -53,6 +55,12 @@ class KeyboardController(
 
     fun hide() {
         softwareController?.hide()
+    }
+
+    fun restartInput() {
+        val imm = view.context.getSystemService(Context.INPUT_METHOD_SERVICE)
+                as InputMethodManager
+        imm.restartInput(view)
     }
 
     fun hideIfVisible(block: () -> Unit = { }) {


### PR DESCRIPTION
Call InputMethodManager.restartInput() after send to switch the keyboard back from emoji/sticker mode to the standard text input mode.