### PR TITLE
fix(tokens): resolve token via tokenCoordinator when stateFlow race loses

### DIFF
--- a/apps/flipcash/shared/tokens/src/main/kotlin/com/flipcash/app/tokens/ui/SwapViewModel.kt
+++ b/apps/flipcash/shared/tokens/src/main/kotlin/com/flipcash/app/tokens/ui/SwapViewModel.kt
@@ -599,10 +599,12 @@ class SwapViewModel @Inject constructor(
                         )
                     )
                     dispatchEvent(Event.UpdateBuyState(loading = true))
-                    val token = stateFlow.value.tokenWithBalance?.token ?: run {
-                        handlePhantomError(IllegalStateException("Token not available"))
-                        return@onEach
-                    }
+                    val token = resolveToken()
+                        ?: run {
+                            handlePhantomError(IllegalStateException("Token not available"))
+                            return@onEach
+                        }
+
                     signAndSendPhantomTransaction(token, amountFiat)
                 } catch (e: CancellationException) {
                     throw e
@@ -839,8 +841,7 @@ class SwapViewModel @Inject constructor(
                             )
                         )
                         dispatchEvent(Event.UpdateBuyState(loading = true))
-                        val token = stateFlow.value.tokenWithBalance?.token ?: return@onEach
-
+                        val token = resolveToken() ?: return@onEach
                         executeCoinbasePurchase(amountFiat, token)
                     }
 
@@ -859,6 +860,14 @@ class SwapViewModel @Inject constructor(
                     }
                 }
             }.launchIn(viewModelScope)
+    }
+
+    private suspend fun resolveToken(): Token? {
+        val mint = stateFlow.value.purpose?.mint
+        val token = stateFlow.value.tokenWithBalance?.token
+            ?: mint?.let { tokenCoordinator.getTokenMetadata(it).getOrNull()?.token }
+
+        return token
     }
 
     private suspend fun executeCoinbasePurchase(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -93,7 +93,7 @@ bugsnag-gradle-plugin = "1.1.0"
 rinku = "1.6.0"
 compose-unstyled = "2.8.0"
 haze = "2.0.0-alpha03"
-phantom-connect-kmp = "2.0.2-1.0.0"
+phantom-connect-kmp = "2.0.2-1.0.1"
 vico = "3.2.3"
 
 androidxTestRules = "1.7.0"


### PR DESCRIPTION
The ConfirmPhantomTransaction and Coinbase purchase handlers read stateFlow.value.tokenWithBalance?.token synchronously. After the amount-entry refactor the async combine flow that populates tokenWithBalance can lose the race, leaving the snapshot null.

Extract resolveToken() that falls back to
tokenCoordinator.getTokenMetadata(mint) (memory -> Room -> network) when the flow hasn't delivered yet.

Also bumps phantom-connect-kmp 2.0.2-1.0.0 -> 2.0.2-1.0.1.