### PR TITLE
fix(auth): repair AuthManagerTest compile after ocpAccountController param

### DIFF
--- a/apps/flipcash/shared/authentication/src/test/kotlin/com/flipcash/app/auth/AuthManagerTest.kt
+++ b/apps/flipcash/shared/authentication/src/test/kotlin/com/flipcash/app/auth/AuthManagerTest.kt
@@ -53,6 +53,7 @@ class AuthManagerTest {
     private val userManager: UserManager = mockk(relaxed = true)
     private val notificationManager: NotificationManagerCompat = mockk(relaxed = true)
     private val accountController: AccountController = mockk(relaxed = true)
+    private val ocpAccountController: com.getcode.opencode.controllers.AccountController = mockk(relaxed = true)
     private val profileController: ProfileController = mockk(relaxed = true)
     private val pushController: PushController = mockk(relaxed = true)
     private val pushTokenProvider: PushTokenProvider = mockk(relaxed = true)
@@ -90,6 +91,7 @@ class AuthManagerTest {
             userManager = userManager,
             notificationManager = notificationManager,
             accountController = accountController,
+            ocpAccountController = ocpAccountController,
             profileController = profileController,
             pushController = pushController,
             pushTokenProvider = pushTokenProvider,


### PR DESCRIPTION
Squash-merging #1082 landed `AuthManager`'s new `ocpAccountController` constructor parameter but not the corresponding test change, breaking `code/cash` at `:apps:flipcash:shared:authentication:compileDebugUnitTestKotlin`:

```
e: AuthManagerTest.kt:104:13 No value passed for parameter 'ocpAccountController'.
```

This adds the `ocpAccountController` mock to `AuthManagerTest` and passes it to the `AuthManager` constructor.

## Test plan
- `./gradlew :apps:flipcash:shared:authentication:testDebugUnitTest` — green (20/20).
