### PR TITLE
chore(logging): report all errors to Bugsnag, downgrade non-notifiable severity

### DIFF
--- a/apps/flipcash/app/src/main/kotlin/com/flipcash/app/internal/startup/BugsnagErrorReporter.kt
+++ b/apps/flipcash/app/src/main/kotlin/com/flipcash/app/internal/startup/BugsnagErrorReporter.kt
@@ -1,12 +1,17 @@
 package com.flipcash.app.internal.startup
 
 import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.Severity
 import com.getcode.utils.ErrorReporter
 
 class BugsnagErrorReporter : ErrorReporter {
     override fun report(error: Throwable, cause: Throwable, isNotifiable: Boolean) {
-        if (!isNotifiable) return
         if (!Bugsnag.isStarted()) return
-        Bugsnag.notify(error)
+        Bugsnag.notify(error) { event ->
+            // WARNING = needs active attention (also drives the Slack filter);
+            // INFO = recorded for reference only, excluded from Slack.
+            event.severity = if (isNotifiable) Severity.WARNING else Severity.INFO
+            true
+        }
     }
 }


### PR DESCRIPTION
Previously only notifiable errors reached Bugsnag; everything else was dropped. Now all non-noise errors are reported, with severity derived from isNotifiable: WARNING for notifiable (needs attention), INFO for non-notifiable (reference only). Crashes remain ERROR. Slack routing should filter on severity != INFO to preserve today's notifiable-only behavior.