### PR TITLE
fix(analytics): actually put amount properties in asProperties maps

### DIFF
--- a/apps/flipcash/shared/analytics/src/main/kotlin/com/flipcash/app/analytics/Events.kt
+++ b/apps/flipcash/shared/analytics/src/main/kotlin/com/flipcash/app/analytics/Events.kt
@@ -300,20 +300,20 @@ internal sealed interface AnalyticsEvent {
 internal fun LocalFiat.asProperties(): Map<String, String> {
     return buildMap {
         putAll(underlyingTokenAmount.asProperties())
-        "Fiat" to nativeAmount.decimalValue.toString()
-        "Exchange Rate" to rate.fx.toString()
-        "Currency" to rate.currency.name
-        "Mint" to mint.base58()
+        put("Fiat", nativeAmount.decimalValue.toString())
+        put("Exchange Rate", rate.fx.toString())
+        put("Currency", rate.currency.name)
+        put("Mint", mint.base58())
     }
 }
 
 
 internal fun Fiat.asProperties(): Map<String, String> {
     return buildMap {
-        "Fiat" to decimalValue.toString()
-        "Currency" to currencyCode.name
-        "USDC" to decimalValue.toString()
-        "Quarks" to quarks.toDouble().toString()
+        put("Fiat", decimalValue.toString())
+        put("Currency", currencyCode.name)
+        put("USDC", decimalValue.toString())
+        put("Quarks", quarks.toDouble().toString())
     }
 }
 


### PR DESCRIPTION
## Summary

`Fiat.asProperties()` and `LocalFiat.asProperties()` in `shared/analytics` built their entries with bare `"key" to value` expressions inside `buildMap` — creating `Pair`s and immediately discarding them instead of calling `put()`. Both helpers returned **empty maps**.

As a result, every analytics event that attaches an amount has been reaching Mixpanel with no amount data at all:

- All `transfer()` events — Grab Bill, Give Bill, Withdrawal, Sent Cash, Send/Receive Cash Link — missing `Fiat`/`Currency`/`USDC`/`Quarks` (and `Exchange Rate`/`Mint` for local fiat amounts)
- Onramp purchase events (`Invoke Payment`, `Completed`)
- Wallet events (`Wallet: Request Amount`)

## Fix

Use `put()` inside `buildMap`. No call-site changes — properties flow through the existing `track()` plumbing.

## Testing

- `:apps:flipcash:shared:analytics` compiles and unit tests pass