### PR TITLE
fix(chat,contacts): keep On Flipcash section visible and resume chat sync on re-login

### DIFF
--- a/apps/flipcash/features/direct-send/src/main/kotlin/com/flipcash/app/directsend/internal/screens/ContactListScreen.kt
+++ b/apps/flipcash/features/direct-send/src/main/kotlin/com/flipcash/app/directsend/internal/screens/ContactListScreen.kt
@@ -128,6 +128,24 @@ internal fun ContactListScreen() {
             }
         }
 
+        // When the user grants contacts access from the inline callout, the sync runs
+        // in two passes: device contacts land first (only the "Not on Flipcash"
+        // section), then the "On Flipcash" contacts are fetched and prepended to the
+        // top. LazyColumn's key-based scroll anchoring pins the previously-visible
+        // first row, which pushes the freshly-prepended "On Flipcash" section above the
+        // viewport. Keep the list pinned to the top while a user-initiated sync is
+        // settling so that section stays visible instead of being scrolled offscreen.
+        LaunchedEffect(listState) {
+            snapshotFlow {
+                (state.contactSyncState.loading || state.contactSyncState.success) to
+                    state.listItems.size
+            }.collect { (syncing, _) ->
+                if (syncing && listState.firstVisibleItemIndex != 0) {
+                    listState.scrollToItem(0)
+                }
+            }
+        }
+
         Column(
             modifier = Modifier.padding(innerPadding),
         ) {

--- a/apps/flipcash/shared/chat/src/main/kotlin/com/flipcash/shared/chat/internal/RealChatCoordinator.kt
+++ b/apps/flipcash/shared/chat/src/main/kotlin/com/flipcash/shared/chat/internal/RealChatCoordinator.kt
@@ -76,8 +76,8 @@ class RealChatCoordinator @Inject constructor(
     private val stateHolder: ChatStateHolder,
     private val userManager: UserManager,
     private val featureFlags: FeatureFlagController,
-    networkObserver: NetworkConnectivityListener,
-    dispatchers: DispatcherProvider,
+    private val networkObserver: NetworkConnectivityListener,
+    private val dispatchers: DispatcherProvider,
 ) : ChatCoordinator,
     SessionListener,
     DefaultLifecycleObserver,
@@ -89,8 +89,12 @@ class RealChatCoordinator @Inject constructor(
         private const val TAG = "ChatCoordinator"
     }
 
-    private val supervisorJob = SupervisorJob()
-    private val scope = CoroutineScope(dispatchers.IO + supervisorJob)
+    // Recreated on re-login: [reset] cancels [supervisorJob] on logout, which would
+    // otherwise leave the scope permanently dead for this @Singleton and no-op every
+    // launch in a subsequent [onUserLoggedIn] (chats never sync until a process
+    // restart rebuilds the singleton). See [onUserLoggedIn].
+    private var supervisorJob = SupervisorJob()
+    private var scope = CoroutineScope(dispatchers.IO + supervisorJob)
     private val cluster = MutableStateFlow<AccountCluster?>(null)
     private var flagObserverJob: Job? = null
     private var networkObserverJob: Job? = null
@@ -103,6 +107,14 @@ class RealChatCoordinator @Inject constructor(
 
     override suspend fun onUserLoggedIn(cluster: AccountCluster) {
         trace(tag = TAG, message = "User logged in, hydrating chat", type = TraceType.User)
+        // A prior logout in this process cancels [supervisorJob] via [reset], leaving
+        // the scope dead. Rebuild it and re-establish the lifetime wiring before the
+        // session work below, otherwise every launch here is a silent no-op.
+        if (!supervisorJob.isActive) {
+            supervisorJob = SupervisorJob()
+            scope = CoroutineScope(dispatchers.IO + supervisorJob)
+            wireDelegateRouting()
+        }
         this.cluster.value = cluster
         feedDelegate.initialize(scope)
         eventStreamDelegate.initialize(scope)
@@ -119,7 +131,16 @@ class RealChatCoordinator @Inject constructor(
 
     init {
         ProcessLifecycleOwner.get().lifecycle.addObserver(this)
+        wireDelegateRouting()
+    }
 
+    /**
+     * Launches the lifetime collectors — cross-delegate event routing and the
+     * network-reconnect re-sync — onto [scope]. Called once at construction and
+     * again from [onUserLoggedIn] whenever the scope had to be rebuilt after a
+     * [reset], so these collectors are never left orphaned on a dead scope.
+     */
+    private fun wireDelegateRouting() {
         feedDelegate.events
             .onEach { event ->
                 when (event) {

--- a/apps/flipcash/shared/chat/src/test/kotlin/com/flipcash/shared/chat/ChatCoordinatorEventsTest.kt
+++ b/apps/flipcash/shared/chat/src/test/kotlin/com/flipcash/shared/chat/ChatCoordinatorEventsTest.kt
@@ -483,4 +483,37 @@ class ChatCoordinatorEventsTest {
     }
 
     // endregion
+
+    // region Session lifecycle
+
+    @Test
+    fun `re-login after reset resumes chat sync on a fresh scope`() = runTest(testDispatchers.dispatcher) {
+        // First session wires the delegate collectors onto the coordinator scope.
+        coordinator.onUserLoggedIn(mockk(relaxed = true))
+        runCurrent()
+
+        // Logout cancels the coordinator's supervisor job (and thus its scope).
+        coordinator.reset()
+        runCurrent()
+
+        // Re-login in the same process. Before the fix, the scope stayed cancelled,
+        // so every launch in onUserLoggedIn was a silent no-op and incoming chat
+        // updates were dropped until a process restart rebuilt the singleton.
+        coordinator.onUserLoggedIn(mockk(relaxed = true))
+        runCurrent()
+
+        val msg = textMessage(id = 7, eventSequence = 1)
+        chatUpdatesChannel.send(ChatUpdate(chatId = chatId, events = listOf(chatEvent(1, msg))))
+        advanceTimeBy(1_000.milliseconds)
+        runCurrent()
+
+        coVerify {
+            messageDataSource.upsert(chatId, match { messages ->
+                messages.size == 1 && messages[0].messageId == 7L
+            })
+        }
+        coordinator.reset()
+    }
+
+    // endregion
 }


### PR DESCRIPTION
## Summary

Fixes two independent bugs that both surface on the first load of an existing account.

### 1. Contacts — "On Flipcash" section scrolled off-screen after granting permission
`ContactCoordinator.performSync()` populates the list in two passes: device contacts land first (only the "Not on Flipcash" section renders), then the "On Flipcash" contacts are fetched and **prepended** to the top. `LazyColumn`'s key-based scroll anchoring pins the previously-visible first row, pushing the freshly-prepended "On Flipcash" section above the viewport. The full-screen permission gate guards against this, but the **inline permission callout** on `ContactListScreen` (the path existing-account users hit) had no such guard.

**Fix:** while a user-initiated sync is settling, pin the list to the top so the newly-prepended section stays visible.

### 2. Chat — existing-account chats don't appear until a force-quit
`RealChatCoordinator`'s `scope` is built from a `SupervisorJob` created once at construction. `reset()` (fired on `AuthState.LoggedOut`) calls `supervisorJob.cancel()`, killing that scope **permanently**. On a logout→login within the same process, `onUserLoggedIn()` launches feed sync, event stream, and heartbeat into the dead scope — all silent no-ops — so the feed never populates. A force-quit rebuilds the singleton with a fresh scope, which is why restarting "fixed" it.

**Fix:** make the scope recreatable and extract the lifetime wiring into `wireDelegateRouting()`, which `onUserLoggedIn()` re-establishes on a fresh scope when the old one was cancelled.
