### PR TITLE
fix(contacts): persist the server checksum when contacts are already in sync

### DIFF
--- a/apps/flipcash/shared/contacts/src/main/kotlin/com/flipcash/app/contacts/ContactCoordinator.kt
+++ b/apps/flipcash/shared/contacts/src/main/kotlin/com/flipcash/app/contacts/ContactCoordinator.kt
@@ -519,7 +519,7 @@ class ContactCoordinator @Inject constructor(
                 onSuccess = { serverChecksum ->
                     // Checksums match — skip upload
                     trace(tag = TAG, message = "Contacts in sync with server", type = TraceType.Process)
-                    contactDataSource.persistSyncState(newChecksum)
+                    contactDataSource.persistSyncState(serverChecksum)
                 },
                 onFailure = { error ->
                     when (error) {


### PR DESCRIPTION
## Problem

In `ContactCoordinator`, the "checksums match — skip upload" success path persisted `newChecksum` (our locally-computed checksum) as the sync state, rather than the `serverChecksum` the server returned. When the two representations differ, we store the wrong baseline and needlessly re-trigger a sync on the next run.

## Fix

Persist `serverChecksum` so the stored sync state matches exactly what the server holds.

```diff
-contactDataSource.persistSyncState(newChecksum)
+contactDataSource.persistSyncState(serverChecksum)
```