### PR TITLE
chore(protos): sync flipcash protobuf definitions and adapt service layer

### DIFF
--- a/apps/flipcash/features/direct-send/src/main/kotlin/com/flipcash/app/directsend/internal/ContactListBuilder.kt
+++ b/apps/flipcash/features/direct-send/src/main/kotlin/com/flipcash/app/directsend/internal/ContactListBuilder.kt
@@ -50,7 +50,7 @@ internal class ContactListBuilder @Inject constructor(
             }
         }
 
-        val dmChats = chatFeed.filter { it.metadata.type == ChatType.DM }
+        val dmChats = chatFeed.filter { it.metadata.type == ChatType.CONTACT_DM }
         // Build a reverse lookup: e164 -> chatId string for contacts with DMs
         val e164ToChatId = contactState.dmChatIds
 

--- a/apps/flipcash/shared/persistence/db/schemas/com.flipcash.app.persistence.FlipcashDatabase/23.json
+++ b/apps/flipcash/shared/persistence/db/schemas/com.flipcash.app.persistence.FlipcashDatabase/23.json
@@ -1,0 +1,661 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 23,
+    "identityHash": "9ab78877c87a08d5bb3fd93908434346",
+    "entities": [
+      {
+        "tableName": "messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`idBase58` TEXT NOT NULL, `text` TEXT NOT NULL, `amountUsdc` INTEGER, `amountNative` INTEGER, `nativeCurrency` TEXT, `rate` REAL, `state` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `metadata` TEXT, `mintBase58` TEXT DEFAULT 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', PRIMARY KEY(`idBase58`))",
+        "fields": [
+          {
+            "fieldPath": "idBase58",
+            "columnName": "idBase58",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amountUsdc",
+            "columnName": "amountUsdc",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "amountNative",
+            "columnName": "amountNative",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "nativeCurrency",
+            "columnName": "nativeCurrency",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "rate",
+            "columnName": "rate",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadata",
+            "columnName": "metadata",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mintBase58",
+            "columnName": "mintBase58",
+            "affinity": "TEXT",
+            "defaultValue": "'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "idBase58"
+          ]
+        }
+      },
+      {
+        "tableName": "tokens",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`address` TEXT NOT NULL, `decimals` INTEGER NOT NULL, `name` TEXT NOT NULL, `symbol` TEXT NOT NULL, `created_at` INTEGER, `description` TEXT NOT NULL, `image_url` TEXT NOT NULL, `social_links` TEXT, `bill_customizations` TEXT, `holder_metrics` TEXT, `vm_vm` TEXT NOT NULL, `vm_authority` TEXT NOT NULL, `vm_lock_duration_days` INTEGER NOT NULL, `lp_currency_config` TEXT, `lp_liquidity_pool` TEXT, `lp_seed` TEXT, `lp_authority` TEXT, `lp_mint_vault` TEXT, `lp_core_mint_vault` TEXT, `lp_circulating_supply_quarks` INTEGER, `lp_sell_fee_bps` INTEGER, `lp_price_amount_usd` REAL, `lp_market_cap_amount_usd` REAL, PRIMARY KEY(`address`))",
+        "fields": [
+          {
+            "fieldPath": "address",
+            "columnName": "address",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "decimals",
+            "columnName": "decimals",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "symbol",
+            "columnName": "symbol",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "image_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "socialLinks",
+            "columnName": "social_links",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "billCustomizationsJson",
+            "columnName": "bill_customizations",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "holderMetricsJson",
+            "columnName": "holder_metrics",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "vmMetadata.vm",
+            "columnName": "vm_vm",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vmMetadata.authority",
+            "columnName": "vm_authority",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vmMetadata.lockDurationInDays",
+            "columnName": "vm_lock_duration_days",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "launchpadMetadata.currencyConfig",
+            "columnName": "lp_currency_config",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "launchpadMetadata.liquidityPool",
+            "columnName": "lp_liquidity_pool",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "launchpadMetadata.seed",
+            "columnName": "lp_seed",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "launchpadMetadata.authority",
+            "columnName": "lp_authority",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "launchpadMetadata.mintVault",
+            "columnName": "lp_mint_vault",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "launchpadMetadata.coreMintVault",
+            "columnName": "lp_core_mint_vault",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "launchpadMetadata.currentCirculatingSupplyQuarks",
+            "columnName": "lp_circulating_supply_quarks",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "launchpadMetadata.sellFeeBps",
+            "columnName": "lp_sell_fee_bps",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "launchpadMetadata.priceAmount",
+            "columnName": "lp_price_amount_usd",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "launchpadMetadata.marketCapAmount",
+            "columnName": "lp_market_cap_amount_usd",
+            "affinity": "REAL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "address"
+          ]
+        }
+      },
+      {
+        "tableName": "token_social_links",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `token_address` TEXT NOT NULL, `type` TEXT NOT NULL, `value` TEXT NOT NULL, FOREIGN KEY(`token_address`) REFERENCES `tokens`(`address`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tokenAddress",
+            "columnName": "token_address",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_token_social_links_token_address",
+            "unique": false,
+            "columnNames": [
+              "token_address"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_token_social_links_token_address` ON `${TABLE_NAME}` (`token_address`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "tokens",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "token_address"
+            ],
+            "referencedColumns": [
+              "address"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "token_valuation",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`token_address` TEXT NOT NULL, `balance_quarks` INTEGER NOT NULL, `cost_basis` REAL NOT NULL, PRIMARY KEY(`token_address`), FOREIGN KEY(`token_address`) REFERENCES `tokens`(`address`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "tokenAddress",
+            "columnName": "token_address",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "balanceQuarks",
+            "columnName": "balance_quarks",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "costBasis",
+            "columnName": "cost_basis",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "token_address"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_token_valuation_token_address",
+            "unique": false,
+            "columnNames": [
+              "token_address"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_token_valuation_token_address` ON `${TABLE_NAME}` (`token_address`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "tokens",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "token_address"
+            ],
+            "referencedColumns": [
+              "address"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "currency_creator_draft",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `description` TEXT NOT NULL, `icon_uri` TEXT, `bill_customizations` TEXT, `attestations` TEXT, `current_step` TEXT NOT NULL, `created_mint` TEXT, `saved_at` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "iconUri",
+            "columnName": "icon_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "billCustomizations",
+            "columnName": "bill_customizations",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "attestations",
+            "columnName": "attestations",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "currentStep",
+            "columnName": "current_step",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdMint",
+            "columnName": "created_mint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "savedAt",
+            "columnName": "saved_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "contact_sync_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `checksumBytes` BLOB NOT NULL, `lastSyncTimestamp` INTEGER NOT NULL, `needsFullUpload` INTEGER NOT NULL, `hasDiscoveredFlipcashContacts` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "checksumBytes",
+            "columnName": "checksumBytes",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncTimestamp",
+            "columnName": "lastSyncTimestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "needsFullUpload",
+            "columnName": "needsFullUpload",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasDiscoveredFlipcashContacts",
+            "columnName": "hasDiscoveredFlipcashContacts",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "contact_mapping",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`e164` TEXT NOT NULL, `androidContactId` INTEGER NOT NULL, `displayName` TEXT NOT NULL, `photoUri` TEXT, `isOnFlipcash` INTEGER NOT NULL, `displayNumber` TEXT NOT NULL DEFAULT '', `dmChatId` TEXT NOT NULL DEFAULT '', `joinedAtEpochSeconds` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`e164`))",
+        "fields": [
+          {
+            "fieldPath": "e164",
+            "columnName": "e164",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "androidContactId",
+            "columnName": "androidContactId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "photoUri",
+            "columnName": "photoUri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isOnFlipcash",
+            "columnName": "isOnFlipcash",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayNumber",
+            "columnName": "displayNumber",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "dmChatId",
+            "columnName": "dmChatId",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "joinedAtEpochSeconds",
+            "columnName": "joinedAtEpochSeconds",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "e164"
+          ]
+        }
+      },
+      {
+        "tableName": "chat_metadata",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`chat_id_hex` TEXT NOT NULL, `chat_type` TEXT NOT NULL, `last_activity_epoch_ms` INTEGER NOT NULL, `last_message_id` INTEGER, `latest_event_sequence` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`chat_id_hex`))",
+        "fields": [
+          {
+            "fieldPath": "chatIdHex",
+            "columnName": "chat_id_hex",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatType",
+            "columnName": "chat_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastActivityEpochMs",
+            "columnName": "last_activity_epoch_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastMessageId",
+            "columnName": "last_message_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "latestEventSequence",
+            "columnName": "latest_event_sequence",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "chat_id_hex"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chat_metadata_last_activity_epoch_ms",
+            "unique": false,
+            "columnNames": [
+              "last_activity_epoch_ms"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chat_metadata_last_activity_epoch_ms` ON `${TABLE_NAME}` (`last_activity_epoch_ms`)"
+          }
+        ]
+      },
+      {
+        "tableName": "chat_messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`chat_id_hex` TEXT NOT NULL, `message_id` INTEGER NOT NULL, `sender_id_hex` TEXT, `content_json` TEXT, `timestamp_epoch_ms` INTEGER NOT NULL, `unread_seq` INTEGER NOT NULL, `status` TEXT NOT NULL DEFAULT 'SENT', `pending_client_id_hex` TEXT, `event_sequence` INTEGER NOT NULL DEFAULT 0, `last_edited_ts_epoch_ms` INTEGER, `reactions_json` TEXT, PRIMARY KEY(`chat_id_hex`, `message_id`))",
+        "fields": [
+          {
+            "fieldPath": "chatIdHex",
+            "columnName": "chat_id_hex",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageId",
+            "columnName": "message_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "senderIdHex",
+            "columnName": "sender_id_hex",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "contentJson",
+            "columnName": "content_json",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "timestampEpochMs",
+            "columnName": "timestamp_epoch_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "unreadSeq",
+            "columnName": "unread_seq",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'SENT'"
+          },
+          {
+            "fieldPath": "pendingClientIdHex",
+            "columnName": "pending_client_id_hex",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "eventSequence",
+            "columnName": "event_sequence",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "lastEditedTsEpochMs",
+            "columnName": "last_edited_ts_epoch_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "reactionsJson",
+            "columnName": "reactions_json",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "chat_id_hex",
+            "message_id"
+          ]
+        }
+      },
+      {
+        "tableName": "chat_members",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`chat_id_hex` TEXT NOT NULL, `user_id_hex` TEXT NOT NULL, `user_profile_json` TEXT, `pointers_json` TEXT, PRIMARY KEY(`chat_id_hex`, `user_id_hex`))",
+        "fields": [
+          {
+            "fieldPath": "chatIdHex",
+            "columnName": "chat_id_hex",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userIdHex",
+            "columnName": "user_id_hex",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userProfileJson",
+            "columnName": "user_profile_json",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pointersJson",
+            "columnName": "pointers_json",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "chat_id_hex",
+            "user_id_hex"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '9ab78877c87a08d5bb3fd93908434346')"
+    ]
+  }
+}

--- a/apps/flipcash/shared/persistence/db/src/main/kotlin/com/flipcash/app/persistence/FlipcashDatabase.kt
+++ b/apps/flipcash/shared/persistence/db/src/main/kotlin/com/flipcash/app/persistence/FlipcashDatabase.kt
@@ -70,8 +70,9 @@ import com.getcode.utils.subByteArray
         AutoMigration(from = 19, to = 20),
         AutoMigration(from = 20, to = 21),
         AutoMigration(from = 21, to = 22),
+        AutoMigration(from = 22, to = 23, spec = FlipcashDatabase.Migration22To23::class),
     ],
-    version = 22,
+    version = 23,
 )
 @TypeConverters(TokenTypeConverters::class, ChatTypeConverters::class)
 abstract class FlipcashDatabase : RoomDatabase() {
@@ -154,6 +155,17 @@ abstract class FlipcashDatabase : RoomDatabase() {
         override fun migrate(db: SupportSQLiteDatabase) {
             db.execSQL("DELETE FROM tokens")
             db.execSQL("DELETE FROM token_valuation")
+        }
+    }
+
+    // Data-only migration: the chat.v1.ChatType proto enum renamed DM -> CONTACT_DM
+    // (and added TIP_DM), and chat_type is persisted as the domain enum's name. There
+    // is no schema change, so this rides the auto migration and rewrites existing rows
+    // in onPostMigrate so they keep resolving after the rename instead of falling
+    // through to UNKNOWN.
+    class Migration22To23 : AutoMigrationSpec {
+        override fun onPostMigrate(db: SupportSQLiteDatabase) {
+            db.execSQL("UPDATE chat_metadata SET chat_type = 'CONTACT_DM' WHERE chat_type = 'DM'")
         }
     }
 

--- a/definitions/flipcash/protos/src/main/proto/blob/v1/blob_storage_service.proto
+++ b/definitions/flipcash/protos/src/main/proto/blob/v1/blob_storage_service.proto
@@ -1,0 +1,152 @@
+syntax = "proto3";
+
+package flipcash.blob.v1;
+
+option go_package = "github.com/code-payments/flipcash2-protobuf-api/generated/go/blob/v1;blobpb";
+option java_package = "com.codeinc.flipcash.gen.blob.v1";
+option objc_class_prefix = "FPBBlobV1";
+
+import "blob/v1/model.proto";
+import "common/v1/common.proto";
+import "validate/validate.proto";
+
+// BlobStorage manages direct-to-storage uploads and authorized, time-limited reads
+// of the bytes behind MediaItem renditions (and other blobs). Clients upload bytes
+// straight to object storage via a presigned target — the server never proxies
+// them — and all blob metadata is server-derived from the stored bytes.
+service BlobStorage {
+    // GetUploadPolicy returns the current upload constraints — which MIME types
+    // are accepted and the per-type ceilings the server enforces — so the client
+    // can validate (and resize/transcode) BEFORE reserving an upload. The policy
+    // is advisory and cacheable; InitiateExternalUpload remains authoritative and
+    // may still deny. Clients re-fetch when version changes or ttl lapses.
+    rpc GetUploadPolicy(GetUploadPolicyRequest) returns (GetUploadPolicyResponse);
+
+    // InitiateExternalUpload reserves a BlobId and returns a short-lived presigned
+    // target the client uploads the bytes to directly. Clients only ever upload
+    // ORIGINALs; the server derives any additional renditions itself.
+    rpc InitiateExternalUpload(InitiateExternalUploadRequest) returns (InitiateExternalUploadResponse);
+
+    // CompleteExternalUpload is an ADVISORY signal that the client finished uploading,
+    // letting the server finalize (validate, derive metadata, transcode
+    // renditions, moderate) without waiting for the storage-completion event.
+    // It is idempotent; if never called, the storage event finalizes the blob
+    // anyway. Clients must not depend on it for correctness.
+    rpc CompleteExternalUpload(CompleteExternalUploadRequest) returns (CompleteExternalUploadResponse);
+
+    // GetBlobs resolves known BlobIds to their current status and metadata,
+    // minting a FRESH, short-lived download_url for each READY blob. Clients
+    // call it to reissue a URL that has expired — the BlobId is the durable
+    // handle; the URL is disposable. A caller must set GetBlobsRequest.context
+    // to the surface it is reading from (e.g. a chat) to authorize blobs it
+    // does not own.
+    rpc GetBlobs(GetBlobsRequest) returns (GetBlobsResponse);
+}
+
+message GetUploadPolicyRequest {
+    common.v1.Auth auth = 1 [(validate.rules).message.required = true];
+}
+
+message GetUploadPolicyResponse {
+    Result result = 1;
+    enum Result {
+        OK     = 0;
+        DENIED = 1;
+    }
+
+    // The constraints in force for the caller. Set when result == OK.
+    UploadPolicy policy = 2;
+}
+
+message InitiateExternalUploadRequest {
+    common.v1.Auth auth = 1 [(validate.rules).message.required = true];
+
+    // Declared MIME type of the bytes the client intends to upload. The server
+    // pins it into the signed upload policy (storage rejects a mismatched
+    // Content-Type) and re-derives it authoritatively from the bytes after
+    // upload. A hint that constrains the upload, never blindly trusted.
+    string mime_type = 2 [(validate.rules).string = {
+        min_len: 1
+        max_len: 255
+    }];
+
+    // Declared byte size. The server bakes it into the policy's
+    // content-length-range so storage rejects an upload that exceeds it.
+    uint64 size_bytes = 3 [(validate.rules).uint64.gte = 1];
+}
+
+message InitiateExternalUploadResponse {
+    Result result = 1;
+    enum Result {
+        OK               = 0;
+        DENIED           = 1;
+        UNSUPPORTED_TYPE = 2; // MIME type not accepted
+        TOO_LARGE        = 3; // declared size over the per-type ceiling
+        QUOTA_EXCEEDED   = 4; // caller is over their storage/upload quota
+    }
+
+    // Server-assigned handle. On OK the client references this as the ORIGINAL
+    // rendition's blob_id on SendMessage.
+    BlobId blob_id = 2;
+
+    // Where and how to upload the bytes. Set only when result == OK.
+    UploadTarget upload_target = 3;
+
+    // On a policy-driven denial (UNSUPPORTED_TYPE / TOO_LARGE), the UploadPolicy
+    // version in force, so the client can detect a stale cached policy and
+    // re-fetch. Unset otherwise.
+    PolicyVersion policy_version = 4;
+}
+
+message CompleteExternalUploadRequest {
+    common.v1.Auth auth = 1 [(validate.rules).message.required = true];
+
+    // The blob whose upload just finished.
+    BlobId blob_id = 2 [(validate.rules).message.required = true];
+}
+
+message CompleteExternalUploadResponse {
+    Result result = 1;
+    enum Result {
+        OK           = 0;
+        NOT_FOUND    = 1; // no pending blob with this id for the caller
+        NOT_UPLOADED = 2; // bytes not present / upload incomplete
+    }
+
+    // Blob state after this call (often still PROCESSING).
+    BlobStatus status = 2;
+
+    // Why the blob was rejected. Set only when status == REJECTED.
+    RejectionMetadata rejection_metadata = 3;
+}
+
+message GetBlobsRequest {
+    common.v1.Auth auth = 1 [(validate.rules).message.required = true];
+
+    // The blobs to resolve.
+    BlobIdBatch blob_ids = 2 [(validate.rules).message.required = true];
+
+    // The surface the caller is accessing these blobs from. When set, the
+    // server authorizes the entire batch through this single context, turning
+    // the read into a direct membership check instead of a search across the
+    // blob's grants.
+    //
+    // OPTIONAL on the wire, but REQUIRED in practice for any blob the caller
+    // does not OWN: blobs the caller owns resolve without a context, while a
+    // non-owned id is treated as unauthorized (and omitted from the response)
+    // unless a context that authorizes it is supplied. A caller reading only
+    // its own blobs may omit it, so existing owner-only clients are unaffected.
+    AccessContext context = 3;
+}
+
+message GetBlobsResponse {
+    Result result = 1;
+    enum Result {
+        OK     = 0;
+        DENIED = 1;
+    }
+
+    // The resolved blobs. Unknown or unauthorized ids are omitted; the batch
+    // is left unset (not empty) when none resolve.
+    BlobBatch blobs = 2;
+}

--- a/definitions/flipcash/protos/src/main/proto/blob/v1/model.proto
+++ b/definitions/flipcash/protos/src/main/proto/blob/v1/model.proto
@@ -6,6 +6,10 @@ option go_package = "github.com/code-payments/flipcash2-protobuf-api/generated/g
 option java_package = "com.codeinc.flipcash.gen.blob.v1";
 option objc_class_prefix = "FPBBlobV1";
 
+import "common/v1/common.proto";
+import "moderation/v1/model.proto";
+import "google/protobuf/duration.proto";
+import "google/protobuf/timestamp.proto";
 import "validate/validate.proto";
 
 // Opaque, client-held handle to a stored blob. This is the durable identity for
@@ -14,6 +18,46 @@ message BlobId {
     bytes value = 1 [(validate.rules).bytes = {
         min_len: 16
         max_len: 16
+    }];
+}
+
+// A batch of BlobIds
+message BlobIdBatch {
+    repeated BlobId blob_ids = 1 [(validate.rules).repeated = {
+        min_items: 1
+        max_items: 100
+    }];
+}
+
+// Lifecycle state of a blob.
+enum BlobStatus {
+    BLOB_STATUS_UNKNOWN    = 0;
+    BLOB_STATUS_PENDING    = 1; // reserved; awaiting the client's upload
+    BLOB_STATUS_PROCESSING = 2; // bytes present; deriving metadata / transcoding / moderating
+    BLOB_STATUS_READY      = 3; // available; metadata populated and moderation passed
+    BLOB_STATUS_REJECTED   = 4; // failed validation or moderation; not servable
+}
+
+// A blob's current status, plus its metadata once READY — or, once REJECTED,
+// the reason it was rejected.
+message Blob {
+    BlobId id = 1 [(validate.rules).message.required = true];
+
+    BlobStatus status = 2;
+
+    // Server-authoritative metadata, including a freshly minted download_url.
+    // Set only when status == READY.
+    BlobMetadata metadata = 3;
+
+    // Why the blob was rejected. Set only when status == REJECTED.
+    RejectionMetadata rejection = 4;
+}
+
+// A batch of Blobs.
+message BlobBatch {
+    repeated Blob blobs = 1 [(validate.rules).repeated = {
+        min_items: 1
+        max_items: 100
     }];
 }
 
@@ -30,15 +74,9 @@ message BlobMetadata {
     // Total size of the blob in bytes.
     uint64 size_bytes = 2 [(validate.rules).uint64.gte = 1];
 
-    // Ephemeral, server-minted URL for fetching the blob bytes. Unlike the
-    // other fields it is NOT intrinsic to the blob: it is re-issued on every
-    // fetch, may expire (signed URL with a short TTL), and is authorized at
-    // mint time, not at fetch time. Clients MUST NOT persist or cache it across
-    // fetches; treat the BlobId as the durable handle and this as disposable.
-    string download_url = 3 [(validate.rules).string = {
-        uri: true
-        max_len: 2048
-    }];
+    // Ephemeral, server-minted URL for fetching the blob bytes, together with
+    // the instant it expires. Re-issued on every fetch — see DownloadUrl.
+    DownloadUrl download_url = 3 [(validate.rules).message.required = true];
 
     // Kind-specific metadata the server derived from the bytes. Exactly one
     // variant is set for a recognized media kind; left unset for opaque blobs.
@@ -57,4 +95,232 @@ message ImageMetadata {
 
     // Compact preview shown while the full image downloads (BlurHash string).
     string blurhash = 3 [(validate.rules).string.max_len = 64];
+}
+
+// One logical piece of media — a chat image, a profile picture — carried as the
+// set of renditions it is stored as. Distinct from Blob: a Blob is ONE stored
+// object, while a Media is the several stored objects that together represent
+// the same content at different qualities/sizes.
+//
+// Wherever a surface attaches media, it embeds this type: the client uploads a
+// single ORIGINAL and the server derives the rest, identically everywhere.
+message Media {
+    // The renditions of this media, each an independently-stored blob. When a
+    // client attaches media (e.g. SendMessage, SetProfilePicture) it supplies
+    // exactly one ORIGINAL rendition (its blob_id); the server fills that
+    // rendition's metadata and appends any derived renditions (e.g. a
+    // downscaled DISPLAY and a THUMBNAIL).
+    repeated Rendition renditions = 1 [(validate.rules).repeated = {
+        min_items: 1
+    }];
+}
+
+// A single stored variant of a Media.
+message Rendition {
+    // The intended use of this rendition within the media.
+    Role role = 1 [(validate.rules).enum = {
+        not_in: [0]
+    }];
+    enum Role {
+        UNKNOWN   = 0;
+        ORIGINAL  = 1; // full-quality source the client uploaded
+        DISPLAY   = 2; // downscaled/compressed for inline display
+        THUMBNAIL = 3; // tiny preview (grid cell, avatar, ...)
+    }
+
+    // Handle to the blob holding this rendition's bytes. Client-set on the
+    // ORIGINAL when attaching the media; server-set for derived renditions.
+    BlobId blob_id = 2 [(validate.rules).message.required = true];
+
+    // Server-authoritative blob metadata (mime type, size, download URL, and
+    // the image dimensions/preview), resolved from the blob record. Omitted on
+    // the request that attaches the media and populated on returned copies.
+    //
+    // If unavailable at the time the media is retrieved, the client can use
+    // GetBlobs to query for the blob metadata.
+    BlobMetadata blob = 3;
+}
+
+// The constraints the server enforces on uploads, surfaced so clients can
+// validate and resize/transcode before reserving an upload. Advisory and
+// cacheable; InitiateExternalUpload remains authoritative. Constraints can
+// depend on the caller (quota, tier), so this is fetched per-user, not static.
+message UploadPolicy {
+    // Opaque generation token for this policy. Clients cache the policy under it
+    // and re-fetch when they observe a different version — including one echoed
+    // on a denied upload.
+    PolicyVersion version = 1 [(validate.rules).message.required = true];
+
+    // How long the client may rely on this policy before re-fetching. The client
+    // should also refresh on any version mismatch, whichever comes first.
+    google.protobuf.Duration ttl = 2 [(validate.rules).duration.required = true];
+
+    // Per-MIME-type constraints, ordered MOST SPECIFIC FIRST. The client picks
+    // the FIRST entry whose mime_type_pattern matches the bytes' declared MIME
+    // type; later entries (e.g. "image/*", then "*/*") act as fallbacks. An
+    // upload whose type matches no entry is not accepted.
+    repeated MimeTypeConstraints mime_type_constraints = 3 [(validate.rules).repeated = {
+        min_items: 1
+        max_items: 1024
+    }];
+}
+
+// Opaque generation token identifying a snapshot of an UploadPolicy. Compared
+// by equality, never parsed; clients cache the policy under it and re-fetch when
+// they observe a different value (including one echoed on a denied upload).
+message PolicyVersion {
+    string value = 1 [(validate.rules).string = {
+        min_len: 1
+        max_len: 256
+    }];
+}
+
+// Upload constraints for one MIME-type matcher.
+message MimeTypeConstraints {
+    // The MIME type(s) this entry governs: an exact type ("image/jpeg"), a
+    // subtype wildcard ("image/*"), or the catch-all "*/*".
+    string mime_type_pattern = 1 [(validate.rules).string = {
+        min_len: 3
+        max_len: 255
+    }];
+
+    // Hard ceiling on a matching blob's byte size.
+    uint64 max_size_bytes = 2 [(validate.rules).uint64.gte = 1];
+
+    // Kind-specific bounds, mirroring BlobMetadata.kind. Set the variant for the
+    // pattern's media kind; left unset for opaque blobs.
+    oneof kind {
+        ImageConstraints image = 3;
+    }
+}
+
+// Bounds on a still image, mirroring ImageMetadata.
+message ImageConstraints {
+    // Max pixel dimensions the server will accept (or downscale to).
+    uint32 max_width  = 1 [(validate.rules).uint32.gte = 1];
+    uint32 max_height = 2 [(validate.rules).uint32.gte = 1];
+
+    // Max total pixel count (width * height), guarding against decompression
+    // bombs that slip under the per-axis caps.
+    uint64 max_pixels = 3 [(validate.rules).uint64.gte = 1];
+}
+
+// A short-lived, presigned target for a direct-to-storage upload. Bearer
+// credential: anyone holding it can upload to the reserved key until it expires
+// — the client must not share or persist it.
+//
+// Provider-agnostic by design: it describes the HTTP request the client must
+// make, with all signed material opaque to the client. Today the server mints
+// S3 POST policies (method POST with form_fields); the same shape also
+// expresses presigned PUT (S3/GCS) and Azure SAS without a contract change.
+message UploadTarget {
+    // How the client issues the upload request.
+    Method method = 1 [(validate.rules).enum = {
+        not_in: [0]
+    }];
+    enum Method {
+        UNKNOWN = 0;
+        PUT     = 1; // raw-body upload
+        POST    = 2; // multipart/form-data carrying form_fields
+    }
+
+    // Signed URL to send the request to. For PUT-style uploads this often
+    // already carries the signature in its query string (presigned PUT, SAS).
+    string url = 2 [(validate.rules).string = {
+        uri: true
+        max_len: 2048
+    }];
+
+    // Headers the client MUST send verbatim (e.g. Content-Type, x-ms-blob-type,
+    // and any signed headers the presign requires).
+    map<string, string> headers = 3;
+
+    // For method == POST: multipart/form-data fields sent before the file part,
+    // carrying the server-chosen key and the SIGNED policy that storage enforces
+    // (Content-Type, content-length-range, key prefix, ...). The client cannot
+    // alter them without invalidating the signature. Empty for PUT uploads.
+    map<string, string> form_fields = 4;
+
+    // When the target expires; after this the client must call InitiateUpload
+    // again for a fresh one.
+    google.protobuf.Timestamp expires_at = 5 [(validate.rules).timestamp.required = true];
+}
+
+// An ephemeral, server-minted URL for fetching the blob bytes, paired with the
+// instant it expires. Unlike the intrinsic blob metadata, the URL is NOT a
+// property of the bytes: it is re-issued on every fetch, expires (signed URL
+// with a short TTL), and is authorized at mint time, not at fetch time. Clients
+// MUST NOT persist or cache it across fetches; treat the BlobId as the durable
+// handle and this as disposable.
+message DownloadUrl {
+    // Signed URL for fetching the blob bytes.
+    string url = 1 [(validate.rules).string = {
+        uri: true
+        max_len: 2048
+    }];
+
+    // When the URL expires; after this the client must call GetBlobs again to
+    // mint a fresh one.
+    google.protobuf.Timestamp expires_at = 2 [(validate.rules).timestamp.required = true];
+}
+
+// Explains why a blob was rejected during finalization. Set on a Blob only when
+// status == REJECTED. Rejection is TERMINAL: the bytes behind a BlobId are
+// immutable, so this id will never become READY — to try again the client must
+// reserve a fresh upload via InitiateExternalUpload.
+message RejectionMetadata {
+    // The top-level reason finalization failed.
+    RejectionReason reason = 1 [(validate.rules).enum = {
+        not_in: [0]
+    }];
+
+    // The best-fit category that tripped moderation, mirroring the Moderation
+    // service's vocabulary. Set only when reason == REJECTION_REASON_MODERATION;
+    // NONE otherwise.
+    moderation.v1.FlaggedCategory flagged_category = 2;
+}
+
+// Why a blob failed finalization, after its bytes were uploaded. Distinct from
+// the pre-upload denials in InitiateExternalUploadResponse.Result, which reject
+// before any bytes are stored.
+enum RejectionReason {
+    REJECTION_REASON_UNKNOWN          = 0;
+    REJECTION_REASON_MODERATION       = 1; // tripped content moderation; see flagged_category
+    REJECTION_REASON_UNSUPPORTED_TYPE = 2; // MIME type derived from the bytes is not accepted
+    REJECTION_REASON_MISMATCHED_TYPE  = 3; // derived type didn't match the declared mime_type
+    REJECTION_REASON_TOO_LARGE        = 4; // stored bytes exceeded the per-type ceiling
+    REJECTION_REASON_CORRUPT          = 5; // bytes unreadable; failed to decode or transcode
+    REJECTION_REASON_INTERNAL         = 6; // server-side processing error
+    REJECTION_REASON_PRIVACY_METADATA = 7; // blob contains privacy metadata that was not stripped
+}
+
+// AccessContext names the surface a caller is accessing blobs THROUGH on a
+// request — the "place" the read is happening from. It is the extension point
+// for blob authorization contexts: each scope maps to a server-side membership
+// check (e.g. a chat scope authorizes the caller iff they belong to that chat
+// AND the blob was shared into it).
+//
+// It is a hint that can only ever NARROW a read, never widen it: the server
+// still independently verifies both that the blob is granted to the named scope
+// and that the caller belongs to it. A caller never needs a context to read
+// blobs it OWNS, but does need one for any blob it does not own. New surfaces (a
+// feed, a profile, a public link) are added as new arms of `scope` without
+// changing any request plumbing.
+message AccessContext {
+    oneof scope {
+        option (validate.required) = true;
+
+        // The caller is accessing these blobs from within this chat. Authorized
+        // iff the caller is a member of the chat and the blob was shared into it.
+        common.v1.ChatId chat = 1 [(validate.rules).message.required = true];
+
+        // The caller is accessing these blobs from this user's public profile.
+        // Authorized iff the blob is a rendition of that user's CURRENT profile
+        // picture — a profile grants nothing else, and a superseded picture's
+        // renditions stop resolving through it.
+        //
+        // A caller never needs this for its OWN profile picture, since it owns
+        // those blobs.
+        common.v1.UserId profile = 2 [(validate.rules).message.required = true];
+    }
 }

--- a/definitions/flipcash/protos/src/main/proto/chat/v1/chat_service.proto
+++ b/definitions/flipcash/protos/src/main/proto/chat/v1/chat_service.proto
@@ -67,6 +67,13 @@ message GetDmChatFeedRequest {
     // snapshot. The token is opaque and server-generated; do not construct it.
     common.v1.QueryOptions query_options = 1;
 
+    // The type of DM chat to filter for
+    //
+    // For backwards compatiblity, UNKNOWN maps to CONTACT_DM for legacy clients
+    ChatType dm_chat_type = 2 [(validate.rules).enum = {
+        in: [0, 1, 2] // UNKNOWN, CONTACT_DM, TIP_DM
+    }];
+
     common.v1.Auth auth = 10 [(validate.rules).message.required = true];
 }
 

--- a/definitions/flipcash/protos/src/main/proto/chat/v1/model.proto
+++ b/definitions/flipcash/protos/src/main/proto/chat/v1/model.proto
@@ -12,6 +12,12 @@ import "messaging/v1/model.proto";
 import "validate/validate.proto";
 import "google/protobuf/timestamp.proto";
 
+enum ChatType {
+    UNKNOWN    = 0;
+    CONTACT_DM = 1;
+    TIP_DM     = 2;
+}
+
 message Metadata {
     common.v1.ChatId chat_id = 1 [(validate.rules).message.required = true];
 
@@ -19,10 +25,6 @@ message Metadata {
     ChatType type = 2 [(validate.rules).enum = {
         not_in: [0] // UNKNOWN
     }];
-    enum ChatType {
-        UNKNOWN = 0;
-        DM      = 1;
-    }
 
     // Members of this chat
     repeated Member members = 3;

--- a/definitions/flipcash/protos/src/main/proto/event/v1/model.proto
+++ b/definitions/flipcash/protos/src/main/proto/event/v1/model.proto
@@ -6,6 +6,7 @@ option go_package = "github.com/code-payments/flipcash2-protobuf-api/generated/g
 option java_package = "com.codeinc.flipcash.gen.events.v1";
 option objc_class_prefix = "FPBEventV1";
 
+import "blob/v1/model.proto";
 import "chat/v1/model.proto";
 import "common/v1/common.proto";
 import "messaging/v1/model.proto";
@@ -31,6 +32,7 @@ message Event {
 
         TestEvent  test        = 3;
         ChatUpdate chat_update = 4;
+        BlobUpdate blob_update = 5;
     }
 }
 
@@ -112,4 +114,19 @@ message ChatUpdate {
     // ReactionUpdate.sequence and reconcile any misses by refreshing a message's
     // ReactionSummary on view.
     messaging.v1.ReactionUpdateBatch reaction_updates = 7;
+}
+
+// BlobUpdate notifies the recipient in real time that blobs they uploaded have
+// transitioned to a new lifecycle state — e.g. PROCESSING → READY once the
+// server finishes validating, transcoding, and moderating, or → REJECTED on
+// failure. It lets clients react to upload completion via the event stream
+// instead of polling BlobStorage.GetBlobs.
+//
+// Best-effort: a client that misses an update reconciles by calling
+// BlobStorage.GetBlobs. The BlobId is the durable handle; any download_url
+// carried here is ephemeral and may be re-minted via GetBlobs.
+message BlobUpdate {
+    // The blobs that transitioned, each carrying its new status and, when READY,
+    // its resolved metadata (including a freshly minted download_url).
+    blob.v1.BlobBatch blobs = 1 [(validate.rules).message.required = true];
 }

--- a/definitions/flipcash/protos/src/main/proto/intent/v1/model.proto
+++ b/definitions/flipcash/protos/src/main/proto/intent/v1/model.proto
@@ -26,6 +26,7 @@ message ChatMetadata {
         option (validate.required) = true;
 
         ContactDmPayment contact_dm_payment = 2;
+        TipDmPayment     tip_dm_payment     = 3;
     }
 
     // For sending a payment to a contact in a DM
@@ -35,5 +36,10 @@ message ChatMetadata {
 
         // Destination phone number that is being paid. This is validated to be linked to the receiver.
         phone.v1.PhoneNumber destination = 2 [(validate.rules).message.required = true];
+    }
+
+    // For sending a DM tip payment to someone. The message is empty, since
+    // it's between two user IDs, which map directly to/from public keys.
+    message TipDmPayment {
     }
 }

--- a/definitions/flipcash/protos/src/main/proto/messaging/v1/model.proto
+++ b/definitions/flipcash/protos/src/main/proto/messaging/v1/model.proto
@@ -147,47 +147,16 @@ message ReplyContent {
 message MediaContent {
     // The media items attached to this message. A single item today; raising
     // this cap later enables albums (each item self-describes its kind).
-    repeated MediaItem items = 1 [(validate.rules).repeated = {
+    //
+    // On SendMessage the client supplies exactly one ORIGINAL rendition per
+    // item; the server fills its metadata and appends the derived renditions.
+    repeated blob.v1.Media items = 1 [(validate.rules).repeated = {
         min_items: 1
         max_items: 1
     }];
 
     // Optional caption rendered alongside the media
     TextContent caption = 2;
-}
-
-// One logical media item, carried as its set of renditions (quality/size variants).
-message MediaItem {
-    // The renditions of this media, each an independently-stored blob. On
-    // SendMessage the client supplies exactly one ORIGINAL rendition (its
-    // blob_id); the server fills metadata and appends any derived renditions
-    // (e.g. a downscaled DISPLAY and a THUMBNAIL).
-    repeated MediaItemRendition renditions = 1 [(validate.rules).repeated = {
-        min_items: 1
-    }];
-}
-
-// A single stored variant of a MediaItem
-message MediaItemRendition {
-    // The intended use of this rendition within the item.
-    Role role = 1 [(validate.rules).enum = {
-        not_in: [0]
-    }];
-    enum Role {
-        UNKNOWN   = 0;
-        ORIGINAL  = 1; // full-quality source the client uploaded
-        DISPLAY   = 2; // downscaled/compressed for inline display
-        THUMBNAIL = 3; // tiny grid preview
-    }
-
-    // Handle to the blob holding this rendition's bytes. Client-set on the
-    // ORIGINAL at send time; server-set for derived renditions.
-    blob.v1.BlobId blob_id = 2 [(validate.rules).message.required = true];
-
-    // Server-authoritative blob metadata (mime type, size, download URL, and
-    // the image dimensions/preview), resolved from the blob record. Omitted on
-    // SendMessage and populated on stored/returned messages.
-    blob.v1.BlobMetadata blob = 3;
 }
 
 // System message content

--- a/definitions/flipcash/protos/src/main/proto/moderation/v1/model.proto
+++ b/definitions/flipcash/protos/src/main/proto/moderation/v1/model.proto
@@ -1,0 +1,38 @@
+syntax = "proto3";
+
+package flipcash.moderation.v1;
+
+option go_package = "github.com/code-payments/flipcash2-protobuf-api/generated/go/moderation/v1;moderationpb";
+option java_package = "com.codeinc.flipcash.gen.moderation.v1";
+option objc_class_prefix = "FPBModerationV1";
+
+import "common/v1/common.proto";
+import "google/protobuf/timestamp.proto";
+
+// ModerationAttestation is a signed proof of the moderation result.
+// The signature is computed over this message without the signature field set.
+message ModerationAttestation {
+    // SHA-256 hash of the moderated content to be allowed
+    bytes content_hash = 1;
+
+    // Timestamp of the moderation
+    google.protobuf.Timestamp timestamp = 2;
+
+    // The user who submitted the content
+    common.v1.UserId user_id = 3;
+
+    // Public key of the attestor that signed this message
+    common.v1.PublicKey attestor = 4;
+
+    // Attestor signature over this message
+    common.v1.Signature signature = 5;
+}
+
+enum FlaggedCategory {
+    NONE          = 0;
+    OTHER         = 1; // Fallback category when flagged content does not fit into a well-defined FlaggedCategory
+    NSFW          = 2;
+    IMPERSONATION = 3;
+    MISLEADING    = 4;
+    SPAM          = 5;
+}

--- a/definitions/flipcash/protos/src/main/proto/moderation/v1/moderation_service.proto
+++ b/definitions/flipcash/protos/src/main/proto/moderation/v1/moderation_service.proto
@@ -7,7 +7,7 @@ option java_package = "com.codeinc.flipcash.gen.moderation.v1";
 option objc_class_prefix = "FPBModerationV1";
 
 import "common/v1/common.proto";
-import "google/protobuf/timestamp.proto";
+import "moderation/v1/model.proto";
 import "validate/validate.proto";
 
 service Moderation {
@@ -72,32 +72,4 @@ message ModerateImageResponse {
 
     // The best fit flagged category when content is not allowed
     FlaggedCategory flagged_category = 4;
-}
-
-// ModerationAttestation is a signed proof of the moderation result.
-// The signature is computed over this message without the signature field set.
-message ModerationAttestation {
-    // SHA-256 hash of the moderated content to be allowed
-    bytes content_hash = 1;
-
-    // Timestamp of the moderation
-    google.protobuf.Timestamp timestamp = 2;
-
-    // The user who submitted the content
-    common.v1.UserId user_id = 3;
-
-    // Public key of the attestor that signed this message
-    common.v1.PublicKey attestor = 4;
-
-    // Attestor signature over this message
-    common.v1.Signature signature = 5;
-}
-
-enum FlaggedCategory {
-    NONE          = 0;
-    OTHER         = 1; // Fallback category when flagged content does not fit into a well-defined FlaggedCategory
-    NSFW          = 2;
-    IMPERSONATION = 3;
-    MISLEADING    = 4;
-    SPAM          = 5;
 }

--- a/definitions/flipcash/protos/src/main/proto/profile/v1/model.proto
+++ b/definitions/flipcash/protos/src/main/proto/profile/v1/model.proto
@@ -6,6 +6,7 @@ option go_package = "github.com/code-payments/flipcash2-protobuf-api/generated/g
 option java_package = "com.codeinc.flipcash.gen.profile.v1";
 option objc_class_prefix = "FPBProfileV1";
 
+import "blob/v1/model.proto";
 import "email/v1/model.proto";
 import "phone/v1/model.proto";
 import "validate/validate.proto";
@@ -31,6 +32,17 @@ message UserProfile {
     // Email address linked to this user. This is private and will only be returned
     // when the requesting user asks for their own profile
     email.v1.EmailAddress email_address = 4;
+
+    // The user's profile picture, as the set of renditions it is stored as —
+    // typically a DISPLAY for the profile view and a THUMBNAIL for avatars in
+    // member rows and chat lists.
+    //
+    // Unset when the user has not set a picture. Set it with SetProfilePicture.
+    //
+    // To fetch the bytes of ANOTHER user's picture, the caller does not own
+    // these blobs, so a GetBlobs call must carry a blob.v1.AccessContext whose
+    // `profile` scope names this user. A caller reading its own needs none.
+    blob.v1.Media profile_picture = 5;
 }
 
 message SocialProfile {

--- a/definitions/flipcash/protos/src/main/proto/profile/v1/profile_service.proto
+++ b/definitions/flipcash/protos/src/main/proto/profile/v1/profile_service.proto
@@ -6,7 +6,9 @@ option go_package = "github.com/code-payments/flipcash2-protobuf-api/generated/g
 option java_package = "com.codeinc.flipcash.gen.profile.v1";
 option objc_class_prefix = "FPBProfileV1";
 
+import "blob/v1/model.proto";
 import "common/v1/common.proto";
+import "moderation/v1/model.proto";
 import "profile/v1/model.proto";
 import "validate/validate.proto";
 
@@ -14,6 +16,15 @@ service Profile {
 	rpc GetProfile(GetProfileRequest) returns (GetProfileResponse);
 
 	rpc SetDisplayName(SetDisplayNameRequest) returns (SetDisplayNameResponse);
+
+	// SetProfilePicture sets the caller's profile picture to a blob they have
+	// already uploaded via BlobStorage, replacing any picture already set.
+	//
+	// The client uploads only the ORIGINAL — InitiateExternalUpload, PUT/POST
+	// the bytes, then (optionally) CompleteExternalUpload — and passes the
+	// resulting BlobId here once the blob is READY. The server derives the
+	// DISPLAY and THUMBNAIL renditions itself and returns the full set.
+	rpc SetProfilePicture(SetProfilePictureRequest) returns (SetProfilePictureResponse);
 
 	// LinkSocialAccount links a social account to a user
 	rpc LinkSocialAccount(LinkSocialAccountRequest) returns (LinkSocialAccountResponse);
@@ -59,7 +70,38 @@ message SetDisplayNameResponse {
 		OK                   = 0;
 		INVALID_DISPLAY_NAME = 1;
 		DENIED               = 2;
+		FAILED_MODERATED     = 3;
 	}
+
+	// The best-fit category that tripped moderation, mirroring the Moderation
+    // service's vocabulary. Set only when result == FAILED_MODERATED; NONE
+	// otherwise.
+    moderation.v1.FlaggedCategory flagged_category = 2;
+}
+
+message SetProfilePictureRequest {
+	// The blob holding the ORIGINAL image the caller uploaded. It must be owned
+	// by the caller and READY; the server derives the remaining renditions from
+	// it. A blob may back at most one profile picture — reuse is not implied.
+	blob.v1.BlobId blob_id = 1 [(validate.rules).message.required = true];
+
+	common.v1.Auth auth = 10 [(validate.rules).message.required = true];
+}
+
+message SetProfilePictureResponse {
+	Result result = 1;
+	enum Result {
+		OK             = 0;
+		DENIED         = 1;
+		BLOB_NOT_FOUND = 2; // no such blob, or it is not owned by the caller
+		BLOB_NOT_READY = 3; // blob is still PENDING/PROCESSING; retry once READY
+		BLOB_REJECTED  = 4; // blob failed validation or moderation; terminal for this id, so the client must upload again
+		INVALID_BLOB   = 5; // blob is READY but unusable as a picture (e.g. not an image)
+	}
+
+	// The caller's new profile picture, including the renditions the server
+	// derived. Set only when result == OK.
+	blob.v1.Media profile_picture = 2;
 }
 
 message LinkSocialAccountRequest {

--- a/definitions/flipcash/protos/src/main/proto/resolver/v1/model.proto
+++ b/definitions/flipcash/protos/src/main/proto/resolver/v1/model.proto
@@ -16,7 +16,8 @@ message Identifier {
     oneof kind {
         option (validate.required) = true;
 
-        phone.v1.PhoneNumber phone = 1;
+        phone.v1.PhoneNumber phone   = 1;
+        common.v1.UserId     user_id = 2;
     }
 }
 

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/controllers/EventStreamingController.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/controllers/EventStreamingController.kt
@@ -1,6 +1,7 @@
 package com.flipcash.services.controllers
 
 import com.flipcash.services.internal.network.services.EventStreamReference
+import com.flipcash.services.models.chat.BlobUpdate
 import com.flipcash.services.models.chat.ChatUpdate
 import com.flipcash.services.repository.EventStreamingRepository
 import com.flipcash.services.user.UserManager
@@ -19,6 +20,9 @@ class EventStreamingController @Inject constructor(
 ) {
     private val _chatUpdates = Channel<ChatUpdate>(capacity = Channel.UNLIMITED)
     val chatUpdates: Flow<ChatUpdate> = _chatUpdates.receiveAsFlow()
+
+    private val _blobUpdates = Channel<BlobUpdate>(capacity = Channel.UNLIMITED)
+    val blobUpdates: Flow<BlobUpdate> = _blobUpdates.receiveAsFlow()
 
     // Guards all reads/writes of [streamRef]. open()/close() are invoked
     // concurrently from multiple triggers (login, lifecycle onStart, network
@@ -51,6 +55,10 @@ class EventStreamingController @Inject constructor(
             onEvent = { update ->
                 trace("EventStreamingController: Received chat update, messages=${update.newMessages.size}")
                 _chatUpdates.trySend(update)
+            },
+            onBlobUpdate = { update ->
+                trace("EventStreamingController: Received blob update, blobs=${update.blobs.size}")
+                _blobUpdates.trySend(update)
             },
             onError = { error ->
                 trace("EventStreamingController: Stream error: ${error.message}")

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/internal/domain/ModerationAttestationMapper.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/internal/domain/ModerationAttestationMapper.kt
@@ -1,6 +1,6 @@
 package com.flipcash.services.internal.domain
 
-import com.codeinc.flipcash.gen.moderation.v1.ModerationService
+import com.codeinc.flipcash.gen.moderation.v1.Model
 import com.flipcash.services.internal.network.extensions.toId
 import com.flipcash.services.internal.network.extensions.toPublicKey
 import com.flipcash.services.internal.network.extensions.toSignature
@@ -10,8 +10,8 @@ import com.getcode.opencode.mapper.Mapper
 import javax.inject.Inject
 import kotlin.time.Instant
 
-class ModerationAttestationMapper @Inject constructor(): Mapper<ModerationService.ModerationAttestation, ModerationResult.Attestation> {
-    override fun map(from: ModerationService.ModerationAttestation): ModerationResult.Attestation {
+class ModerationAttestationMapper @Inject constructor(): Mapper<Model.ModerationAttestation, ModerationResult.Attestation> {
+    override fun map(from: Model.ModerationAttestation): ModerationResult.Attestation {
         return ModerationResult.Attestation(
             rawValue = from.toByteArray().toList(),
             hash = Sha256Hash.of(from.contentHash.toByteArray()),

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/internal/network/extensions/LocalToProtobuf.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/internal/network/extensions/LocalToProtobuf.kt
@@ -149,14 +149,14 @@ internal fun MessageContent.asContent(): MessagingModel.Content {
     }
 }
 
-internal fun com.flipcash.services.models.chat.MediaItem.asMediaItem(): MessagingModel.MediaItem {
-    return MessagingModel.MediaItem.newBuilder()
+internal fun com.flipcash.services.models.chat.MediaItem.asMediaItem(): com.codeinc.flipcash.gen.blob.v1.Model.Media {
+    return com.codeinc.flipcash.gen.blob.v1.Model.Media.newBuilder()
         .addAllRenditions(renditions.map { it.asRendition() })
         .build()
 }
 
-internal fun com.flipcash.services.models.chat.MediaItemRendition.asRendition(): MessagingModel.MediaItemRendition {
-    return MessagingModel.MediaItemRendition.newBuilder()
+internal fun com.flipcash.services.models.chat.MediaItemRendition.asRendition(): com.codeinc.flipcash.gen.blob.v1.Model.Rendition {
+    return com.codeinc.flipcash.gen.blob.v1.Model.Rendition.newBuilder()
         .setRole(role.asProtoRole())
         .setBlobId(
             com.codeinc.flipcash.gen.blob.v1.Model.BlobId.newBuilder()
@@ -165,12 +165,12 @@ internal fun com.flipcash.services.models.chat.MediaItemRendition.asRendition():
         .build()
 }
 
-internal fun com.flipcash.services.models.chat.MediaItemRendition.Role.asProtoRole(): MessagingModel.MediaItemRendition.Role {
+internal fun com.flipcash.services.models.chat.MediaItemRendition.Role.asProtoRole(): com.codeinc.flipcash.gen.blob.v1.Model.Rendition.Role {
     return when (this) {
-        com.flipcash.services.models.chat.MediaItemRendition.Role.ORIGINAL -> MessagingModel.MediaItemRendition.Role.ORIGINAL
-        com.flipcash.services.models.chat.MediaItemRendition.Role.DISPLAY -> MessagingModel.MediaItemRendition.Role.DISPLAY
-        com.flipcash.services.models.chat.MediaItemRendition.Role.THUMBNAIL -> MessagingModel.MediaItemRendition.Role.THUMBNAIL
-        com.flipcash.services.models.chat.MediaItemRendition.Role.UNKNOWN -> MessagingModel.MediaItemRendition.Role.UNKNOWN
+        com.flipcash.services.models.chat.MediaItemRendition.Role.ORIGINAL -> com.codeinc.flipcash.gen.blob.v1.Model.Rendition.Role.ORIGINAL
+        com.flipcash.services.models.chat.MediaItemRendition.Role.DISPLAY -> com.codeinc.flipcash.gen.blob.v1.Model.Rendition.Role.DISPLAY
+        com.flipcash.services.models.chat.MediaItemRendition.Role.THUMBNAIL -> com.codeinc.flipcash.gen.blob.v1.Model.Rendition.Role.THUMBNAIL
+        com.flipcash.services.models.chat.MediaItemRendition.Role.UNKNOWN -> com.codeinc.flipcash.gen.blob.v1.Model.Rendition.Role.UNKNOWN
     }
 }
 

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/internal/network/extensions/ProtobufToLocal.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/internal/network/extensions/ProtobufToLocal.kt
@@ -7,6 +7,7 @@ import com.codeinc.flipcash.gen.push.v1.Model as PushModels
 import com.flipcash.services.internal.extensions.toChecksum
 import com.flipcash.services.internal.extensions.toMint
 import com.flipcash.services.internal.extensions.toPublicKey
+import com.flipcash.services.models.ModerationResult
 import com.flipcash.services.models.NavigationTrigger
 import com.flipcash.services.models.NotificationCategory
 import com.flipcash.services.models.NotificationPayload
@@ -26,6 +27,11 @@ import com.flipcash.services.models.chat.Emoji
 import com.flipcash.services.models.chat.EmojiReaction
 import com.flipcash.services.models.chat.BlobId
 import com.flipcash.services.models.chat.BlobMetadata
+import com.flipcash.services.models.chat.BlobRejection
+import com.flipcash.services.models.chat.BlobState
+import com.flipcash.services.models.chat.BlobStatus
+import com.flipcash.services.models.chat.BlobUpdate
+import com.flipcash.services.models.chat.RejectionReason
 import com.flipcash.services.models.chat.ImageMetadata
 import com.flipcash.services.models.chat.MediaItem
 import com.flipcash.services.models.chat.MediaItemRendition
@@ -366,4 +372,56 @@ internal fun EventModel.ChatUpdate.toChatUpdate(
         events = if (hasEvents()) events.eventsList.map { it.toChatEvent() } else emptyList(),
         reactionUpdates = if (hasReactionUpdates()) reactionUpdates.reactionUpdatesList.map { it.toReactionUpdate() } else emptyList(),
     )
+}
+
+// -- EventModel.BlobUpdate --
+
+internal fun EventModel.BlobUpdate.toBlobUpdate(): BlobUpdate {
+    return BlobUpdate(
+        blobs = blobs.blobsList.map { it.toBlobState() },
+    )
+}
+
+internal fun com.codeinc.flipcash.gen.blob.v1.Model.Blob.toBlobState(): BlobState {
+    return BlobState(
+        id = BlobId(id.value.toByteArray()),
+        status = status.toBlobStatus(),
+        metadata = if (hasMetadata()) metadata.toBlobMetadata() else null,
+        rejection = if (hasRejection()) rejection.toBlobRejection() else null,
+    )
+}
+
+internal fun com.codeinc.flipcash.gen.blob.v1.Model.BlobStatus.toBlobStatus(): BlobStatus {
+    return when (this) {
+        com.codeinc.flipcash.gen.blob.v1.Model.BlobStatus.BLOB_STATUS_PENDING -> BlobStatus.PENDING
+        com.codeinc.flipcash.gen.blob.v1.Model.BlobStatus.BLOB_STATUS_PROCESSING -> BlobStatus.PROCESSING
+        com.codeinc.flipcash.gen.blob.v1.Model.BlobStatus.BLOB_STATUS_READY -> BlobStatus.READY
+        com.codeinc.flipcash.gen.blob.v1.Model.BlobStatus.BLOB_STATUS_REJECTED -> BlobStatus.REJECTED
+        else -> BlobStatus.UNKNOWN
+    }
+}
+
+internal fun com.codeinc.flipcash.gen.blob.v1.Model.RejectionMetadata.toBlobRejection(): BlobRejection {
+    return BlobRejection(
+        reason = reason.toRejectionReason(),
+        flaggedCategory = flaggedCategory.toFlaggedCategory(),
+    )
+}
+
+internal fun com.codeinc.flipcash.gen.blob.v1.Model.RejectionReason.toRejectionReason(): RejectionReason {
+    return when (this) {
+        com.codeinc.flipcash.gen.blob.v1.Model.RejectionReason.REJECTION_REASON_MODERATION -> RejectionReason.MODERATION
+        com.codeinc.flipcash.gen.blob.v1.Model.RejectionReason.REJECTION_REASON_UNSUPPORTED_TYPE -> RejectionReason.UNSUPPORTED_TYPE
+        com.codeinc.flipcash.gen.blob.v1.Model.RejectionReason.REJECTION_REASON_MISMATCHED_TYPE -> RejectionReason.MISMATCHED_TYPE
+        com.codeinc.flipcash.gen.blob.v1.Model.RejectionReason.REJECTION_REASON_TOO_LARGE -> RejectionReason.TOO_LARGE
+        com.codeinc.flipcash.gen.blob.v1.Model.RejectionReason.REJECTION_REASON_CORRUPT -> RejectionReason.CORRUPT
+        com.codeinc.flipcash.gen.blob.v1.Model.RejectionReason.REJECTION_REASON_INTERNAL -> RejectionReason.INTERNAL
+        com.codeinc.flipcash.gen.blob.v1.Model.RejectionReason.REJECTION_REASON_PRIVACY_METADATA -> RejectionReason.PRIVACY_METADATA
+        else -> RejectionReason.UNKNOWN
+    }
+}
+
+internal fun com.codeinc.flipcash.gen.moderation.v1.Model.FlaggedCategory.toFlaggedCategory(): ModerationResult.FlaggedCategory {
+    return ModerationResult.FlaggedCategory.entries.firstOrNull { it.name == name }
+        ?: ModerationResult.FlaggedCategory.OTHER
 }

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/internal/network/extensions/ProtobufToLocal.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/internal/network/extensions/ProtobufToLocal.kt
@@ -150,13 +150,13 @@ internal fun MessagingModel.Content.toMessageContent(): MessageContent {
     }
 }
 
-internal fun MessagingModel.MediaItem.toMediaItem(): MediaItem {
+internal fun com.codeinc.flipcash.gen.blob.v1.Model.Media.toMediaItem(): MediaItem {
     return MediaItem(
         renditions = renditionsList.map { it.toMediaItemRendition() },
     )
 }
 
-internal fun MessagingModel.MediaItemRendition.toMediaItemRendition(): MediaItemRendition {
+internal fun com.codeinc.flipcash.gen.blob.v1.Model.Rendition.toMediaItemRendition(): MediaItemRendition {
     return MediaItemRendition(
         role = role.toRole(),
         blobId = BlobId(blobId.value.toByteArray()),
@@ -164,11 +164,11 @@ internal fun MessagingModel.MediaItemRendition.toMediaItemRendition(): MediaItem
     )
 }
 
-internal fun MessagingModel.MediaItemRendition.Role.toRole(): MediaItemRendition.Role {
+internal fun com.codeinc.flipcash.gen.blob.v1.Model.Rendition.Role.toRole(): MediaItemRendition.Role {
     return when (this) {
-        MessagingModel.MediaItemRendition.Role.ORIGINAL -> MediaItemRendition.Role.ORIGINAL
-        MessagingModel.MediaItemRendition.Role.DISPLAY -> MediaItemRendition.Role.DISPLAY
-        MessagingModel.MediaItemRendition.Role.THUMBNAIL -> MediaItemRendition.Role.THUMBNAIL
+        com.codeinc.flipcash.gen.blob.v1.Model.Rendition.Role.ORIGINAL -> MediaItemRendition.Role.ORIGINAL
+        com.codeinc.flipcash.gen.blob.v1.Model.Rendition.Role.DISPLAY -> MediaItemRendition.Role.DISPLAY
+        com.codeinc.flipcash.gen.blob.v1.Model.Rendition.Role.THUMBNAIL -> MediaItemRendition.Role.THUMBNAIL
         else -> MediaItemRendition.Role.UNKNOWN
     }
 }
@@ -177,7 +177,7 @@ internal fun com.codeinc.flipcash.gen.blob.v1.Model.BlobMetadata.toBlobMetadata(
     return BlobMetadata(
         mimeType = mimeType,
         sizeBytes = sizeBytes,
-        downloadUrl = downloadUrl,
+        downloadUrl = downloadUrl.url,
         image = if (hasImage()) image.toImageMetadata() else null,
     )
 }
@@ -317,9 +317,10 @@ internal fun ChatModel.MetadataUpdate.toMetadataUpdate(
 
 // -- Chat type --
 
-internal fun ChatModel.Metadata.ChatType.toChatType(): ChatType {
+internal fun ChatModel.ChatType.toChatType(): ChatType {
     return when (this) {
-        ChatModel.Metadata.ChatType.DM -> ChatType.DM
+        ChatModel.ChatType.CONTACT_DM -> ChatType.CONTACT_DM
+        ChatModel.ChatType.TIP_DM -> ChatType.TIP_DM
         else -> ChatType.UNKNOWN
     }
 }

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/internal/network/services/EventStreamingService.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/internal/network/services/EventStreamingService.kt
@@ -4,8 +4,10 @@ import com.codeinc.flipcash.gen.events.v1.EventStreamingService as RpcEventStrea
 import com.codeinc.flipcash.gen.events.v1.Model as EventModel
 import com.flipcash.services.internal.network.api.EventStreamingApi
 import com.flipcash.services.internal.network.extensions.authenticate
+import com.flipcash.services.internal.network.extensions.toBlobUpdate
 import com.flipcash.services.internal.network.extensions.toChatUpdate
 import com.flipcash.services.models.StreamEventsError
+import com.flipcash.services.models.chat.BlobUpdate
 import com.flipcash.services.models.chat.ChatUpdate
 import com.getcode.ed25519.Ed25519.KeyPair
 import com.getcode.opencode.internal.bidi.BidirectionalStreamReference
@@ -30,6 +32,7 @@ internal class EventStreamingService @Inject constructor(
         scope: CoroutineScope,
         owner: KeyPair,
         onEvent: (ChatUpdate) -> Unit,
+        onBlobUpdate: (BlobUpdate) -> Unit = {},
         onError: (Throwable) -> Unit = {},
     ): EventStreamReference {
         trace(tag = "event-stream", message = "Opening stream.")
@@ -43,7 +46,7 @@ internal class EventStreamingService @Inject constructor(
         }
 
         streamReference.coroutineScope.launch {
-            openStream(scope, owner, streamReference, onEvent, onError)
+            openStream(scope, owner, streamReference, onEvent, onBlobUpdate, onError)
         }
 
         return streamReference
@@ -54,6 +57,7 @@ internal class EventStreamingService @Inject constructor(
         owner: KeyPair,
         streamRef: EventStreamReference,
         onEvent: (ChatUpdate) -> Unit,
+        onBlobUpdate: (BlobUpdate) -> Unit,
         onError: (Throwable) -> Unit,
     ) {
         openBidirectionalStream(
@@ -98,6 +102,9 @@ internal class EventStreamingService @Inject constructor(
                             when (event.typeCase) {
                                 EventModel.Event.TypeCase.CHAT_UPDATE -> {
                                     onEvent(event.chatUpdate.toChatUpdate())
+                                }
+                                EventModel.Event.TypeCase.BLOB_UPDATE -> {
+                                    onBlobUpdate(event.blobUpdate.toBlobUpdate())
                                 }
                                 else -> {
                                     trace(

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/internal/network/services/ProfileService.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/internal/network/services/ProfileService.kt
@@ -3,6 +3,7 @@ package com.flipcash.services.internal.network.services
 import com.codeinc.flipcash.gen.profile.v1.Model
 import com.codeinc.flipcash.gen.profile.v1.ProfileService
 import com.flipcash.services.internal.network.api.ProfileApi
+import com.flipcash.services.internal.network.extensions.toFlaggedCategory
 import com.getcode.opencode.utils.toValidationOrElse
 import com.flipcash.services.models.GetUserProfileError
 import com.flipcash.services.models.LinkSocialAccountError
@@ -48,6 +49,8 @@ internal class ProfileService @Inject constructor(
                     ProfileService.SetDisplayNameResponse.Result.OK -> Result.success(Unit)
                     ProfileService.SetDisplayNameResponse.Result.INVALID_DISPLAY_NAME -> Result.failure(SetDisplayNameError.InvalidDisplayName())
                     ProfileService.SetDisplayNameResponse.Result.DENIED -> Result.failure(SetDisplayNameError.Denied())
+                    ProfileService.SetDisplayNameResponse.Result.FAILED_MODERATED ->
+                        Result.failure(SetDisplayNameError.FailedModerated(response.flaggedCategory.toFlaggedCategory()))
                     ProfileService.SetDisplayNameResponse.Result.UNRECOGNIZED -> Result.failure(SetDisplayNameError.Unrecognized())
                 }
             },

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/internal/repositories/InternalEventStreamingRepository.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/internal/repositories/InternalEventStreamingRepository.kt
@@ -2,6 +2,7 @@ package com.flipcash.services.internal.repositories
 
 import com.flipcash.services.internal.network.services.EventStreamReference
 import com.flipcash.services.internal.network.services.EventStreamingService
+import com.flipcash.services.models.chat.BlobUpdate
 import com.flipcash.services.models.chat.ChatUpdate
 import com.flipcash.services.repository.EventStreamingRepository
 import com.getcode.ed25519.Ed25519.KeyPair
@@ -14,8 +15,9 @@ internal class InternalEventStreamingRepository(
         scope: CoroutineScope,
         owner: KeyPair,
         onEvent: (ChatUpdate) -> Unit,
+        onBlobUpdate: (BlobUpdate) -> Unit,
         onError: (Throwable) -> Unit,
     ): EventStreamReference {
-        return service.openEventStream(scope, owner, onEvent, onError)
+        return service.openEventStream(scope, owner, onEvent, onBlobUpdate, onError)
     }
 }

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/models/Errors.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/models/Errors.kt
@@ -200,6 +200,7 @@ sealed class SetDisplayNameError(
 ): CodeServerError(message, cause) {
     class InvalidDisplayName: SetDisplayNameError("Invalid display name")
     class Denied: SetDisplayNameError("Denied")
+    class FailedModerated(val category: ModerationResult.FlaggedCategory) : SetDisplayNameError("Content flagged: $category")
     class Unrecognized : SetDisplayNameError("Unrecognized"), NotifiableError
     data class Other(override val cause: Throwable? = null) : SetDisplayNameError(message = cause?.message, cause = cause), NotifiableError
 }

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/models/chat/BlobUpdate.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/models/chat/BlobUpdate.kt
@@ -1,0 +1,50 @@
+package com.flipcash.services.models.chat
+
+import com.flipcash.services.models.ModerationResult
+
+// Real-time notification that blobs the user uploaded transitioned to a new
+// lifecycle state (e.g. PROCESSING -> READY once the server finishes validating,
+// transcoding, and moderating, or -> REJECTED on failure). Delivered over the
+// event stream so clients react to upload completion instead of polling.
+data class BlobUpdate(
+    val blobs: List<BlobState>,
+)
+
+// A single blob's current status, plus its metadata once READY — or, once
+// REJECTED, the reason it was rejected.
+data class BlobState(
+    val id: BlobId,
+    val status: BlobStatus,
+    // Server-authoritative metadata (including a freshly minted download URL).
+    // Set only when status == READY.
+    val metadata: BlobMetadata?,
+    // Why the blob was rejected. Set only when status == REJECTED.
+    val rejection: BlobRejection?,
+)
+
+enum class BlobStatus {
+    UNKNOWN,
+    PENDING,
+    PROCESSING,
+    READY,
+    REJECTED,
+}
+
+// Explains why a blob was rejected during finalization. Rejection is terminal:
+// the id will never become READY, so the client must upload again to retry.
+data class BlobRejection(
+    val reason: RejectionReason,
+    // Best-fit moderation category. Meaningful only when reason == MODERATION.
+    val flaggedCategory: ModerationResult.FlaggedCategory,
+)
+
+enum class RejectionReason {
+    UNKNOWN,
+    MODERATION,
+    UNSUPPORTED_TYPE,
+    MISMATCHED_TYPE,
+    TOO_LARGE,
+    CORRUPT,
+    INTERNAL,
+    PRIVACY_METADATA,
+}

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/models/chat/ChatType.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/models/chat/ChatType.kt
@@ -2,5 +2,6 @@ package com.flipcash.services.models.chat
 
 enum class ChatType {
     UNKNOWN,
-    DM,
+    CONTACT_DM,
+    TIP_DM,
 }

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/repository/EventStreamingRepository.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/repository/EventStreamingRepository.kt
@@ -1,6 +1,7 @@
 package com.flipcash.services.repository
 
 import com.flipcash.services.internal.network.services.EventStreamReference
+import com.flipcash.services.models.chat.BlobUpdate
 import com.flipcash.services.models.chat.ChatUpdate
 import com.getcode.ed25519.Ed25519.KeyPair
 import kotlinx.coroutines.CoroutineScope
@@ -10,6 +11,7 @@ interface EventStreamingRepository {
         scope: CoroutineScope,
         owner: KeyPair,
         onEvent: (ChatUpdate) -> Unit,
+        onBlobUpdate: (BlobUpdate) -> Unit = {},
         onError: (Throwable) -> Unit = {},
     ): EventStreamReference
 }

--- a/services/flipcash/src/test/kotlin/com/flipcash/services/controllers/ChatControllerTest.kt
+++ b/services/flipcash/src/test/kotlin/com/flipcash/services/controllers/ChatControllerTest.kt
@@ -156,7 +156,7 @@ class ChatControllerTest {
 
     private fun stubMetadata(chatId: ChatId = ChatId(ByteArray(32))) = ChatMetadata(
         chatId = chatId,
-        type = ChatType.DM,
+        type = ChatType.CONTACT_DM,
         members = emptyList(),
         lastMessage = null,
         lastActivity = Instant.fromEpochSeconds(1000),

--- a/services/flipcash/src/test/kotlin/com/flipcash/services/controllers/EventStreamingControllerTest.kt
+++ b/services/flipcash/src/test/kotlin/com/flipcash/services/controllers/EventStreamingControllerTest.kt
@@ -1,6 +1,7 @@
 package com.flipcash.services.controllers
 
 import com.flipcash.services.internal.network.services.EventStreamReference
+import com.flipcash.services.models.chat.BlobUpdate
 import com.flipcash.services.models.chat.ChatId
 import com.flipcash.services.models.chat.ChatUpdate
 import com.flipcash.services.repository.EventStreamingRepository
@@ -113,6 +114,7 @@ private class FakeEventStreamingRepository : EventStreamingRepository {
         scope: CoroutineScope,
         owner: Ed25519.KeyPair,
         onEvent: (ChatUpdate) -> Unit,
+        onBlobUpdate: (BlobUpdate) -> Unit,
         onError: (Throwable) -> Unit,
     ): EventStreamReference {
         // Widen the controller's check-then-act window so an unsynchronized

--- a/services/flipcash/src/test/kotlin/com/flipcash/services/internal/domain/ChatMetadataMapperTest.kt
+++ b/services/flipcash/src/test/kotlin/com/flipcash/services/internal/domain/ChatMetadataMapperTest.kt
@@ -66,7 +66,7 @@ class ChatMetadataMapperTest {
         block: ChatModel.Metadata.Builder.() -> Unit = {},
     ): ChatModel.Metadata = ChatModel.Metadata.newBuilder()
         .setChatId(chatId())
-        .setType(ChatModel.Metadata.ChatType.DM)
+        .setType(ChatModel.ChatType.CONTACT_DM)
         .setLastActivity(Timestamp.newBuilder().setSeconds(2000))
         .apply(block)
         .build()
@@ -74,7 +74,7 @@ class ChatMetadataMapperTest {
     @Test
     fun `maps chat type DM`() {
         val result = mapper.map(metadata())
-        assertEquals(ChatType.DM, result.type)
+        assertEquals(ChatType.CONTACT_DM, result.type)
     }
 
     @Test

--- a/services/flipcash/src/test/kotlin/com/flipcash/services/models/chat/DomainModelsTest.kt
+++ b/services/flipcash/src/test/kotlin/com/flipcash/services/models/chat/DomainModelsTest.kt
@@ -11,9 +11,10 @@ class DomainModelsTest {
 
     @Test
     fun `ChatType has expected values`() {
-        assertEquals(2, ChatType.entries.size)
+        assertEquals(3, ChatType.entries.size)
         assertIs<ChatType>(ChatType.UNKNOWN)
-        assertIs<ChatType>(ChatType.DM)
+        assertIs<ChatType>(ChatType.CONTACT_DM)
+        assertIs<ChatType>(ChatType.TIP_DM)
     }
 
     @Test
@@ -77,7 +78,7 @@ class DomainModelsTest {
     fun `MetadataUpdate FullRefresh holds metadata`() {
         val metadata = ChatMetadata(
             chatId = ChatId(ByteArray(32)),
-            type = ChatType.DM,
+            type = ChatType.CONTACT_DM,
             members = emptyList(),
             lastMessage = null,
             lastActivity = Instant.fromEpochSeconds(500),


### PR DESCRIPTION
## Summary

Syncs the flipcash protobuf definitions from upstream and adapts the service layer to the changes. Split into three commits:

1. **`chore(protos)`** — the raw proto definition update (no code)
2. **`fix(services,persistence)`** — P1: resolve compile breaks from the breaking proto changes + Room migration
3. **`fix(services)`** — P2: close runtime-correctness gaps (new moderation result + blob update events)

## Proto changes of note
- **blob/v1**: new `Blob` lifecycle (`BlobStatus`, `Blob`/`BlobBatch`), `Media`/`Rendition` (moved from messaging), `UploadPolicy`/`UploadTarget`/`DownloadUrl`, `RejectionMetadata`, `AccessContext`; `BlobMetadata.download_url` is now a `DownloadUrl` message
- **chat/v1**: `ChatType` promoted to top-level, `DM` → `CONTACT_DM`, added `TIP_DM`; `GetDmChatFeedRequest.dm_chat_type` filter
- **profile/v1**: `SetProfilePicture` RPC, `UserProfile.profile_picture`, `SetDisplayName` `FAILED_MODERATED` + `flagged_category`
- **messaging/v1**: `MediaContent.items` now `blob.v1.Media`; `MediaItem` removed
- **moderation/v1**: `FlaggedCategory` + `ModerationAttestation` moved to `model.proto`
- **event/v1**: `Event` gains `BlobUpdate`; **intent/v1**: `TipDmPayment`; **resolver/v1**: `user_id`

## Code adaptation
**breaking-change fixes + migration**
- `ChatType` domain enum + proto→domain mapper + direct-send DM filter (`CONTACT_DM`)
- Media converters retargeted to `blob.v1.Media`/`Rendition` (both directions)
- `BlobMetadata.download_url` read via `.url`
- `ModerationAttestation` type moved to `moderation.v1.Model`
- **Room migration 22→23** rewrites persisted `chat_type` `'DM'` → `'CONTACT_DM'` (data-only, no schema change)
- Affected unit tests updated

**runtime correctness**
- `SetDisplayName` maps `FAILED_MODERATED` → `SetDisplayNameError.FailedModerated(category)` instead of a generic error
- Event stream now handles `BLOB_UPDATE`: new `BlobUpdate` domain model + mappers, `onBlobUpdate` threaded through the repository, and `EventStreamingController.blobUpdates` exposed as a `Flow` (mirrors `chatUpdates`)