### PR TITLE
fix(contact-verification): pass analytics param in PhoneVerificationViewModel tests

### DIFF
--- a/apps/flipcash/features/contact-verification/src/test/kotlin/com/flipcash/app/contact/verification/internal/phone/PhoneVerificationViewModelErrorTest.kt
+++ b/apps/flipcash/features/contact-verification/src/test/kotlin/com/flipcash/app/contact/verification/internal/phone/PhoneVerificationViewModelErrorTest.kt
@@ -59,6 +59,7 @@ class PhoneVerificationViewModelErrorTest {
             featureFlags = featureFlags,
             resources = resources,
             dispatchers = dispatchers,
+            analytics = mockk(relaxed = true),
         )
     }
 

--- a/apps/flipcash/features/contact-verification/src/test/kotlin/com/flipcash/app/contact/verification/internal/phone/PhoneVerificationViewModelTest.kt
+++ b/apps/flipcash/features/contact-verification/src/test/kotlin/com/flipcash/app/contact/verification/internal/phone/PhoneVerificationViewModelTest.kt
@@ -50,6 +50,7 @@ class PhoneVerificationViewModelTest {
         featureFlags = featureFlags,
         resources = resources,
         dispatchers = dispatchers,
+        analytics = mockk(relaxed = true),
     )
 
     /**


### PR DESCRIPTION
## Summary

CI on `code/cash` is red because `:apps:flipcash:features:contact-verification:compileDebugUnitTestKotlin` fails to compile:

```
PhoneVerificationViewModelErrorTest.kt:61:13 No value passed for parameter 'analytics'.
PhoneVerificationViewModelTest.kt:52:9 No value passed for parameter 'analytics'.
```

The phone verification funnel analytics work (#1076) added a required `analytics: FlipcashAnalyticsService` constructor parameter to `PhoneVerificationViewModel`, but the two unit-test factories that construct the view model were never updated. Because the analytics PR and the failing PR (#1077) landed independently, neither surfaced the break until both were on `code/cash`.

## Fix

Pass a relaxed mock (`mockk(relaxed = true)`) for `analytics` in both test factories. No production code changes.

## Testing

```
./gradlew :apps:flipcash:features:contact-verification:testDebugUnitTest
BUILD SUCCESSFUL
```