### PR TITLE
fix(oc): make SupervisorJob the scope's real Job so destroy() cancels reconnect loop

### DIFF
--- a/services/opencode/src/main/kotlin/com/getcode/opencode/internal/bidi/BidirectionalStreamReference.kt
+++ b/services/opencode/src/main/kotlin/com/getcode/opencode/internal/bidi/BidirectionalStreamReference.kt
@@ -15,8 +15,16 @@ class BidirectionalStreamReference<Request, Response>(
     val instanceLabel: String = ""
 ) : AutoCloseable {
 
-    private val supervisorJob = SupervisorJob()
-    val coroutineScope = CoroutineScope(supervisorJob + scope.coroutineContext)
+    // supervisorJob must be THE Job of coroutineScope so destroy()/cancel() can
+    // tear down every coroutine launched on this reference. CoroutineContext.plus
+    // lets the right operand win on key collision, so supervisorJob has to come
+    // LAST — otherwise scope's own Job overrides it and the reconnect loop is
+    // launched under the outer scope instead, leaving destroy() to cancel an
+    // orphaned job while the loop keeps reconnecting (the server's
+    // "ABORTED: stream already exists" storm). Parenting it to scope's Job keeps
+    // the reference tied to the outer lifecycle (scope cancel → ref cancel).
+    private val supervisorJob = SupervisorJob(scope.coroutineContext[Job])
+    val coroutineScope = CoroutineScope(scope.coroutineContext + supervisorJob)
 
     val isActive: Boolean get() = isStreamActive
 

--- a/services/opencode/src/test/kotlin/com/getcode/opencode/internal/bidi/OpenBidirectionalStreamTest.kt
+++ b/services/opencode/src/test/kotlin/com/getcode/opencode/internal/bidi/OpenBidirectionalStreamTest.kt
@@ -159,6 +159,58 @@ class OpenBidirectionalStreamTest {
     }
 
     /**
+     * Regression for the "ABORTED: stream already exists" storm on device.
+     *
+     * destroy() MUST cancel the running reconnect loop. If the reference's
+     * SupervisorJob is not actually the parent of the launched loop (context
+     * composition order bug), destroy() cancels an orphaned job and the loop
+     * keeps reconnecting — spawning a second live gRPC stream and producing the
+     * server's "ABORTED: stream already exists".
+     *
+     * Here the loop reconnects forever on ABORTED (maxReconnectAttempts high,
+     * healthy resets disabled by a frozen clock). On the 3rd attempt we call
+     * destroy() from inside the stream. With the fix the loop is cancelled and
+     * attemptCount freezes at 3. Without it, the loop runs on to give-up.
+     */
+    @Test
+    fun `destroy cancels the reconnect loop`() = runTest {
+        var attemptCount = 0
+        val timeSource = TestTimeSource() // frozen → never healthy, never resets
+
+        val streamRef = BidirectionalStreamReference<String, String>(this, "test-stream")
+        streamRef.retain()
+
+        openBidirectionalStream<String, String, BidirectionalStreamReference<String, String>>(
+            streamRef = streamRef,
+            apiCall = { requestFlow ->
+                attemptCount++
+                flow {
+                    requestFlow.first()
+                    emit("activation")
+                    if (attemptCount >= 3) streamRef.destroy()
+                    throw Status.ABORTED.withDescription("stream already exists").asRuntimeException()
+                }
+            },
+            initialRequest = { "req" },
+            responseHandler = { _: String, _: (String) -> Unit -> },
+            onError = { },
+            reconnectOnAborted = true,
+            maxReconnectAttempts = 50,
+            reconnectDelayMs = 0,
+            healthyThreshold = 30.seconds,
+            timeSource = timeSource,
+        )
+
+        advanceUntilIdle()
+
+        assertEquals(
+            3,
+            attemptCount,
+            "destroy() must cancel the loop; it kept reconnecting to $attemptCount attempts"
+        )
+    }
+
+    /**
      * A stream that stays healthy (survives past healthyThreshold) between failures
      * must reset the backoff counter and keep reconnecting well beyond
      * maxReconnectAttempts, until a non-retryable error stops it.


### PR DESCRIPTION
## Problem

On device we were seeing a storm of `ABORTED: stream already exists` from the server. Root cause is a coroutine-context composition bug in `BidirectionalStreamReference`.

`CoroutineContext.plus` lets the **right** operand win on a key collision. The scope was built as:

```kotlin
private val supervisorJob = SupervisorJob()
val coroutineScope = CoroutineScope(supervisorJob + scope.coroutineContext)
```

Because `scope.coroutineContext` came last, the **outer** scope's `Job` overrode our `SupervisorJob` as the scope's governing job. The reconnect loop was therefore launched under the outer scope — so `destroy()`/`cancel()` cancelled an orphaned `SupervisorJob` while the loop kept reconnecting, opening a second live gRPC stream and triggering the server's "stream already exists".

## Fix

```kotlin
private val supervisorJob = SupervisorJob(scope.coroutineContext[Job])
val coroutineScope = CoroutineScope(scope.coroutineContext + supervisorJob)
```

- `supervisorJob` now comes last, so it actually governs the scope and `destroy()` tears down the reconnect loop.
- Parenting it to `scope`'s `Job` keeps the reference tied to the outer lifecycle (scope cancel → ref cancel).

## Test

Adds `destroy cancels the reconnect loop`: the stream reconnects forever on `ABORTED` (frozen clock → never healthy, never resets backoff), calls `destroy()` from inside the stream on the 3rd attempt, and asserts the attempt count freezes at 3. Fails without the fix (loop runs on to give-up), passes with it.