### PR TITLE
fix(navigation): make BaseViewModel setState an atomic compare-and-set

### DIFF
--- a/ui/navigation/src/main/kotlin/com/getcode/view/BaseViewModel.kt
+++ b/ui/navigation/src/main/kotlin/com/getcode/view/BaseViewModel.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlin.coroutines.CoroutineContext
@@ -38,8 +39,12 @@ abstract class BaseViewModel<ViewState : Any, Event : Any>(
         }
     }
 
+    // Events are dispatched from multiple threads — the UI thread and background flows on
+    // defaultDispatcher — so this must be an atomic compare-and-set, not a plain
+    // read-modify-write. A non-atomic assignment lets concurrent reducers derive from the same
+    // snapshot and clobber each other, silently dropping one event's state change.
     private fun setState(update: ViewState.() -> ViewState) {
-        _stateFlow.value = _stateFlow.value.update()
+        _stateFlow.update(update)
     }
 }
 


### PR DESCRIPTION
## Problem

`BaseViewModel.setState` did a non-atomic read-modify-write:

```kotlin
_stateFlow.value = _stateFlow.value.update()
```

Events are dispatched from multiple threads — the UI thread and background flows on `defaultDispatcher`. Two concurrent reducers can read the same snapshot and clobber each other, silently dropping one event's state change.

## Fix

Use `MutableStateFlow.update {}`, which applies the reducer in a compare-and-set loop and retries against the latest value:

```kotlin
_stateFlow.update(update)
```
