### PR TITLE
fix(onboarding): gate USDF account provisioning, harden Create Account UX, resume phone verification, and trace the flow

### DIFF
--- a/apps/flipcash/app/src/main/kotlin/com/flipcash/app/internal/ui/navigation/MainRoot.kt
+++ b/apps/flipcash/app/src/main/kotlin/com/flipcash/app/internal/ui/navigation/MainRoot.kt
@@ -186,13 +186,27 @@ internal fun buildNavGraphForLaunch(
     deepLink: () -> DeepLink?,
 ): LaunchNavGraph? {
     return when (state) {
-        is AuthState.Onboarding -> {
-            val resumePoint = when (state.resumePoint) {
-                AuthState.ResumePoint.AccessKey -> AppRoute.OnboardingFlow.ResumePoint.AccessKey
-                AuthState.ResumePoint.AccessKeyThenPurchase -> AppRoute.OnboardingFlow.ResumePoint.AccessKeyThenPurchase
-                AuthState.ResumePoint.PostAccessKey -> AppRoute.OnboardingFlow.ResumePoint.PostAccessKey
-            }
-            LaunchNavGraph(listOf(AppRoute.OnboardingFlow(resumeAt = resumePoint)))
+        is AuthState.Onboarding -> when (state.resumePoint) {
+            // Resume directly into phone verification; on success it replaces the
+            // stack with the access-key resume (see VerificationFlowScreen target).
+            AuthState.ResumePoint.PhoneNumber -> LaunchNavGraph(
+                listOf(
+                    AppRoute.Verification(
+                        origin = AppRoute.OnboardingFlow(),
+                        includePhone = true,
+                        includeEmail = false,
+                        target = AppRoute.OnboardingFlow(resumeAt = AppRoute.OnboardingFlow.ResumePoint.AccessKey),
+                        fullScreen = true,
+                    )
+                )
+            )
+
+            AuthState.ResumePoint.AccessKey ->
+                LaunchNavGraph(listOf(AppRoute.OnboardingFlow(resumeAt = AppRoute.OnboardingFlow.ResumePoint.AccessKey)))
+            AuthState.ResumePoint.AccessKeyThenPurchase ->
+                LaunchNavGraph(listOf(AppRoute.OnboardingFlow(resumeAt = AppRoute.OnboardingFlow.ResumePoint.AccessKeyThenPurchase)))
+            AuthState.ResumePoint.PostAccessKey ->
+                LaunchNavGraph(listOf(AppRoute.OnboardingFlow(resumeAt = AppRoute.OnboardingFlow.ResumePoint.PostAccessKey)))
         }
 
         AuthState.Ready -> {

--- a/apps/flipcash/app/src/test/kotlin/com/flipcash/app/internal/ui/navigation/BuildNavGraphForLaunchTest.kt
+++ b/apps/flipcash/app/src/test/kotlin/com/flipcash/app/internal/ui/navigation/BuildNavGraphForLaunchTest.kt
@@ -150,6 +150,16 @@ class BuildNavGraphForLaunchTest {
         assertEquals(AppRoute.OnboardingFlow.ResumePoint.AccessKeyThenPurchase, route.resumeAt)
     }
 
+    @Test
+    fun `onboarding at PhoneNumber resume point routes to phone verification then access key`() {
+        val result = build(AuthState.Onboarding(AuthState.ResumePoint.PhoneNumber))!!
+        val route = assertIs<AppRoute.Verification>(result.baseRoutes.single())
+        assertTrue(route.includePhone)
+        assertEquals(false, route.includeEmail)
+        val target = assertIs<AppRoute.OnboardingFlow>(route.target)
+        assertEquals(AppRoute.OnboardingFlow.ResumePoint.AccessKey, target.resumeAt)
+    }
+
     // -- Authenticating --
 
     @Test

--- a/apps/flipcash/core/src/main/res/values/strings.xml
+++ b/apps/flipcash/core/src/main/res/values/strings.xml
@@ -13,6 +13,9 @@
     <string name="action_tryDifferentFlipcashAccount">Try a Different Flipcash Account</string>
     <string name="error_title_createAccountFailed">Create Account Failed</string>
     <string name="error_description_createAccountFailed">Something went wrong</string>
+    <string name="error_title_accountSetupFailed">Account setup incomplete</string>
+    <string name="error_description_accountSetupFailed">We couldn\'t finish setting up your account. Please check your connection and try again.</string>
+    <string name="error_description_accountSetupFailedAfterPurchase">Your purchase went through but we couldn\'t finish setting up your account. Please check your connection and try again.</string>
     <string name="error_title_loginFailed">Login Failed</string>
     <string name="error_description_loginFailed">Something went wrong</string>
 

--- a/apps/flipcash/features/contact-verification/src/main/kotlin/com/flipcash/app/contact/verification/internal/phone/PhoneVerificationViewModel.kt
+++ b/apps/flipcash/features/contact-verification/src/main/kotlin/com/flipcash/app/contact/verification/internal/phone/PhoneVerificationViewModel.kt
@@ -15,6 +15,7 @@ import com.flipcash.libs.coroutines.DispatcherProvider
 import com.flipcash.services.controllers.ContactVerificationController
 import com.flipcash.services.controllers.ProfileController
 import com.flipcash.services.models.ContactMethod
+import com.flipcash.services.user.AuthState
 import com.flipcash.services.user.UserManager
 import com.flipcash.services.models.PhoneVerificationError
 import com.getcode.manager.BottomBarManager
@@ -111,7 +112,14 @@ internal class PhoneVerificationViewModel @Inject constructor(
 
     private var timer: Timer? = null
 
+    // Composite trace tag so verification steps that happen during onboarding read as
+    // "[Onboarding · Verification]" (matched by both an "\[Onboarding" and a
+    // "Verification" grep), and as plain "[Verification]" when linking a phone later.
+    private val traceTag: String
+        get() = if (userManager.authState is AuthState.Onboarding) "Onboarding · Verification" else "Verification"
+
     init {
+        trace(tag = traceTag, message = "Phone verification started", type = TraceType.Process)
         viewModelScope.launch {
             // PhoneUtils is normally pre-warmed at app startup, so ensureLoaded()
             // is typically a cheap no-op. Input observation is intentionally started
@@ -124,7 +132,7 @@ internal class PhoneVerificationViewModel @Inject constructor(
             } catch (e: Exception) {
                 // Metadata load failed; continue with the Stub locale. Input still
                 // functions (formatting may be degraded until a later load succeeds).
-                trace(message = "PhoneUtils.ensureLoaded failed: $e", type = TraceType.Error)
+                trace(tag = traceTag, message = "PhoneUtils.ensureLoaded failed: $e", type = TraceType.Error)
             }
             dispatchEvent(Event.OnCountryLocalesLoaded(phoneUtils.countryLocales))
             val loaded = phoneUtils.defaultCountryLocale
@@ -165,14 +173,14 @@ internal class PhoneVerificationViewModel @Inject constructor(
                 ContactMethod.Phone(cleanedNumber)
             }
             .onEach {
-                trace(message = "Verifying code", type = TraceType.Process)
+                trace(tag = traceTag, message = "Verifying code", type = TraceType.Process)
                 dispatchEvent(Event.OnVerifyingCodeChanged(loading = true))
             }
             .map { method ->
                 verificationController.checkVerificationCode(method, stateFlow.value.codeTextFieldState.text.toString())
             }.onResult(
                 onSuccess = {
-                    trace(message = "Code verified successfully", type = TraceType.Process)
+                    trace(tag = traceTag, message = "Code verified successfully", type = TraceType.Process)
                     stopTimer()
                     dispatchEvent(Event.OnVerifyingCodeChanged(success = true))
                     viewModelScope.launch {
@@ -187,7 +195,7 @@ internal class PhoneVerificationViewModel @Inject constructor(
                     }
                 },
                 onError = { cause ->
-                    trace(message = "Code verification failed: $cause", type = TraceType.Error)
+                    trace(tag = traceTag, message = "Code verification failed: $cause", type = TraceType.Error)
                     dispatchEvent(Event.OnVerifyingCodeChanged())
                     val (title, message) = when (cause) {
                         is PhoneVerificationError -> when (cause) {
@@ -224,13 +232,13 @@ internal class PhoneVerificationViewModel @Inject constructor(
                 val number = stateFlow.value.numberTextFieldState.text.toString()
                 val locale = stateFlow.value.selectedLocale
                 val cleanedNumber = phoneUtils.cleanNumber(number, locale)
-                trace(message = "Calling linkForPayment", type = TraceType.Process)
+                trace(tag = traceTag, message = "Calling linkForPayment", type = TraceType.Process)
                 ContactMethod.Phone(cleanedNumber)
             }
             .map { method -> verificationController.linkForPayment(method) }
             .onResult(
                 onSuccess = {
-                    trace(message = "linkForPayment succeeded", type = TraceType.Process)
+                    trace(tag = traceTag, message = "linkForPayment succeeded", type = TraceType.Process)
                     analytics.action(Action.LinkedPhoneNumber)
                     dispatchEvent(Event.OnPhoneVerificationComplete)
                 },
@@ -295,6 +303,7 @@ internal class PhoneVerificationViewModel @Inject constructor(
     private suspend fun handleSendVerificationCode(method: ContactMethod, isResend: Boolean) {
         dispatchEvent(Event.OnSendingCodeChanged(loading = true))
         if (stateFlow.value.attempts >= 3) {
+            trace(tag = traceTag, message = "Max verification attempts reached", type = TraceType.Error)
             dispatchEvent(Event.OnSendingCodeChanged())
             BottomBarManager.showAlert(
                 title = resources.getString(R.string.error_title_maxAttemptsReached),
@@ -309,8 +318,10 @@ internal class PhoneVerificationViewModel @Inject constructor(
             analytics.action(Action.EnteredPhoneNumber)
         }
 
+        trace(tag = traceTag, message = if (isResend) "Resending verification code" else "Sending verification code", type = TraceType.Process)
         verificationController.sendVerificationCode(method)
             .onSuccess {
+                trace(tag = traceTag, message = "Verification code sent", type = TraceType.Process)
                 dispatchEvent(Event.OnSendingCodeChanged(success = true))
                 viewModelScope.launch {
                     delay(1.seconds)
@@ -320,6 +331,7 @@ internal class PhoneVerificationViewModel @Inject constructor(
                 startTimer()
             }
             .onFailure { error ->
+                trace(tag = traceTag, message = "Failed to send verification code: $error", type = TraceType.Error)
                 val (title, message) = when (error) {
                     is PhoneVerificationError -> when (error) {
                         is PhoneVerificationError.Denied -> null to null

--- a/apps/flipcash/features/login/build.gradle.kts
+++ b/apps/flipcash/features/login/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
     testImplementation(libs.bundles.unit.testing)
     testImplementation(testFixtures(project(":ui:resources")))
     testImplementation(libs.mockito.kotlin)
+    testImplementation(libs.bundles.compose.ui.testing)
 
     implementation(project(":apps:flipcash:shared:accesskey"))
     implementation(project(":apps:flipcash:shared:analytics"))

--- a/apps/flipcash/features/login/src/main/kotlin/com/flipcash/app/login/OnboardingFlowScreen.kt
+++ b/apps/flipcash/features/login/src/main/kotlin/com/flipcash/app/login/OnboardingFlowScreen.kt
@@ -49,6 +49,8 @@ import com.flipcash.app.purchase.internal.PurchaseAccountViewModel
 import com.flipcash.features.login.R
 import com.flipcash.services.user.AuthState
 import com.getcode.libs.analytics.LocalAnalytics
+import com.getcode.utils.TraceType
+import com.getcode.utils.trace
 import com.getcode.navigation.annotatedEntry
 import com.getcode.navigation.core.LocalCodeNavigator
 import com.getcode.navigation.core.NavOptions
@@ -68,6 +70,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlin.time.Duration.Companion.milliseconds
 
 /**
  * Entry point for the unified onboarding flow.
@@ -180,6 +183,7 @@ private fun PermissionsPhaseFlowHost(
             when (reason) {
                 is FlowExitReason.Completed -> {
                     analytics.action(Action.CompletedOnboarding)
+                    trace(tag = "Onboarding", message = "Onboarding complete — releasing to scanner", type = TraceType.Process)
                     userManager?.set(AuthState.Ready)
                     outerNavigator.navigate(
                         route = AppRoute.Main.Scanner,
@@ -189,6 +193,7 @@ private fun PermissionsPhaseFlowHost(
 
                 FlowExitReason.BackedOutOfRoot -> {
                     // All permissions already granted
+                    trace(tag = "Onboarding", message = "Onboarding complete (permissions already granted) — releasing to scanner", type = TraceType.Process)
                     userManager?.set(AuthState.Ready)
                     outerNavigator.navigate(
                         route = AppRoute.Main.Scanner,
@@ -292,9 +297,10 @@ private fun LoginStepContent(seed: String?) {
 
     LaunchedEffect(vm) {
         vm.eventFlow
-            .filterIsInstance<LoginViewModel.Event.OnAccountCreated>()
+            .filterIsInstance<LoginViewModel.Event.CreateAccountSettled>()
             .onEach {
                 if (state.needsPhoneVerification) {
+                    trace(tag = "Onboarding", message = "Account created — navigating to phone verification", type = TraceType.Process)
                     flowNavigator.navigate(
                         AppRoute.Verification(
                             origin = AppRoute.OnboardingFlow(),
@@ -307,6 +313,7 @@ private fun LoginStepContent(seed: String?) {
                         )
                     )
                 } else {
+                    trace(tag = "Onboarding", message = "Account created — navigating to access key", type = TraceType.Process)
                     flowNavigator.navigateTo(OnboardingStep.AccessKey)
                 }
             }
@@ -316,7 +323,7 @@ private fun LoginStepContent(seed: String?) {
     LaunchedEffect(vm) {
         vm.eventFlow
             .filterIsInstance<LoginViewModel.Event.LoggedInSuccessfully>()
-            .onEach { delay(500) }
+            .onEach { delay(500.milliseconds) }
             .onEach { flowNavigator.exitWithResult(OnboardingResult.LoggedIn) }
             .launchIn(this)
     }
@@ -324,7 +331,7 @@ private fun LoginStepContent(seed: String?) {
     LaunchedEffect(vm) {
         vm.eventFlow
             .filterIsInstance<LoginViewModel.Event.LoggedInRequiresPayment>()
-            .onEach { delay(500) }
+            .onEach { delay(500.milliseconds) }
             .onEach {
                 flowNavigator.replaceStack(
                     listOf(

--- a/apps/flipcash/features/login/src/main/kotlin/com/flipcash/app/login/OnboardingFlowScreen.kt
+++ b/apps/flipcash/features/login/src/main/kotlin/com/flipcash/app/login/OnboardingFlowScreen.kt
@@ -349,6 +349,7 @@ private fun LoginStepContent(seed: String?) {
     ) {
         LoginRouterScreenContent(
             isLoggingIn = state.loggingIn,
+            isCreatingAccount = state.creatingAccount,
             createAccount = { vm.dispatchEvent(LoginViewModel.Event.CreateAccount) },
             login = { flowNavigator.navigateTo(OnboardingStep.SeedInput) },
             isLabsOpen = state.betaOptionsVisible,

--- a/apps/flipcash/features/login/src/main/kotlin/com/flipcash/app/login/internal/LoginAccessKeyViewModel.kt
+++ b/apps/flipcash/features/login/src/main/kotlin/com/flipcash/app/login/internal/LoginAccessKeyViewModel.kt
@@ -9,8 +9,10 @@ import com.flipcash.app.core.storage.MediaSaver
 import com.flipcash.app.featureflags.FeatureFlag
 import com.flipcash.app.featureflags.FeatureFlagController
 import com.flipcash.app.userflags.UserFlagsCoordinator
+import com.flipcash.features.login.R
 import com.flipcash.services.user.UserManager
 import com.getcode.libs.qr.QRCodeGenerator
+import com.getcode.manager.BottomBarManager
 import com.getcode.opencode.managers.MnemonicManager
 import com.getcode.util.resources.ResourceHelper
 import com.getcode.view.LoadingSuccessState
@@ -21,7 +23,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 internal class LoginAccessKeyViewModel @Inject constructor(
-    resources: ResourceHelper,
+    private val resources: ResourceHelper,
     mnemonicManager: MnemonicManager,
     qrCodeGenerator: QRCodeGenerator,
     mediaSaver: MediaSaver,
@@ -39,9 +41,20 @@ internal class LoginAccessKeyViewModel @Inject constructor(
         return runCatching {
             authManager.onUserAccessKeySeen()
             authManager.presentCredentialStorage()
+            val requiresIap = userFlags.resolvedFlags.value.requiresIapForRegistration.effectiveValue
+            if (!requiresIap) {
+                // Gate: provision the core account before advancing. On failure this
+                // throws, runCatching yields Result.failure, and the screen stays put.
+                authManager.ensureCoreAccountProvisioned()
+                    .onFailure { showAccountSetupError() }
+                    .getOrThrow()
+            }
             delay(150)
             uiFlow.update { s -> s.copy(skipState = LoadingSuccessState(success = true)) }
-            userFlags.resolvedFlags.value.requiresIapForRegistration.effectiveValue
+            requiresIap
+        }.onFailure {
+            // Reset the spinner so the button is tappable again to retry.
+            uiFlow.update { s -> s.copy(skipState = LoadingSuccessState()) }
         }
     }
 
@@ -51,10 +64,25 @@ internal class LoginAccessKeyViewModel @Inject constructor(
             .onSuccess { authManager.onUserAccessKeySeen() }
             .mapCatching {
                 authManager.presentCredentialStorage()
+                val requiresIap = userFlags.resolvedFlags.value.requiresIapForRegistration.effectiveValue
+                if (!requiresIap) {
+                    // Gate: provision the core account before advancing. On failure this
+                    // throws, mapCatching yields Result.failure, and the screen stays put.
+                    authManager.ensureCoreAccountProvisioned()
+                        .onFailure { showAccountSetupError() }
+                        .getOrThrow()
+                }
                 delay(150)
                 uiFlow.update { s -> s.copy(exportState = LoadingSuccessState(success = true)) }
-                userFlags.resolvedFlags.value.requiresIapForRegistration.effectiveValue
+                requiresIap
             }
+    }
+
+    private fun showAccountSetupError() {
+        BottomBarManager.showError(
+            title = resources.getString(R.string.error_title_accountSetupFailed),
+            message = resources.getString(R.string.error_description_accountSetupFailed),
+        )
     }
 
     private fun trackButton(button: Button): Result<Unit> {

--- a/apps/flipcash/features/login/src/main/kotlin/com/flipcash/app/login/internal/screens/LoginScreenContent.kt
+++ b/apps/flipcash/features/login/src/main/kotlin/com/flipcash/app/login/internal/screens/LoginScreenContent.kt
@@ -41,6 +41,7 @@ import com.getcode.view.LoadingSuccessState
 @Composable
 internal fun LoginRouterScreenContent(
     isLoggingIn: LoadingSuccessState = LoadingSuccessState(),
+    isCreatingAccount: LoadingSuccessState = LoadingSuccessState(),
     isLabsOpen: Boolean,
     createAccount: () -> Unit,
     login: () -> Unit,
@@ -77,7 +78,9 @@ internal fun LoginRouterScreenContent(
                     .fillMaxWidth()
                     .padding(horizontal = CodeTheme.dimens.inset)
                     .testTag("create_account_button"),
-                enabled = !isLoggingIn.loading && !isLoggingIn.success,
+                enabled = !isCreatingAccount.loading && !isCreatingAccount.success && !isLoggingIn.loading,
+                isLoading = isCreatingAccount.loading,
+                isSuccess = isCreatingAccount.success,
                 onClick = createAccount,
                 text = stringResource(R.string.action_createNewAccount),
                 buttonState = ButtonState.Filled,

--- a/apps/flipcash/features/login/src/main/kotlin/com/flipcash/app/login/router/LoginViewModel.kt
+++ b/apps/flipcash/features/login/src/main/kotlin/com/flipcash/app/login/router/LoginViewModel.kt
@@ -25,7 +25,10 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.onEach
 import com.getcode.vendor.Base58
+import kotlinx.coroutines.delay
+import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Inject
+import kotlin.time.Duration.Companion.seconds
 
 @HiltViewModel
 class LoginViewModel @Inject constructor(
@@ -44,6 +47,7 @@ class LoginViewModel @Inject constructor(
     data class State(
         val followerModeEnabled: Boolean = false,
         val loggingIn: LoadingSuccessState = LoadingSuccessState(),
+        val creatingAccount: LoadingSuccessState = LoadingSuccessState(),
         val logoTapCount: Int = 0,
         val betaOptionsVisible: Boolean = false,
         val needsPhoneVerification: Boolean = false,
@@ -59,9 +63,12 @@ class LoginViewModel @Inject constructor(
         data object LoggedInRequiresPayment : Event
         data object LogInFailed : Event
         data object OnAccountCreated : Event
+        data object CreateAccountSettled : Event
         data object CreateFailed : Event
         data class PhoneVerificationUpdated(val needed: Boolean) : Event
     }
+
+    private val createInFlight = AtomicBoolean(false)
 
     init {
         combine(
@@ -85,18 +92,27 @@ class LoginViewModel @Inject constructor(
 
         eventFlow
             .filterIsInstance<Event.CreateAccount>()
+            .filter { createInFlight.compareAndSet(false, true) }
             .onEach { analytics.buttonTapped(Button.CreateAccount) }
-            .map {
-                authManager.createAccount()
-                    .onFailure {
-                        dispatchEvent(Event.CreateFailed)
-                        BottomBarManager.showError(
-                            title = resources.getString(R.string.error_title_createAccountFailed),
-                            message = it.localizedMessage ?: resources.getString(R.string.error_description_createAccountFailed)
-                        )
-                    }.onSuccess {
-                        dispatchEvent(Event.OnAccountCreated)
-                    }
+            .onEach {
+                try {
+                    authManager.createAccount()
+                        .onFailure {
+                            dispatchEvent(Event.CreateFailed)
+                            BottomBarManager.showError(
+                                title = resources.getString(R.string.error_title_createAccountFailed),
+                                message = it.localizedMessage ?: resources.getString(R.string.error_description_createAccountFailed)
+                            )
+                        }.onSuccess {
+                            dispatchEvent(Event.OnAccountCreated)
+                            // Show the success state briefly, then settle back to idle
+                            // as the flow navigates on to the next onboarding step.
+                            delay(1.seconds)
+                            dispatchEvent(Event.CreateAccountSettled)
+                        }
+                } finally {
+                    createInFlight.set(false)
+                }
             }
             .launchIn(viewModelScope)
 
@@ -170,9 +186,10 @@ class LoginViewModel @Inject constructor(
         private const val TAP_THRESHOLD = 6
         val updateStateForEvent: (Event) -> ((State) -> State) = { event ->
             when (event) {
-                Event.CreateAccount -> { state -> state }
-                Event.OnAccountCreated -> { state -> state }
-                Event.CreateFailed -> { state -> state }
+                Event.CreateAccount -> { state -> state.copy(creatingAccount = LoadingSuccessState(loading = true)) }
+                Event.OnAccountCreated -> { state -> state.copy(creatingAccount = LoadingSuccessState(loading = false, success = true)) }
+                Event.CreateAccountSettled -> { state -> state.copy(creatingAccount = LoadingSuccessState()) }
+                Event.CreateFailed -> { state -> state.copy(creatingAccount = LoadingSuccessState(loading = false)) }
 
                 is Event.BetaOptionsUnlocked -> { state -> state.copy(betaOptionsVisible = true) }
                 is Event.OnLogoTapped -> { state ->

--- a/apps/flipcash/features/login/src/main/kotlin/com/flipcash/app/login/router/LoginViewModel.kt
+++ b/apps/flipcash/features/login/src/main/kotlin/com/flipcash/app/login/router/LoginViewModel.kt
@@ -26,6 +26,7 @@ import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.onEach
 import com.getcode.vendor.Base58
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.seconds
@@ -101,14 +102,15 @@ class LoginViewModel @Inject constructor(
                             dispatchEvent(Event.CreateFailed)
                             BottomBarManager.showError(
                                 title = resources.getString(R.string.error_title_createAccountFailed),
-                                message = it.localizedMessage ?: resources.getString(R.string.error_description_createAccountFailed)
+                                message = resources.getString(R.string.error_description_createAccountFailed)
                             )
                         }.onSuccess {
+                            viewModelScope.launch {
+                                // Show the success state briefly, then settle back to idle
+                                // as the flow navigates on to the next onboarding step.
+                                delay(1.seconds)
+                                dispatchEvent(Event.CreateAccountSettled) }
                             dispatchEvent(Event.OnAccountCreated)
-                            // Show the success state briefly, then settle back to idle
-                            // as the flow navigates on to the next onboarding step.
-                            delay(1.seconds)
-                            dispatchEvent(Event.CreateAccountSettled)
                         }
                 } finally {
                     createInFlight.set(false)

--- a/apps/flipcash/features/login/src/test/kotlin/com/flipcash/app/login/internal/LoginAccessKeyViewModelTest.kt
+++ b/apps/flipcash/features/login/src/test/kotlin/com/flipcash/app/login/internal/LoginAccessKeyViewModelTest.kt
@@ -1,0 +1,118 @@
+package com.flipcash.app.login.internal
+
+import com.flipcash.app.analytics.FlipcashAnalyticsService
+import com.flipcash.app.auth.AuthManager
+import com.flipcash.app.core.MainCoroutineRule
+import com.flipcash.app.core.dispatchers.TestDispatchers
+import com.flipcash.app.core.storage.MediaSaver
+import com.flipcash.app.featureflags.FeatureFlagController
+import com.flipcash.app.userflags.UserFlagsCoordinator
+import com.flipcash.services.user.UserManager
+import com.getcode.libs.qr.QRCodeGenerator
+import com.getcode.manager.BottomBarManager
+import com.getcode.opencode.managers.MnemonicManager
+import com.getcode.util.resources.FakeResourceHelper
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verifyBlocking
+import org.mockito.kotlin.whenever
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Verifies the onboarding provisioning GATE at the access-key step: the core OCP
+ * account must be provisioned before the user advances (free path), and a failed
+ * provisioning must block advancement instead of releasing to the scanner.
+ * Uses [onWroteDownInstead] ("I wrote it down" / continue-without) which exercises
+ * the identical gate code path as save-to-photos without bitmap rendering.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class LoginAccessKeyViewModelTest {
+
+    @get:Rule
+    var mainCoroutineRule = MainCoroutineRule(UnconfinedTestDispatcher())
+
+    // Mockito for the Result-returning suspend method (MockK double-boxes Result).
+    private val authManager: AuthManager = mock()
+
+    // MockK for the rest.
+    private val resources = FakeResourceHelper()
+    private val mnemonicManager: MnemonicManager = mockk(relaxed = true)
+    private val qrCodeGenerator: QRCodeGenerator = mockk(relaxed = true)
+    private val mediaSaver: MediaSaver = mockk(relaxed = true)
+    private val userManager: UserManager = mockk(relaxed = true)
+    private val userFlags: UserFlagsCoordinator = mockk(relaxed = true)
+    private val featureFlags: FeatureFlagController = mockk(relaxed = true)
+    private val analytics: FlipcashAnalyticsService = mockk(relaxed = true)
+
+    private lateinit var dispatchers: TestDispatchers
+
+    @Before
+    fun setUp() = BottomBarManager.clear()
+
+    @After
+    fun tearDown() = BottomBarManager.clear()
+
+    private fun createViewModel() = LoginAccessKeyViewModel(
+        resources = resources,
+        mnemonicManager = mnemonicManager,
+        qrCodeGenerator = qrCodeGenerator,
+        mediaSaver = mediaSaver,
+        userManager = userManager,
+        dispatchers = dispatchers,
+        userFlags = userFlags,
+        featureFlags = featureFlags,
+        authManager = authManager,
+        analytics = analytics,
+    )
+
+    @Test
+    fun `provisions and advances on success when not IAP`() = runTest(mainCoroutineRule.dispatcher) {
+        dispatchers = TestDispatchers(testScheduler)
+        every { userFlags.resolvedFlags.value.requiresIapForRegistration.effectiveValue } returns false
+        whenever(authManager.ensureCoreAccountProvisioned()).thenReturn(Result.success(Unit))
+        val viewModel = createViewModel()
+
+        val result = viewModel.onWroteDownInstead()
+
+        assertTrue(result.isSuccess)
+        assertFalse(result.getOrThrow()) // requiresIap == false
+        verifyBlocking(authManager) { ensureCoreAccountProvisioned() }
+    }
+
+    @Test
+    fun `blocks with failure and error when provisioning is denied`() = runTest(mainCoroutineRule.dispatcher) {
+        dispatchers = TestDispatchers(testScheduler)
+        every { userFlags.resolvedFlags.value.requiresIapForRegistration.effectiveValue } returns false
+        whenever(authManager.ensureCoreAccountProvisioned())
+            .thenReturn(Result.failure(RuntimeException("antispam denied")))
+        val viewModel = createViewModel()
+
+        val result = viewModel.onWroteDownInstead()
+
+        assertTrue(result.isFailure) // gate: screen will NOT call onCompleted -> stays put
+        assertTrue(BottomBarManager.messages.value.any { it.title == "error_title_accountSetupFailed" })
+    }
+
+    @Test
+    fun `skips provisioning when IAP is required`() = runTest(mainCoroutineRule.dispatcher) {
+        dispatchers = TestDispatchers(testScheduler)
+        every { userFlags.resolvedFlags.value.requiresIapForRegistration.effectiveValue } returns true
+        val viewModel = createViewModel()
+
+        val result = viewModel.onWroteDownInstead()
+
+        assertTrue(result.isSuccess)
+        assertTrue(result.getOrThrow()) // requiresIap == true
+        verifyBlocking(authManager, never()) { ensureCoreAccountProvisioned() }
+    }
+}

--- a/apps/flipcash/features/login/src/test/kotlin/com/flipcash/app/login/internal/screens/LoginScreenContentTest.kt
+++ b/apps/flipcash/features/login/src/test/kotlin/com/flipcash/app/login/internal/screens/LoginScreenContentTest.kt
@@ -1,0 +1,64 @@
+package com.flipcash.app.login.internal.screens
+
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import com.getcode.theme.DesignSystem
+import com.getcode.view.LoadingSuccessState
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.assertTrue
+
+/**
+ * UI-level regression guard for the Create Account button: it must be tappable when
+ * idle and DISABLED while creating (which is what debounces the double-taps the
+ * tester hit on the slow first run).
+ */
+@RunWith(RobolectricTestRunner::class)
+class LoginScreenContentTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private fun setScreen(
+        isCreatingAccount: LoadingSuccessState,
+        onCreate: () -> Unit = {},
+    ) {
+        composeTestRule.setContent {
+            DesignSystem {
+                LoginRouterScreenContent(
+                    isLoggingIn = LoadingSuccessState(),
+                    isCreatingAccount = isCreatingAccount,
+                    isLabsOpen = false,
+                    createAccount = onCreate,
+                    login = {},
+                    onLogoTapped = {},
+                    openBetaFlags = {},
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `create account button is enabled and clickable when idle`() {
+        var clicked = false
+        setScreen(isCreatingAccount = LoadingSuccessState(), onCreate = { clicked = true })
+
+        composeTestRule.onNodeWithTag("create_account_button")
+            .assertIsEnabled()
+            .performClick()
+
+        assertTrue(clicked)
+    }
+
+    @Test
+    fun `create account button is disabled while creating`() {
+        setScreen(isCreatingAccount = LoadingSuccessState(loading = true))
+
+        composeTestRule.onNodeWithTag("create_account_button").assertIsNotEnabled()
+    }
+}

--- a/apps/flipcash/features/login/src/test/kotlin/com/flipcash/app/login/router/LoginViewModelCreateAccountTest.kt
+++ b/apps/flipcash/features/login/src/test/kotlin/com/flipcash/app/login/router/LoginViewModelCreateAccountTest.kt
@@ -1,0 +1,121 @@
+package com.flipcash.app.login.router
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.flipcash.app.analytics.FlipcashAnalyticsService
+import com.flipcash.app.auth.AuthManager
+import com.flipcash.app.core.MainCoroutineRule
+import com.flipcash.app.core.dispatchers.TestDispatchers
+import com.flipcash.app.featureflags.FeatureFlagController
+import com.flipcash.services.controllers.AccountController
+import com.flipcash.services.user.UserManager
+import com.getcode.manager.BottomBarManager
+import com.getcode.util.resources.FakeResourceHelper
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Covers the Create Account button loading/lifecycle (the "tapped, nothing happened,
+ * tapped again" fix). The disabled-while-loading behaviour is verified at the UI
+ * layer in [com.flipcash.app.login.internal.screens.LoginScreenContentTest].
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class LoginViewModelCreateAccountTest {
+
+    @get:Rule
+    val instantExecutorRule = InstantTaskExecutorRule()
+
+    @get:Rule
+    var mainCoroutineRule = MainCoroutineRule(UnconfinedTestDispatcher())
+
+    private val authManager: AuthManager = mock()
+    private val accounts: AccountController = mock()
+    private val resources = FakeResourceHelper()
+    private val analytics: FlipcashAnalyticsService = mockk(relaxed = true)
+    private val userManager: UserManager = mockk(relaxed = true)
+    private val featureFlags: FeatureFlagController = mockk(relaxed = true)
+
+    private lateinit var dispatchers: TestDispatchers
+
+    @Before
+    fun setUp() {
+        BottomBarManager.clear()
+        mockkStatic(android.util.Base64::class)
+        every { android.util.Base64.encodeToString(any(), any()) } answers { java.util.Base64.getEncoder().encodeToString(firstArg()) }
+    }
+
+    @After
+    fun tearDown() {
+        BottomBarManager.clear()
+        unmockkStatic(android.util.Base64::class)
+    }
+
+    private fun createViewModel() = LoginViewModel(
+        authManager = authManager,
+        accounts = accounts,
+        resources = resources,
+        analytics = analytics,
+        userManager = userManager,
+        featureFlags = featureFlags,
+        dispatchers = dispatchers,
+    )
+
+    @Test
+    fun `CreateAccount immediately shows loading so the button disables`() = runTest(mainCoroutineRule.dispatcher) {
+        dispatchers = TestDispatchers(testScheduler)
+        whenever(authManager.createAccount()).thenReturn(Result.success(Unit))
+        val viewModel = createViewModel()
+
+        viewModel.dispatchEvent(LoginViewModel.Event.CreateAccount)
+        // No advanceUntilIdle: the reducer runs synchronously inside dispatchEvent,
+        // so loading is set before the async createAccount() call is dispatched.
+
+        assertTrue(viewModel.stateFlow.value.creatingAccount.loading)
+    }
+
+    @Test
+    fun `CreateAccount success shows success then settles to idle after a delay`() = runTest(mainCoroutineRule.dispatcher) {
+        dispatchers = TestDispatchers(testScheduler)
+        whenever(authManager.createAccount()).thenReturn(Result.success(Unit))
+        val viewModel = createViewModel()
+
+        viewModel.dispatchEvent(LoginViewModel.Event.CreateAccount)
+        advanceTimeBy(500) // within the 1s success window
+        runCurrent()
+
+        assertTrue(viewModel.stateFlow.value.creatingAccount.success)
+
+        advanceUntilIdle() // elapse the settle delay
+
+        val settled = viewModel.stateFlow.value.creatingAccount
+        assertFalse(settled.success)
+        assertFalse(settled.loading)
+    }
+
+    @Test
+    fun `CreateAccount failure resets loading so the button is tappable again`() = runTest(mainCoroutineRule.dispatcher) {
+        dispatchers = TestDispatchers(testScheduler)
+        whenever(authManager.createAccount()).thenReturn(Result.failure(RuntimeException("boom")))
+        val viewModel = createViewModel()
+
+        viewModel.dispatchEvent(LoginViewModel.Event.CreateAccount)
+        advanceUntilIdle()
+
+        assertFalse(viewModel.stateFlow.value.creatingAccount.loading)
+    }
+}

--- a/apps/flipcash/features/purchase/src/main/kotlin/com/flipcash/app/purchase/internal/PurchaseAccountViewModel.kt
+++ b/apps/flipcash/features/purchase/src/main/kotlin/com/flipcash/app/purchase/internal/PurchaseAccountViewModel.kt
@@ -171,9 +171,20 @@ class PurchaseAccountViewModel @Inject constructor(
             .onEach {
                 authManager.onAccountPurchased()
                     .onSuccess {
-                        dispatchEvent(Event.OnCreatingChanged(creating = false, created = true))
-                        delay(2.seconds)
-                        dispatchEvent(Event.OnAccountCreated)
+                        // Gate: provision the core account after purchase before completing.
+                        authManager.ensureCoreAccountProvisioned()
+                            .onSuccess {
+                                dispatchEvent(Event.OnCreatingChanged(creating = false, created = true))
+                                delay(2.seconds)
+                                dispatchEvent(Event.OnAccountCreated)
+                            }
+                            .onFailure {
+                                dispatchEvent(Event.OnCreatingChanged(creating = false, created = false))
+                                BottomBarManager.showError(
+                                    title = resources.getString(R.string.error_title_accountSetupFailed),
+                                    message = resources.getString(R.string.error_description_accountSetupFailedAfterPurchase),
+                                )
+                            }
                     }
                     .onFailure {
                         dispatchEvent(Event.OnCreatingChanged(creating = false, created = true))

--- a/apps/flipcash/shared/authentication/build.gradle.kts
+++ b/apps/flipcash/shared/authentication/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
     implementation(project(":apps:flipcash:shared:profile"))
     implementation(project(":apps:flipcash:shared:userflags"))
     implementation(project(":services:flipcash"))
+    implementation(project(":services:opencode"))
 
     testImplementation(kotlin("test"))
     testImplementation(libs.bundles.unit.testing)

--- a/apps/flipcash/shared/authentication/src/main/kotlin/com/flipcash/app/auth/AuthManager.kt
+++ b/apps/flipcash/shared/authentication/src/main/kotlin/com/flipcash/app/auth/AuthManager.kt
@@ -151,6 +151,7 @@ class AuthManager @Inject constructor(
     }
 
     suspend fun createAccount(): Result<Unit> {
+        trace(tag = "Onboarding", message = "Registering new account", type = TraceType.Process)
         return credentialManager.createAccount()
             .fold(
                 onSuccess = { entropy ->
@@ -167,9 +168,12 @@ class AuthManager @Inject constructor(
             ).onSuccess { entropy ->
                 persistence.openDatabase(entropy)
             }.map { Unit }
+            .onSuccess { trace(tag = "Onboarding", message = "Account registered (identity)", type = TraceType.Process) }
+            .onFailure { trace(tag = "Onboarding", message = "Account registration failed", error = it, type = TraceType.Error) }
     }
 
     suspend fun onUserAccessKeySeen(): Result<Unit> {
+        trace(tag = "Onboarding", message = "Access key seen", type = TraceType.Process)
         return credentialManager.onUserAccessKeySeen()
             .onSuccess {
                 if (userManager.authState !is AuthState.LoggedIn) {
@@ -193,6 +197,7 @@ class AuthManager @Inject constructor(
     }
 
     suspend fun onAccountPurchased(): Result<Unit> {
+        trace(tag = "Onboarding", message = "Finalizing account purchase", type = TraceType.Process)
         return credentialManager.onAccountPurchased()
             .fold(
                 onSuccess = {
@@ -267,6 +272,7 @@ class AuthManager @Inject constructor(
                                     flags.requiresIapForRegistration -> AuthState.ResumePoint.AccessKeyThenPurchase
                                     else -> AuthState.ResumePoint.PostAccessKey
                                 }
+                                trace(tag = "Onboarding", message = "Resuming onboarding at $resumePoint", type = TraceType.Process)
                                 userManager.set(AuthState.Onboarding(resumePoint))
                             }
                         } else {
@@ -279,6 +285,7 @@ class AuthManager @Inject constructor(
                                     phoneVerificationEnabled && phoneUnverified -> AuthState.ResumePoint.PhoneNumber
                                     else -> AuthState.ResumePoint.AccessKey
                                 }
+                                trace(tag = "Onboarding", message = "Resuming onboarding at $resumePoint (flags unavailable)", type = TraceType.Process)
                                 userManager.set(authState = AuthState.Onboarding(resumePoint))
                             }
                         }

--- a/apps/flipcash/shared/authentication/src/main/kotlin/com/flipcash/app/auth/AuthManager.kt
+++ b/apps/flipcash/shared/authentication/src/main/kotlin/com/flipcash/app/auth/AuthManager.kt
@@ -43,6 +43,7 @@ class AuthManager @Inject constructor(
     private val userManager: UserManager,
     private val notificationManager: NotificationManagerCompat,
     private val accountController: AccountController,
+    private val ocpAccountController: com.getcode.opencode.controllers.AccountController,
     private val profileController: ProfileController,
     private val pushController: PushController,
     private val pushTokenProvider: PushTokenProvider,
@@ -133,6 +134,19 @@ class AuthManager @Inject constructor(
     private suspend fun softLogin(entropyB64: String): Result<ID> {
         if (softLoginDisabled) return Result.failure(Throwable("Disabled"))
         return login(entropyB64, isSoftLogin = true)
+    }
+
+    /**
+     * Provisions the core OCP USDF account and awaits the result. Onboarding calls
+     * this at the access-key step to gate release to the scanner. Returns
+     * [Result.failure] (e.g. antispam denial) when the caller must not proceed.
+     */
+    suspend fun ensureCoreAccountProvisioned(): Result<Unit> {
+        val owner = userManager.accountCluster
+            ?: return Result.failure(
+                IllegalStateException("Cannot provision core account: no account cluster established")
+            )
+        return ocpAccountController.ensureCoreAccount(owner)
     }
 
     suspend fun createAccount(): Result<Unit> {

--- a/apps/flipcash/shared/authentication/src/main/kotlin/com/flipcash/app/auth/AuthManager.kt
+++ b/apps/flipcash/shared/authentication/src/main/kotlin/com/flipcash/app/auth/AuthManager.kt
@@ -5,6 +5,7 @@ import com.flipcash.app.appsettings.AppSettingsCoordinator
 import com.flipcash.app.auth.internal.credentials.LookupResult
 import com.flipcash.app.auth.internal.credentials.PassphraseCredentialManager
 import com.flipcash.app.contacts.ContactCoordinator
+import com.flipcash.app.featureflags.FeatureFlag
 import com.flipcash.app.featureflags.FeatureFlagController
 import com.flipcash.app.persistence.PersistenceProvider
 import com.flipcash.app.push.PushTokenProvider
@@ -249,12 +250,19 @@ class AuthManager @Inject constructor(
                         // Soft logins (app restart) can trust the persisted flag.
                         val completedOnboarding = if (!isSoftLogin) false
                             else credentialManager.hasCompletedOnboarding()
+                        // If phone verification is required but not yet completed, onboarding
+                        // should resume at the phone-verification step (which precedes the
+                        // access key) rather than jumping ahead to the access key.
+                        val phoneVerificationEnabled = featureFlags.get(FeatureFlag.OnboardingPhoneVerification)
+                        val phoneUnverified = userManager.profile?.verifiedPhoneNumber == null
                         if (flags != null) {
                             userManager.set(flags)
                             if (flags.isRegistered && seenAccessKey && completedOnboarding) {
                                 userManager.set(AuthState.Ready)
                             } else {
                                 val resumePoint = when {
+                                    !seenAccessKey && (phoneVerificationEnabled || flags.enablePhoneNumberSend) && phoneUnverified ->
+                                        AuthState.ResumePoint.PhoneNumber
                                     !seenAccessKey -> AuthState.ResumePoint.AccessKey
                                     flags.requiresIapForRegistration -> AuthState.ResumePoint.AccessKeyThenPurchase
                                     else -> AuthState.ResumePoint.PostAccessKey
@@ -266,8 +274,11 @@ class AuthManager @Inject constructor(
                             if (seenAccessKey && completedOnboarding) {
                                 userManager.set(authState = AuthState.Ready)
                             } else {
-                                val resumePoint = if (seenAccessKey) AuthState.ResumePoint.PostAccessKey
-                                    else AuthState.ResumePoint.AccessKey
+                                val resumePoint = when {
+                                    seenAccessKey -> AuthState.ResumePoint.PostAccessKey
+                                    phoneVerificationEnabled && phoneUnverified -> AuthState.ResumePoint.PhoneNumber
+                                    else -> AuthState.ResumePoint.AccessKey
+                                }
                                 userManager.set(authState = AuthState.Onboarding(resumePoint))
                             }
                         }

--- a/apps/flipcash/shared/session/src/main/kotlin/com/flipcash/app/session/internal/RealSessionController.kt
+++ b/apps/flipcash/shared/session/src/main/kotlin/com/flipcash/app/session/internal/RealSessionController.kt
@@ -326,6 +326,10 @@ class RealSessionController @Inject constructor(
                                         else currentState.resumePoint
 
                                     AuthState.ResumePoint.AccessKey -> currentState.resumePoint
+
+                                    // Phone verification precedes the access key and is
+                                    // unrelated to IAP correction — leave it unchanged.
+                                    AuthState.ResumePoint.PhoneNumber -> currentState.resumePoint
                                 }
                                 if (corrected != currentState.resumePoint) {
                                     userManager.set(authState = AuthState.Onboarding(corrected))

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/user/UserManager.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/user/UserManager.kt
@@ -49,6 +49,8 @@ sealed interface AuthState {
     data object Unknown : AuthState
 
     enum class ResumePoint {
+        /** User created account but has not verified their phone number yet. */
+        PhoneNumber,
         /** User created account but has not seen their access key. */
         AccessKey,
         /** User has seen their access key but must complete IAP before registration. */

--- a/services/opencode/src/main/kotlin/com/getcode/opencode/controllers/AccountController.kt
+++ b/services/opencode/src/main/kotlin/com/getcode/opencode/controllers/AccountController.kt
@@ -9,6 +9,7 @@ import com.getcode.opencode.model.accounts.AccountType
 import com.getcode.opencode.model.accounts.unusable
 import com.getcode.opencode.model.core.ID
 import com.getcode.opencode.model.core.errors.GetAccountsError
+import com.getcode.opencode.model.core.errors.SubmitIntentError
 import com.getcode.opencode.repositories.AccountRepository
 import com.getcode.solana.keys.Mint
 import com.getcode.utils.TraceType
@@ -86,6 +87,42 @@ class AccountController @Inject constructor(
      */
     suspend fun createUserAccount(ownerForMint: AccountCluster, mint: Mint): Result<ID> {
         return accountRepository.createUserAccount(scope, ownerForMint, mint)
+    }
+
+    /**
+     * Ensures the core USDF account exists for [owner], creating it if the server
+     * reports none yet. Idempotent: a no-op once the account is known.
+     *
+     * Unlike [fetchAdditionalAccountInfo] (the reactive bootstrap that runs after
+     * login), this is an explicit, awaitable call used to GATE onboarding before
+     * the user is released to the scanner. A [Result.failure] — e.g. an antispam
+     * [SubmitIntentError.Denied] — means the caller must NOT proceed.
+     */
+    suspend fun ensureCoreAccount(owner: AccountCluster): Result<Unit> {
+        if (hasAccountFor(Mint.usdf)) return Result.success(Unit)
+        return getAccounts(owner, owner).fold(
+            onSuccess = { response ->
+                accounts.value = response.accounts.values.toList()
+                Result.success(Unit)
+            },
+            onFailure = { error ->
+                if (error is GetAccountsError.NotFound) {
+                    createUserAccount(owner, mint = Mint.usdf).fold(
+                        onSuccess = {
+                            // Best-effort refresh so hasAccountFor(USDF) is true for
+                            // downstream grabs; the account already exists server-side.
+                            getAccounts(owner, owner).onSuccess {
+                                accounts.value = it.accounts.values.toList()
+                            }
+                            Result.success(Unit)
+                        },
+                        onFailure = { Result.failure(it) }
+                    )
+                } else {
+                    Result.failure(error)
+                }
+            }
+        )
     }
 
     suspend fun getAccounts(

--- a/services/opencode/src/main/kotlin/com/getcode/opencode/controllers/AccountController.kt
+++ b/services/opencode/src/main/kotlin/com/getcode/opencode/controllers/AccountController.kt
@@ -99,16 +99,22 @@ class AccountController @Inject constructor(
      * [SubmitIntentError.Denied] — means the caller must NOT proceed.
      */
     suspend fun ensureCoreAccount(owner: AccountCluster): Result<Unit> {
-        if (hasAccountFor(Mint.usdf)) return Result.success(Unit)
+        if (hasAccountFor(Mint.usdf)) {
+            trace(tag = "Onboarding", message = "USDF core account already present", type = TraceType.Process)
+            return Result.success(Unit)
+        }
         return getAccounts(owner, owner).fold(
             onSuccess = { response ->
                 accounts.value = response.accounts.values.toList()
+                trace(tag = "Onboarding", message = "USDF core account already present", type = TraceType.Process)
                 Result.success(Unit)
             },
             onFailure = { error ->
                 if (error is GetAccountsError.NotFound) {
+                    trace(tag = "Onboarding", message = "Provisioning USDF core account (onboarding gate)", type = TraceType.Process)
                     createUserAccount(owner, mint = Mint.usdf).fold(
                         onSuccess = {
+                            trace(tag = "Onboarding", message = "USDF core account provisioned", type = TraceType.Process)
                             // Best-effort refresh so hasAccountFor(USDF) is true for
                             // downstream grabs; the account already exists server-side.
                             getAccounts(owner, owner).onSuccess {
@@ -116,9 +122,13 @@ class AccountController @Inject constructor(
                             }
                             Result.success(Unit)
                         },
-                        onFailure = { Result.failure(it) }
+                        onFailure = {
+                            trace(tag = "Onboarding", message = "USDF core account provisioning failed", error = it, type = TraceType.Error)
+                            Result.failure(it)
+                        }
                     )
                 } else {
+                    trace(tag = "Onboarding", message = "USDF core account lookup failed", error = error, type = TraceType.Error)
                     Result.failure(error)
                 }
             }

--- a/services/opencode/src/test/kotlin/com/getcode/opencode/controllers/AccountControllerTest.kt
+++ b/services/opencode/src/test/kotlin/com/getcode/opencode/controllers/AccountControllerTest.kt
@@ -1,0 +1,84 @@
+package com.getcode.opencode.controllers
+
+import com.getcode.ed25519.Ed25519.KeyPair
+import com.getcode.opencode.model.accounts.AccountCluster
+import com.getcode.opencode.model.accounts.AccountFilter
+import com.getcode.opencode.model.accounts.AccountInfo
+import com.getcode.opencode.model.accounts.AccountResponse
+import com.getcode.opencode.model.core.ID
+import com.getcode.opencode.model.core.errors.GetAccountsError
+import com.getcode.opencode.model.core.errors.SubmitIntentError
+import com.getcode.opencode.repositories.AccountRepository
+import com.getcode.solana.keys.Mint
+import com.getcode.utils.network.NetworkConnectivityListener
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AccountControllerTest {
+
+    // Hand-written fake: MockK has a known bug returning Result<T> from suspend
+    // fns (see GrabBillTransactorTest.kt:82), so we return real Result values here.
+    private class FakeAccountRepository(
+        var onGetAccounts: () -> Result<AccountResponse> = { Result.failure(GetAccountsError.NotFound()) },
+        var onCreate: () -> Result<ID> = { Result.success(listOf<Byte>(1)) },
+    ) : AccountRepository {
+        var createCount = 0
+        override suspend fun isValidAccount(owner: KeyPair): Result<Boolean> = Result.success(true)
+        override suspend fun createUserAccount(scope: CoroutineScope, ownerForMint: AccountCluster, mint: Mint): Result<ID> {
+            createCount++
+            return onCreate()
+        }
+        override suspend fun getAccounts(accountOwner: KeyPair, requestingOwner: KeyPair, filter: AccountFilter?): Result<AccountResponse> = onGetAccounts()
+        override suspend fun getAccount(accountOwner: KeyPair, requestingOwner: KeyPair, filter: AccountFilter): Result<AccountInfo> = Result.failure(GetAccountsError.NotFound())
+    }
+
+    private val networkObserver = mockk<NetworkConnectivityListener>(relaxed = true)
+    private val owner = mockk<AccountCluster>(relaxed = true)
+
+    @Test
+    fun `ensureCoreAccount creates USDF when server reports NotFound`() = runTest {
+        val repo = FakeAccountRepository(
+            onGetAccounts = { Result.failure(GetAccountsError.NotFound()) },
+            onCreate = { Result.success(listOf<Byte>(1)) },
+        )
+        val controller = AccountController(repo, networkObserver)
+
+        val result = controller.ensureCoreAccount(owner)
+
+        assertTrue(result.isSuccess)
+        assertEquals(1, repo.createCount)
+    }
+
+    @Test
+    fun `ensureCoreAccount fails when create is denied by antispam`() = runTest {
+        val repo = FakeAccountRepository(
+            onGetAccounts = { Result.failure(GetAccountsError.NotFound()) },
+            onCreate = { Result.failure(SubmitIntentError.Denied(listOf("antispam guard denied account creation"))) },
+        )
+        val controller = AccountController(repo, networkObserver)
+
+        val result = controller.ensureCoreAccount(owner)
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is SubmitIntentError.Denied)
+    }
+
+    @Test
+    fun `ensureCoreAccount is a no-op when getAccounts already returns accounts`() = runTest {
+        val repo = FakeAccountRepository(
+            onGetAccounts = { Result.success(AccountResponse(accounts = emptyMap())) },
+        )
+        val controller = AccountController(repo, networkObserver)
+
+        val result = controller.ensureCoreAccount(owner)
+
+        assertTrue(result.isSuccess)
+        assertEquals(0, repo.createCount)
+    }
+}


### PR DESCRIPTION
## Summary

Hardens Flipcash onboarding around **core-account provisioning** — the root cause of the S26 "doom loop" (Bugsnag `6a569eb4`), where a server antispam denial left the user on the scanner with no OCP account, triggering an infinite camera-driven grab/create retry storm that made the whole app feel broken. Adds UX polish and full-flow observability.

- **Provision the OCP USDF account during onboarding, gated.** It's now created as an *awaited* step at the access-key screen (save-to-photos / continue-without) — matching iOS — and after IAP purchase. If provisioning fails (antispam/offline), onboarding shows a retryable "account setup incomplete" error and **does not** release to the scanner. Previously the account was a fire-and-forget reactive side-effect that started *after* `AuthState.Ready`, so its failure was never checked.
- **Create Account button UX.** Shows a spinner + disables while creating (debouncing the double-taps seen on slow first runs), flashes success on creation, then settles to idle after 1s.
- **Resume at phone verification when it wasn't completed.** Wires up the previously-unused `AuthState.ResumePoint.PhoneNumber`: the resume decision yields it when phone verification is required and no verified phone exists, and `MainRoot` launches the phone `Verification` flow (targeting the access-key resume). Also completes a non-exhaustive `when` in `RealSessionController`.
- **Trace the full onboarding + verification flow.** Consistent `[Onboarding]` / `[Verification]` (`[Onboarding · Verification]` when verification runs during onboarding) traces across registration, resume decision, access-key, purchase, USDF provisioning gate, navigation, and release-to-scanner — visible in logcat and Bugsnag breadcrumbs.