### PR TITLE
feat(theme): wallpaper-derived dynamic accent for buttons

### DIFF
--- a/apps/flipcash/features/currency-creator/src/main/kotlin/com/flipcash/app/currencycreator/CurrencyCreatorFlowScreen.kt
+++ b/apps/flipcash/features/currency-creator/src/main/kotlin/com/flipcash/app/currencycreator/CurrencyCreatorFlowScreen.kt
@@ -1,8 +1,10 @@
 package com.flipcash.app.currencycreator
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -63,6 +65,7 @@ import com.getcode.opencode.model.financial.Fiat
 import com.getcode.opencode.model.financial.LocalFiat
 import com.getcode.opencode.model.financial.toFiat
 import com.getcode.theme.CodeTheme
+import com.getcode.theme.rememberDynamicAccent
 import com.getcode.ui.core.unboundedClickable
 
 @Composable
@@ -136,15 +139,24 @@ fun CurrencyCreatorFlowScreen(
                 endContent = when (state.currentStep) {
                     is CurrencyCreatorStep.BillCustomization -> {
                         {
+                            val (accent, onAccent) = rememberDynamicAccent(
+                                fallbackAccent = CodeTheme.colors.secondary,
+                                fallbackOnAccent = CodeTheme.colors.onAction,
+                            )
+
                             Text(
-                                text = stringResource(R.string.action_done),
+                                text = stringResource(R.string.action_next),
                                 style = CodeTheme.typography.textMedium,
-                                color = Color.White,
+                                color = onAccent,
                                 modifier = Modifier
+                                    .background(accent, shape = CircleShape)
                                     .unboundedClickable {
                                         topBarController.onEndAction?.invoke()
                                     }
-                                    .padding(5.dp),
+                                    .padding(
+                                        horizontal = CodeTheme.dimens.grid.x2,
+                                        vertical = CodeTheme.dimens.grid.x1
+                                    ),
                             )
                         }
                     }

--- a/ui/theme/build.gradle.kts
+++ b/ui/theme/build.gradle.kts
@@ -13,6 +13,7 @@ android {
 dependencies {    debugImplementation(libs.compose.ui.tools)
     implementation(libs.compose.ui.tools.preview)
     implementation(libs.compose.material)
+    implementation(libs.compose.material3)
     implementation(libs.compose.accompanist)
 
     implementation(libs.androidx.appcompat)

--- a/ui/theme/src/main/kotlin/com/getcode/theme/DynamicColor.kt
+++ b/ui/theme/src/main/kotlin/com/getcode/theme/DynamicColor.kt
@@ -1,0 +1,50 @@
+package com.getcode.theme
+
+import android.os.Build
+import androidx.compose.material3.dynamicDarkColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+
+/**
+ * The user's Material You (Monet) accent color, derived from their wallpaper / system theme.
+ *
+ * On Android 12+ (API 31) this reads the wallpaper-derived tonal palette via Material3's
+ * [dynamicDarkColorScheme] and returns its [accent] (`primary`) and [onAccent] (`onPrimary`).
+ * The app is dark-only, so we always take the *dark* dynamic scheme regardless of the system
+ * light/dark setting — its tonal steps read correctly on our dark surfaces.
+ *
+ * On API < 31 both fields fall back to [fallbackAccent] / [fallbackOnAccent].
+ *
+ * Usage:
+ * ```
+ * val (accent, onAccent) = rememberDynamicAccent(
+ *     fallbackAccent = CodeTheme.colors.secondary,
+ *     fallbackOnAccent = CodeTheme.colors.onAction,
+ * )
+ * Button(colors = ButtonDefaults.buttonColors(containerColor = accent)) {
+ *     Text("Save", color = onAccent)
+ * }
+ * ```
+ */
+@Composable
+fun rememberDynamicAccent(
+    fallbackAccent: Color,
+    fallbackOnAccent: Color = Color.White,
+): DynamicAccent {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+        return DynamicAccent(accent = fallbackAccent, onAccent = fallbackOnAccent)
+    }
+    val context = LocalContext.current
+    return remember(context) {
+        val scheme = dynamicDarkColorScheme(context)
+        DynamicAccent(accent = scheme.primary, onAccent = scheme.onPrimary)
+    }
+}
+
+/** A wallpaper-derived accent paired with the content color that reads on top of it. */
+data class DynamicAccent(
+    val accent: Color,
+    val onAccent: Color,
+)


### PR DESCRIPTION
## What

Adds `rememberDynamicAccent()` to `:ui:theme` — a small helper that returns the user's Material You (Monet) accent color derived from their wallpaper / system theme, à la Google Photos' Save action.

On Android 12+ it reads the palette via Material3's `dynamicDarkColorScheme()` (we're dark-only, so we always take the dark scheme) and returns its `primary` / `onPrimary`. Below API 31 it falls back to the brand colors you pass in.

```kotlin
val (accent, onAccent) = rememberDynamicAccent(
    fallbackAccent = CodeTheme.colors.secondary,
    fallbackOnAccent = CodeTheme.colors.onAction,
)
Button(colors = ButtonDefaults.buttonColors(containerColor = accent)) {
    Text("Save", color = onAccent)
}
```

First use: the currency creator's bill-customization action button (relabelled "Done" → "Next") now uses the system accent instead of a flat white pill.

## Notes

- Pulls `compose-material3` into `:ui:theme` for the first time. This is the intended first step toward migrating the theme layer off the bespoke Material2-based color system onto Material3 — the natural follow-up is mapping the full `dynamicDarkColorScheme` into `com.getcode.theme.ColorScheme` at the `DesignSystem(colorScheme = …)` entry point so dynamic color can flow app-wide.
- `minSdk` is 29, so the helper guards on `Build.VERSION.SDK_INT >= S` and falls back to brand colors on older devices.
- No new manifest permissions required.

## Testing

- `:ui:theme:compileDebugKotlin` and `:apps:flipcash:features:currency-creator:compileDebugKotlin` both build clean (verified in an isolated worktree at this commit).
