### PR TITLE
fix: silence ClosedSendChannelException during bidi stream reconnect

### DIFF
--- a/services/opencode/src/main/kotlin/com/getcode/opencode/internal/bidi/OpenStream.kt
+++ b/services/opencode/src/main/kotlin/com/getcode/opencode/internal/bidi/OpenStream.kt
@@ -122,15 +122,23 @@ fun <Request, Response, StreamRef> openBidirectionalStream(
                 requestChannel.send(initialRequest())
                 trace(tag = tag, message = "Initial request sent")
             } catch (e: Exception) {
+                collectionJob.cancel()
+                requestChannel.close()
+                if (e is ClosedSendChannelException) {
+                    // Expected race: the response flow can close the request
+                    // channel (e.g. gRPC TRANSIENT_FAILURE) before the initial
+                    // send completes. Retry silently.
+                    trace(tag = tag, message = "Channel closed before initial request, retrying")
+                    onReconnectAttempt?.invoke(attempt, e)
+                    continue
+                }
                 trace(
                     tag = tag,
                     message = "Failed to send initial request",
                     type = TraceType.Error,
                     error = e
                 )
-                collectionJob.cancel()
-                requestChannel.close()
-                if (isRetryable(e) || e is ClosedSendChannelException) {
+                if (isRetryable(e)) {
                     onReconnectAttempt?.invoke(attempt, e)
                     continue
                 }


### PR DESCRIPTION
When gRPC enters TRANSIENT_FAILURE during a reconnect attempt, the response flow closes the request channel before the initial send completes. This is an expected race condition — handle it silently instead of reporting it to Bugsnag as an error.