### PR TITLE
fix(add-money): stop pushing Coinbase email verification twice

### DIFF
--- a/apps/flipcash/shared/payments/src/main/kotlin/com/flipcash/app/payments/internal/InternalPurchaseMethodController.kt
+++ b/apps/flipcash/shared/payments/src/main/kotlin/com/flipcash/app/payments/internal/InternalPurchaseMethodController.kt
@@ -167,10 +167,18 @@ class InternalPurchaseMethodController @Inject constructor(
             PurchaseMethod.CoinbaseOnRamp -> {
                 val profile = userManager.profile
                 val needsPhone = profile?.verifiedPhoneNumber == null
-                val email = profile?.email?.value
                 val needsEmailVerification = userFlags.resolvedFlags.value
                     .requireCoinbaseEmailVerification.effectiveValue
-                val needsEmail = needsEmailVerification || email == null
+                // Match CoinbaseOnRampController.resolveEmail(): when verification is required only a
+                // server-verified email is usable, otherwise any entered email counts. Diverging here
+                // (forcing verification whenever the flag is on) made this gate disagree with the
+                // purchase-time check and could send an already-verified user to verification.
+                val email = if (needsEmailVerification) {
+                    profile?.verifiedEmailAddress
+                } else {
+                    profile?.email?.value
+                }
+                val needsEmail = email == null
                 trace("needsPhone: $needsPhone, needsEmail: $needsEmail, needsEmailVerification: $needsEmailVerification")
                 val swapRoute = AppRoute.Token.Swap(
                     purpose = SwapPurpose.Buy(Mint.usdf, FundingSource.Coinbase),

--- a/apps/flipcash/shared/tokens/src/main/kotlin/com/flipcash/app/tokens/ui/SwapViewModel.kt
+++ b/apps/flipcash/shared/tokens/src/main/kotlin/com/flipcash/app/tokens/ui/SwapViewModel.kt
@@ -1138,6 +1138,12 @@ class SwapViewModel @Inject constructor(
             .onEach { (method, metadata) ->
                 when (method) {
                     PurchaseMethod.CoinbaseOnRamp -> {
+                        // The add-money deposit sheet (presentDepositOptions) emits a Plain
+                        // selection with no amount and owns its own email/phone gate + navigation.
+                        // Only react to an actual purchase (which carries an amount) here — reacting
+                        // to the deposit selection would push the verification screen a second time.
+                        val amount = metadata.purchaseAmount ?: return@onEach
+
                         analytics.buttonTapped(Button.TokenBuyWithCoinbase)
                         dispatchEvent(Event.CoinbaseSelected)
 
@@ -1162,8 +1168,6 @@ class SwapViewModel @Inject constructor(
                             )
                             return@onEach
                         }
-
-                        val amount = metadata.purchaseAmount ?: return@onEach
 
                         if (amount < minimumCoinbasePurchaseAmount) {
                             BottomBarManager.showAlert(


### PR DESCRIPTION
The email verification screen is pushed **twice** when adding money via Coinbase / Google Pay.

## Root cause
Picking Coinbase from the add-money deposit sheet emits one `_selections` value that **two** handlers act on, and both navigate to verification:

1. `InternalPurchaseMethodController.presentDepositOptions` runs its own email/phone gate and returns `AppRoute.Verification` → navigate.
2. `SwapViewModel`'s persistent `purchaseMethodController.selections` collector — its Coinbase branch ran the email gate and dispatched `OnVerificationNeeded` (a second navigation) **before** bailing on the missing `purchaseAmount`.

The deposit-sheet selection is `PaymentAction.Plain` with **no amount**; the real purchase carries an amount. The collector was reacting to a selection it shouldn't handle — the same "shared controller also emits for the deposit sheet" trap the currency-creator already guards against.

## Fix
- **`SwapViewModel`** — move the `purchaseAmount ?: return` bail to the top of the Coinbase branch, before the email gate. The collector now ignores the amount-less deposit-sheet selection, leaving `presentDepositOptions` as the sole handler → one push.
- **`InternalPurchaseMethodController`** — resolve the email the same way as `CoinbaseOnRampController.resolveEmail()` (verified email only when the flag is on, any entered email otherwise). The pre-emptive gate previously forced verification whenever the flag was on — even for an already-verified user — and disagreed with the purchase-time check.