### PR TITLE
feat(profile,chat): profile pictures + tip DM service-layer support

### DIFF
--- a/apps/flipcash/shared/chat/src/main/kotlin/com/flipcash/shared/chat/internal/delegates/FeedSyncDelegate.kt
+++ b/apps/flipcash/shared/chat/src/main/kotlin/com/flipcash/shared/chat/internal/delegates/FeedSyncDelegate.kt
@@ -8,6 +8,7 @@ import com.flipcash.services.controllers.ChatController
 import com.flipcash.services.models.chat.ChatId
 import com.flipcash.services.models.chat.ChatMember
 import com.flipcash.services.models.chat.ChatMetadata
+import com.flipcash.services.models.chat.ChatType
 import com.flipcash.services.models.chat.PointerType
 import com.flipcash.shared.chat.ChatSummary
 import com.flipcash.shared.chat.FeedOperations
@@ -156,7 +157,7 @@ class FeedSyncDelegate @Inject constructor(
 
     private suspend fun performFeedSync() {
         stateHolder.update { it.copy(feedSyncState = FeedSyncState.Syncing) }
-        chatController.getDmChatFeed()
+        chatController.getDmChatFeed(ChatType.CONTACT_DM)
             .onSuccess { page ->
                 metadataDataSource.upsert(page.chats)
 

--- a/apps/flipcash/shared/chat/src/test/kotlin/com/flipcash/shared/chat/ChatCoordinatorEagerBalanceTest.kt
+++ b/apps/flipcash/shared/chat/src/test/kotlin/com/flipcash/shared/chat/ChatCoordinatorEagerBalanceTest.kt
@@ -68,7 +68,7 @@ class ChatCoordinatorEagerBalanceTest {
         every { eventStreamingController.isStreamActive } returns true
 
         val chatController = mockk<ChatController>(relaxed = true)
-        coEvery { chatController.getDmChatFeed() } returns Result.failure(RuntimeException("not needed"))
+        coEvery { chatController.getDmChatFeed(any(), any()) } returns Result.failure(RuntimeException("not needed"))
 
         testDispatchers = TestDispatchers(TestCoroutineScheduler())
 

--- a/apps/flipcash/shared/chat/src/test/kotlin/com/flipcash/shared/chat/ChatCoordinatorEventsTest.kt
+++ b/apps/flipcash/shared/chat/src/test/kotlin/com/flipcash/shared/chat/ChatCoordinatorEventsTest.kt
@@ -72,7 +72,7 @@ class ChatCoordinatorEventsTest {
         every { eventStreamingController.isStreamActive } returns true
 
         val chatController = mockk<ChatController>(relaxed = true)
-        coEvery { chatController.getDmChatFeed() } returns Result.failure(RuntimeException("not needed"))
+        coEvery { chatController.getDmChatFeed(any(), any()) } returns Result.failure(RuntimeException("not needed"))
 
         metadataDataSource = mockk(relaxed = true)
         messageDataSource = mockk(relaxed = true)

--- a/apps/flipcash/shared/contacts/src/main/kotlin/com/flipcash/app/contacts/ContactCoordinator.kt
+++ b/apps/flipcash/shared/contacts/src/main/kotlin/com/flipcash/app/contacts/ContactCoordinator.kt
@@ -227,7 +227,7 @@ class ContactCoordinator @Inject constructor(
     }
 
     suspend fun resolve(e164: String): Result<PublicKey> {
-        return resolverController.resolve(ContactMethod.Phone(e164))
+        return resolverController.resolve(phone = ContactMethod.Phone(e164))
     }
 
     fun refreshContact(e164: String): DeviceContact? {

--- a/apps/flipcash/shared/persistence/db/src/main/kotlin/com/flipcash/app/persistence/converters/ChatTypeConverters.kt
+++ b/apps/flipcash/shared/persistence/db/src/main/kotlin/com/flipcash/app/persistence/converters/ChatTypeConverters.kt
@@ -77,6 +77,7 @@ class ChatTypeConverters {
                         ?: compat.verifiedEmailAddress?.let { address ->
                             VerifiableContactMethod(address, verified = true)
                         },
+                    profilePicture = compat.profilePicture,
                 )
             }.getOrNull()
         }
@@ -163,6 +164,7 @@ data class UserProfileSerialized(
     val socialAccounts: List<SocialAccountSerialized>,
     val phoneNumber: VerifiableContactMethod? = null,
     val email: VerifiableContactMethod? = null,
+    val profilePicture: MediaItem? = null,
 )
 
 /**
@@ -179,6 +181,7 @@ private data class UserProfileSerializedCompat(
     val email: VerifiableContactMethod? = null,
     val verifiedPhoneNumber: String? = null,
     val verifiedEmailAddress: String? = null,
+    val profilePicture: MediaItem? = null,
 )
 
 @Serializable

--- a/apps/flipcash/shared/persistence/sources/src/main/kotlin/com/flipcash/app/persistence/sources/mapper/chat/ChatEntityMapper.kt
+++ b/apps/flipcash/shared/persistence/sources/src/main/kotlin/com/flipcash/app/persistence/sources/mapper/chat/ChatEntityMapper.kt
@@ -275,6 +275,7 @@ private fun UserProfile.toSerialized(): UserProfileSerialized = UserProfileSeria
     socialAccounts = socialAccounts.map { it.toSerialized() },
     phoneNumber = phoneNumber,
     email = email,
+    profilePicture = profilePicture,
 )
 
 private fun UserProfileSerialized.toDomain(): UserProfile = UserProfile(
@@ -282,6 +283,7 @@ private fun UserProfileSerialized.toDomain(): UserProfile = UserProfile(
     socialAccounts = socialAccounts.map { it.toDomain() },
     phoneNumber = phoneNumber,
     email = email,
+    profilePicture = profilePicture,
 )
 
 private fun SocialAccount.toSerialized(): SocialAccountSerialized = when (this) {

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/controllers/ChatController.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/controllers/ChatController.kt
@@ -4,6 +4,7 @@ import com.flipcash.services.models.QueryOptions
 import com.flipcash.services.models.chat.ChatFeedPage
 import com.flipcash.services.models.chat.ChatId
 import com.flipcash.services.models.chat.ChatMetadata
+import com.flipcash.services.models.chat.ChatType
 import com.flipcash.services.repository.ChatRepository
 import com.flipcash.services.user.UserManager
 import javax.inject.Inject
@@ -21,10 +22,13 @@ class ChatController @Inject constructor(
         return repository.getChat(owner, chatId)
     }
 
-    suspend fun getDmChatFeed(queryOptions: QueryOptions = QueryOptions()): Result<ChatFeedPage> {
+    suspend fun getDmChatFeed(
+        chatType: ChatType,
+        queryOptions: QueryOptions = QueryOptions(),
+    ): Result<ChatFeedPage> {
         val owner = userManager.accountCluster?.authority?.keyPair
             ?: return Result.failure(Throwable("No account cluster in UserManager"))
 
-        return repository.getDmChatFeed(owner, queryOptions)
+        return repository.getDmChatFeed(owner, queryOptions, chatType)
     }
 }

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/controllers/ProfileController.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/controllers/ProfileController.kt
@@ -6,6 +6,8 @@ import com.flipcash.services.models.SocialAccount
 import com.flipcash.services.models.SocialAccountLinkRequest
 import com.flipcash.services.models.SocialAccountUnlinkRequest
 import com.flipcash.services.models.UserProfile
+import com.flipcash.services.models.chat.BlobId
+import com.flipcash.services.models.chat.MediaItem
 import com.flipcash.services.repository.ProfileRepository
 import com.flipcash.services.user.UserManager
 import com.getcode.opencode.model.core.ID
@@ -82,6 +84,19 @@ class ProfileController @Inject constructor(
             ?: return Result.failure(Throwable("No account cluster in UserManager"))
 
         return repository.setDisplayName(displayName, owner)
+    }
+
+    /**
+     * Sets the caller's profile picture to a blob already uploaded via BlobStorage.
+     * Returns the full set of renditions the server derived from it.
+     */
+    suspend fun setProfilePicture(
+        blobId: BlobId,
+    ): Result<MediaItem> {
+        val owner = userManager.accountCluster?.authority?.keyPair
+            ?: return Result.failure(Throwable("No account cluster in UserManager"))
+
+        return repository.setProfilePicture(blobId, owner)
     }
 
     suspend fun linkTwitterXAccount(

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/controllers/ResolverController.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/controllers/ResolverController.kt
@@ -1,8 +1,10 @@
 package com.flipcash.services.controllers
 
 import com.flipcash.services.models.ContactMethod
+import com.flipcash.services.models.ResolveIdentifier
 import com.flipcash.services.repository.ResolverRepository
 import com.flipcash.services.user.UserManager
+import com.getcode.opencode.model.core.ID
 import com.getcode.solana.keys.PublicKey
 import javax.inject.Inject
 
@@ -10,9 +12,17 @@ class ResolverController @Inject constructor(
     private val repository: ResolverRepository,
     private val userManager: UserManager,
 ) {
-    suspend fun resolve(phone: ContactMethod.Phone): Result<PublicKey> {
+    /** Resolves a phone number to its on-chain address. */
+    suspend fun resolve(phone: ContactMethod.Phone): Result<PublicKey> =
+        resolve(ResolveIdentifier.Phone(phone))
+
+    /** Resolves a user ID to their on-chain address (e.g. for a tip DM counterparty). */
+    suspend fun resolve(userId: ID): Result<PublicKey> =
+        resolve(ResolveIdentifier.UserId(userId))
+
+    private suspend fun resolve(identifier: ResolveIdentifier): Result<PublicKey> {
         val owner = userManager.accountCluster?.authority?.keyPair
             ?: return Result.failure(Throwable("No account cluster in UserManager"))
-        return repository.resolve(owner, phone)
+        return repository.resolve(owner, identifier)
     }
 }

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/internal/domain/UserProfileMapper.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/internal/domain/UserProfileMapper.kt
@@ -3,6 +3,7 @@ package com.flipcash.services.internal.domain
 import com.codeinc.flipcash.gen.profile.v1.Model
 import com.codeinc.flipcash.gen.profile.v1.emailAddressOrNull
 import com.codeinc.flipcash.gen.profile.v1.phoneNumberOrNull
+import com.flipcash.services.internal.network.extensions.toMediaItem
 import com.flipcash.services.models.UserProfile
 import com.flipcash.services.models.VerifiableContactMethod
 import com.getcode.opencode.mapper.Mapper
@@ -18,6 +19,7 @@ class UserProfileMapper @Inject constructor(
             // A value is only present on the server profile once verified.
             phoneNumber = from.phoneNumberOrNull?.value?.let { VerifiableContactMethod(it, verified = true) },
             email = from.emailAddressOrNull?.value?.let { VerifiableContactMethod(it, verified = true) },
+            profilePicture = if (from.hasProfilePicture()) from.profilePicture.toMediaItem() else null,
         )
     }
 }

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/internal/network/api/ChatApi.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/internal/network/api/ChatApi.kt
@@ -5,10 +5,12 @@ import com.codeinc.flipcash.gen.chat.v1.ChatService as RpcChatService
 import com.codeinc.flipcash.gen.chat.v1.validate
 import com.flipcash.services.internal.annotations.FlipcashManagedChannel
 import com.flipcash.services.internal.network.extensions.asChatId
+import com.flipcash.services.internal.network.extensions.asProtoChatType
 import com.flipcash.services.internal.network.extensions.asQueryOptions
 import com.flipcash.services.internal.network.extensions.authenticate
 import com.flipcash.services.models.QueryOptions
 import com.flipcash.services.models.chat.ChatId
+import com.flipcash.services.models.chat.ChatType
 import com.getcode.ed25519.Ed25519.KeyPair
 import com.getcode.opencode.internal.network.core.GrpcApi
 import dev.bmcreations.protovalidate.orThrow
@@ -46,9 +48,11 @@ internal class ChatApi @Inject constructor(
     suspend fun getDmChatFeed(
         owner: KeyPair,
         queryOptions: QueryOptions,
+        chatType: ChatType,
     ): RpcChatService.GetDmChatFeedResponse {
         val request = RpcChatService.GetDmChatFeedRequest.newBuilder()
             .setQueryOptions(queryOptions.asQueryOptions())
+            .setDmChatType(chatType.asProtoChatType())
             .apply { setAuth(authenticate(owner)) }
             .build()
 

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/internal/network/api/ProfileApi.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/internal/network/api/ProfileApi.kt
@@ -8,9 +8,11 @@ import com.flipcash.services.internal.network.extensions.authenticate
 import com.flipcash.services.internal.network.extensions.linkingToken
 import com.flipcash.services.models.SocialAccountLinkRequest
 import com.flipcash.services.models.SocialAccountUnlinkRequest
+import com.flipcash.services.models.chat.BlobId
 import com.getcode.ed25519.Ed25519
 import com.getcode.opencode.internal.network.core.GrpcApi
 import com.getcode.opencode.model.core.ID
+import com.getcode.utils.toByteString
 import com.codeinc.flipcash.gen.profile.v1.validate
 import dev.bmcreations.protovalidate.orThrow
 import io.grpc.ManagedChannel
@@ -58,6 +60,30 @@ internal class ProfileApi @Inject constructor(
 
         return withContext(Dispatchers.IO) {
             api.setDisplayName(request)
+        }
+    }
+
+    /**
+     * Sets the caller's profile picture to a blob they have already uploaded via
+     * BlobStorage. The server derives the DISPLAY/THUMBNAIL renditions and returns
+     * the full set.
+     */
+    suspend fun setProfilePicture(
+        blobId: BlobId,
+        owner: Ed25519.KeyPair,
+    ): ProfileService.SetProfilePictureResponse {
+        val request = ProfileService.SetProfilePictureRequest.newBuilder()
+            .setBlobId(
+                com.codeinc.flipcash.gen.blob.v1.Model.BlobId.newBuilder()
+                    .setValue(blobId.bytes.toByteString())
+            )
+            .apply { setAuth(authenticate(owner)) }
+            .build()
+
+        request.validate().orThrow()
+
+        return withContext(Dispatchers.IO) {
+            api.setProfilePicture(request)
         }
     }
 

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/internal/network/api/ResolverApi.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/internal/network/api/ResolverApi.kt
@@ -3,8 +3,9 @@ package com.flipcash.services.internal.network.api
 import com.codeinc.flipcash.gen.phone.v1.Model
 import com.codeinc.flipcash.gen.resolver.v1.ResolverGrpcKt
 import com.codeinc.flipcash.gen.resolver.v1.validate
-import com.flipcash.services.models.ContactMethod
+import com.flipcash.services.models.ResolveIdentifier
 import com.flipcash.services.internal.annotations.FlipcashManagedChannel
+import com.flipcash.services.internal.network.extensions.asUserId
 import com.flipcash.services.internal.network.extensions.authenticate
 import com.getcode.ed25519.Ed25519.KeyPair
 import com.getcode.opencode.internal.network.core.GrpcApi
@@ -28,13 +29,10 @@ internal class ResolverApi @Inject constructor(
 
     suspend fun resolve(
         owner: KeyPair,
-        phone: ContactMethod.Phone,
+        identifier: ResolveIdentifier,
     ): RpcResolverService.ResolveResponse {
         val request = RpcResolverService.ResolveRequest.newBuilder()
-            .setIdentifier(
-                ResolverModel.Identifier.newBuilder()
-                    .setPhone(Model.PhoneNumber.newBuilder().setValue(phone.phoneNumber))
-            )
+            .setIdentifier(identifier.asProtoIdentifier())
             .apply { setAuth(authenticate(owner)) }
             .build()
 
@@ -43,5 +41,15 @@ internal class ResolverApi @Inject constructor(
         return withContext(Dispatchers.IO) {
             api.resolve(request)
         }
+    }
+
+    private fun ResolveIdentifier.asProtoIdentifier(): ResolverModel.Identifier {
+        val builder = ResolverModel.Identifier.newBuilder()
+        return when (this) {
+            is ResolveIdentifier.Phone ->
+                builder.setPhone(Model.PhoneNumber.newBuilder().setValue(phone.phoneNumber))
+            is ResolveIdentifier.UserId ->
+                builder.setUserId(userId.asUserId())
+        }.build()
     }
 }

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/internal/network/extensions/LocalToProtobuf.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/internal/network/extensions/LocalToProtobuf.kt
@@ -8,6 +8,7 @@ import com.flipcash.services.models.PagingToken
 import com.flipcash.services.models.QueryOptions
 import com.flipcash.services.models.SocialAccountLinkRequest
 import com.flipcash.services.models.chat.ChatId
+import com.flipcash.services.models.chat.ChatType
 import com.flipcash.services.models.chat.ClientMessageId
 import com.flipcash.services.models.chat.MessageContent
 import com.flipcash.services.models.chat.PointerType
@@ -20,6 +21,7 @@ import com.getcode.solana.keys.PublicKey
 import com.getcode.utils.toByteString
 import com.google.protobuf.Timestamp
 import kotlin.time.Instant
+import com.codeinc.flipcash.gen.chat.v1.Model as ChatModel
 import com.codeinc.flipcash.gen.messaging.v1.Model as MessagingModel
 
 internal fun Checksum.asHash(): Common.Hash {
@@ -176,6 +178,14 @@ internal fun com.flipcash.services.models.chat.MediaItemRendition.Role.asProtoRo
 
 internal fun com.flipcash.services.models.chat.Emoji.asEmoji(): MessagingModel.Emoji {
     return MessagingModel.Emoji.newBuilder().setValue(value).build()
+}
+
+internal fun ChatType.asProtoChatType(): ChatModel.ChatType {
+    return when (this) {
+        ChatType.UNKNOWN -> ChatModel.ChatType.UNKNOWN
+        ChatType.CONTACT_DM -> ChatModel.ChatType.CONTACT_DM
+        ChatType.TIP_DM -> ChatModel.ChatType.TIP_DM
+    }
 }
 
 internal fun Long.asMessageId(): MessagingModel.MessageId {

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/internal/network/extensions/ProtobufToLocal.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/internal/network/extensions/ProtobufToLocal.kt
@@ -346,6 +346,7 @@ internal fun ChatModel.Metadata.toChatMetadata(): ChatMetadata {
                         socialAccounts = emptyList(),
                         phoneNumber = phoneNumber.value.takeIf { it.isNotEmpty() }?.let { VerifiableContactMethod(it, verified = true) },
                         email = emailAddress.value.takeIf { it.isNotEmpty() }?.let { VerifiableContactMethod(it, verified = true) },
+                        profilePicture = if (hasProfilePicture()) profilePicture.toMediaItem() else null,
                     )
                 },
                 pointers = member.pointersList.map { it.toPointer() },

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/internal/network/services/ChatService.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/internal/network/services/ChatService.kt
@@ -7,6 +7,7 @@ import com.flipcash.services.models.GetChatError
 import com.flipcash.services.models.GetDmChatFeedError
 import com.flipcash.services.models.QueryOptions
 import com.flipcash.services.models.chat.ChatId
+import com.flipcash.services.models.chat.ChatType
 import com.getcode.ed25519.Ed25519.KeyPair
 import com.getcode.opencode.internal.network.extensions.foldWithSuppression
 import com.getcode.opencode.utils.toValidationOrElse
@@ -40,9 +41,10 @@ internal class ChatService @Inject constructor(
     suspend fun getDmChatFeed(
         owner: KeyPair,
         queryOptions: QueryOptions,
+        chatType: ChatType,
     ): Result<RpcChatService.GetDmChatFeedResponse> {
         return runCatching {
-            api.getDmChatFeed(owner, queryOptions)
+            api.getDmChatFeed(owner, queryOptions, chatType)
         }.foldWithSuppression(
             onSuccess = { response ->
                 when (response.result) {

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/internal/network/services/ProfileService.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/internal/network/services/ProfileService.kt
@@ -8,9 +8,13 @@ import com.getcode.opencode.utils.toValidationOrElse
 import com.flipcash.services.models.GetUserProfileError
 import com.flipcash.services.models.LinkSocialAccountError
 import com.flipcash.services.models.SetDisplayNameError
+import com.flipcash.services.models.SetProfilePictureError
 import com.flipcash.services.models.SocialAccountLinkRequest
 import com.flipcash.services.models.SocialAccountUnlinkRequest
 import com.flipcash.services.models.UnlinkSocialAccountError
+import com.flipcash.services.models.chat.BlobId
+import com.flipcash.services.models.chat.MediaItem
+import com.flipcash.services.internal.network.extensions.toMediaItem
 import com.getcode.ed25519.Ed25519
 import com.getcode.opencode.internal.network.extensions.foldWithSuppression
 import com.getcode.opencode.model.core.ID
@@ -55,6 +59,28 @@ internal class ProfileService @Inject constructor(
                 }
             },
             onFailure = { Result.failure(it.toValidationOrElse { cause -> SetDisplayNameError.Other(cause) }) }
+        )
+    }
+
+    suspend fun setProfilePicture(
+        blobId: BlobId,
+        owner: Ed25519.KeyPair,
+    ): Result<MediaItem> {
+        return runCatching {
+            api.setProfilePicture(blobId, owner)
+        }.foldWithSuppression(
+            onSuccess = { response ->
+                when (response.result) {
+                    ProfileService.SetProfilePictureResponse.Result.OK -> Result.success(response.profilePicture.toMediaItem())
+                    ProfileService.SetProfilePictureResponse.Result.DENIED -> Result.failure(SetProfilePictureError.Denied())
+                    ProfileService.SetProfilePictureResponse.Result.BLOB_NOT_FOUND -> Result.failure(SetProfilePictureError.BlobNotFound())
+                    ProfileService.SetProfilePictureResponse.Result.BLOB_NOT_READY -> Result.failure(SetProfilePictureError.BlobNotReady())
+                    ProfileService.SetProfilePictureResponse.Result.BLOB_REJECTED -> Result.failure(SetProfilePictureError.BlobRejected())
+                    ProfileService.SetProfilePictureResponse.Result.INVALID_BLOB -> Result.failure(SetProfilePictureError.InvalidBlob())
+                    ProfileService.SetProfilePictureResponse.Result.UNRECOGNIZED -> Result.failure(SetProfilePictureError.Unrecognized())
+                }
+            },
+            onFailure = { Result.failure(it.toValidationOrElse { cause -> SetProfilePictureError.Other(cause) }) }
         )
     }
 

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/internal/network/services/ResolverService.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/internal/network/services/ResolverService.kt
@@ -1,9 +1,9 @@
 package com.flipcash.services.internal.network.services
 
-import com.flipcash.services.models.ContactMethod
 import com.flipcash.services.internal.network.api.ResolverApi
 import com.flipcash.services.internal.network.extensions.toPublicKey
 import com.flipcash.services.models.ResolveContactError
+import com.flipcash.services.models.ResolveIdentifier
 import com.getcode.ed25519.Ed25519.KeyPair
 import com.getcode.opencode.internal.network.extensions.foldWithSuppression
 import com.getcode.opencode.utils.toValidationOrElse
@@ -16,27 +16,29 @@ internal class ResolverService @Inject constructor(
 ) {
     suspend fun resolve(
         owner: KeyPair,
-        phone: ContactMethod.Phone,
+        identifier: ResolveIdentifier,
     ): Result<PublicKey> {
         return runCatching {
-            api.resolve(owner, phone)
+            api.resolve(owner, identifier)
         }.foldWithSuppression(
-            onSuccess = { response ->
-                when (response.result) {
-                    RpcResolverService.ResolveResponse.Result.OK ->
-                        Result.success(response.resolution.address.toPublicKey())
-                    RpcResolverService.ResolveResponse.Result.NOT_FOUND ->
-                        Result.failure(ResolveContactError.NotFound())
-                    RpcResolverService.ResolveResponse.Result.DENIED ->
-                        Result.failure(ResolveContactError.Denied())
-                    RpcResolverService.ResolveResponse.Result.UNRECOGNIZED ->
-                        Result.failure(ResolveContactError.Unrecognized())
-                    else -> Result.failure(ResolveContactError.Other())
-                }
-            },
+            onSuccess = { it.toResult() },
             onFailure = { cause ->
                 Result.failure(cause.toValidationOrElse { ResolveContactError.Other(cause = it) })
             }
         )
+    }
+
+    private fun RpcResolverService.ResolveResponse.toResult(): Result<PublicKey> {
+        return when (result) {
+            RpcResolverService.ResolveResponse.Result.OK ->
+                Result.success(resolution.address.toPublicKey())
+            RpcResolverService.ResolveResponse.Result.NOT_FOUND ->
+                Result.failure(ResolveContactError.NotFound())
+            RpcResolverService.ResolveResponse.Result.DENIED ->
+                Result.failure(ResolveContactError.Denied())
+            RpcResolverService.ResolveResponse.Result.UNRECOGNIZED ->
+                Result.failure(ResolveContactError.Unrecognized())
+            else -> Result.failure(ResolveContactError.Other())
+        }
     }
 }

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/internal/repositories/InternalChatRepository.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/internal/repositories/InternalChatRepository.kt
@@ -7,6 +7,7 @@ import com.flipcash.services.models.QueryOptions
 import com.flipcash.services.models.chat.ChatFeedPage
 import com.flipcash.services.models.chat.ChatId
 import com.flipcash.services.models.chat.ChatMetadata
+import com.flipcash.services.models.chat.ChatType
 import com.flipcash.services.repository.ChatRepository
 import com.getcode.ed25519.Ed25519.KeyPair
 import com.getcode.utils.ErrorUtils
@@ -25,7 +26,8 @@ internal class InternalChatRepository(
     override suspend fun getDmChatFeed(
         owner: KeyPair,
         queryOptions: QueryOptions,
-    ): Result<ChatFeedPage> = service.getDmChatFeed(owner, queryOptions)
+        chatType: ChatType,
+    ): Result<ChatFeedPage> = service.getDmChatFeed(owner, queryOptions, chatType)
         .onFailure { ErrorUtils.handleError(it) }
         .map { response ->
             ChatFeedPage(

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/internal/repositories/InternalProfileRepository.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/internal/repositories/InternalProfileRepository.kt
@@ -8,6 +8,8 @@ import com.flipcash.services.models.SocialAccount
 import com.flipcash.services.models.SocialAccountLinkRequest
 import com.flipcash.services.models.SocialAccountUnlinkRequest
 import com.flipcash.services.models.UserProfile
+import com.flipcash.services.models.chat.BlobId
+import com.flipcash.services.models.chat.MediaItem
 import com.flipcash.services.repository.ProfileRepository
 import com.getcode.ed25519.Ed25519
 import com.getcode.opencode.model.core.ID
@@ -33,6 +35,14 @@ internal class InternalProfileRepository(
         owner: Ed25519.KeyPair
     ): Result<Unit> {
         return service.setDisplayName(displayName, owner)
+            .onFailure { ErrorUtils.handleError(it) }
+    }
+
+    override suspend fun setProfilePicture(
+        blobId: BlobId,
+        owner: Ed25519.KeyPair
+    ): Result<MediaItem> {
+        return service.setProfilePicture(blobId, owner)
             .onFailure { ErrorUtils.handleError(it) }
     }
 

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/internal/repositories/InternalResolverRepository.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/internal/repositories/InternalResolverRepository.kt
@@ -1,7 +1,7 @@
 package com.flipcash.services.internal.repositories
 
 import com.flipcash.services.internal.network.services.ResolverService
-import com.flipcash.services.models.ContactMethod
+import com.flipcash.services.models.ResolveIdentifier
 import com.flipcash.services.repository.ResolverRepository
 import com.getcode.ed25519.Ed25519
 import com.getcode.solana.keys.PublicKey
@@ -12,7 +12,7 @@ internal class InternalResolverRepository(
 ) : ResolverRepository {
     override suspend fun resolve(
         owner: Ed25519.KeyPair,
-        phone: ContactMethod.Phone,
-    ): Result<PublicKey> = service.resolve(owner, phone)
+        identifier: ResolveIdentifier,
+    ): Result<PublicKey> = service.resolve(owner, identifier)
         .onFailure { ErrorUtils.handleError(it) }
 }

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/models/DmPaymentMetadata.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/models/DmPaymentMetadata.kt
@@ -29,3 +29,22 @@ fun buildDmPaymentMetadata(
                 )
         ).build().toByteArray()
 }
+
+/**
+ * Builds the serialized Flipcash `AppMetadata` proto bytes for a tip DM payment.
+ *
+ * Unlike a contact DM payment there is no phone source/destination — a tip DM is
+ * between two user IDs, which map directly to/from public keys. Returns `null` when
+ * [chatId] is missing so the caller can pass the result through unconditionally.
+ */
+fun buildTipDmPaymentMetadata(
+    chatId: ChatId?,
+): ByteArray? {
+    if (chatId == null) return null
+    return FlipcashIntentModel.AppMetadata.newBuilder()
+        .setChat(
+            FlipcashIntentModel.ChatMetadata.newBuilder()
+                .setChatId(Common.ChatId.newBuilder().setValue(chatId.bytes.toByteString()))
+                .setTipDmPayment(FlipcashIntentModel.ChatMetadata.TipDmPayment.newBuilder())
+        ).build().toByteArray()
+}

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/models/Errors.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/models/Errors.kt
@@ -205,6 +205,23 @@ sealed class SetDisplayNameError(
     data class Other(override val cause: Throwable? = null) : SetDisplayNameError(message = cause?.message, cause = cause), NotifiableError
 }
 
+sealed class SetProfilePictureError(
+    override val message: String? = null,
+    override val cause: Throwable? = null
+): CodeServerError(message, cause) {
+    class Denied: SetProfilePictureError("Denied")
+    // No such blob, or it is not owned by the caller.
+    class BlobNotFound: SetProfilePictureError("Blob not found")
+    // Blob is still PENDING/PROCESSING; retry once READY.
+    class BlobNotReady: SetProfilePictureError("Blob not ready")
+    // Blob failed validation or moderation; terminal for this id, must upload again.
+    class BlobRejected: SetProfilePictureError("Blob rejected")
+    // Blob is READY but unusable as a picture (e.g. not an image).
+    class InvalidBlob: SetProfilePictureError("Invalid blob")
+    class Unrecognized : SetProfilePictureError("Unrecognized"), NotifiableError
+    data class Other(override val cause: Throwable? = null) : SetProfilePictureError(message = cause?.message, cause = cause), NotifiableError
+}
+
 sealed class LinkSocialAccountError(
     override val message: String? = null,
     override val cause: Throwable? = null

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/models/ResolveIdentifier.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/models/ResolveIdentifier.kt
@@ -1,0 +1,12 @@
+package com.flipcash.services.models
+
+import com.getcode.opencode.model.core.ID
+
+/**
+ * What to resolve to an on-chain address. Mirrors the resolver `Identifier` oneof:
+ * a resolution is keyed by exactly one of a phone number or a user ID.
+ */
+sealed interface ResolveIdentifier {
+    data class Phone(val phone: ContactMethod.Phone) : ResolveIdentifier
+    data class UserId(val userId: ID) : ResolveIdentifier
+}

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/models/UserProfile.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/models/UserProfile.kt
@@ -1,10 +1,15 @@
 package com.flipcash.services.models
 
+import com.flipcash.services.models.chat.MediaItem
+
 data class UserProfile(
     val displayName: String?,
     val socialAccounts: List<SocialAccount>,
     val phoneNumber: VerifiableContactMethod?,
     val email: VerifiableContactMethod?,
+    // The user's profile picture, as the renditions it is stored as (DISPLAY for
+    // the profile view, THUMBNAIL for avatars). Null when unset.
+    val profilePicture: MediaItem? = null,
 ) {
     /** The phone number only when it has been verified — backwards-compatible accessor. */
     val verifiedPhoneNumber: String? get() = phoneNumber?.takeIf { it.verified }?.value

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/repository/ChatRepository.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/repository/ChatRepository.kt
@@ -4,6 +4,7 @@ import com.flipcash.services.models.QueryOptions
 import com.flipcash.services.models.chat.ChatFeedPage
 import com.flipcash.services.models.chat.ChatId
 import com.flipcash.services.models.chat.ChatMetadata
+import com.flipcash.services.models.chat.ChatType
 import com.getcode.ed25519.Ed25519.KeyPair
 
 interface ChatRepository {
@@ -15,5 +16,6 @@ interface ChatRepository {
     suspend fun getDmChatFeed(
         owner: KeyPair,
         queryOptions: QueryOptions,
+        chatType: ChatType,
     ): Result<ChatFeedPage>
 }

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/repository/ProfileRepository.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/repository/ProfileRepository.kt
@@ -4,12 +4,15 @@ import com.flipcash.services.models.SocialAccountLinkRequest
 import com.flipcash.services.models.SocialAccount
 import com.flipcash.services.models.SocialAccountUnlinkRequest
 import com.flipcash.services.models.UserProfile
+import com.flipcash.services.models.chat.BlobId
+import com.flipcash.services.models.chat.MediaItem
 import com.getcode.ed25519.Ed25519
 import com.getcode.opencode.model.core.ID
 
 interface ProfileRepository {
     suspend fun getProfile(userId: ID, owner: Ed25519.KeyPair): Result<UserProfile>
     suspend fun setDisplayName(displayName: String, owner: Ed25519.KeyPair): Result<Unit>
+    suspend fun setProfilePicture(blobId: BlobId, owner: Ed25519.KeyPair): Result<MediaItem>
     suspend fun linkSocialAccount(request: SocialAccountLinkRequest, owner: Ed25519.KeyPair): Result<SocialAccount>
     suspend fun unlinkSocialAccount(request: SocialAccountUnlinkRequest, owner: Ed25519.KeyPair): Result<Unit>
 }

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/repository/ResolverRepository.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/repository/ResolverRepository.kt
@@ -1,9 +1,9 @@
 package com.flipcash.services.repository
 
-import com.flipcash.services.models.ContactMethod
+import com.flipcash.services.models.ResolveIdentifier
 import com.getcode.ed25519.Ed25519.KeyPair
 import com.getcode.solana.keys.PublicKey
 
 interface ResolverRepository {
-    suspend fun resolve(owner: KeyPair, phone: ContactMethod.Phone): Result<PublicKey>
+    suspend fun resolve(owner: KeyPair, identifier: ResolveIdentifier): Result<PublicKey>
 }

--- a/services/flipcash/src/test/kotlin/com/flipcash/services/controllers/ChatControllerTest.kt
+++ b/services/flipcash/src/test/kotlin/com/flipcash/services/controllers/ChatControllerTest.kt
@@ -88,7 +88,7 @@ class ChatControllerTest {
     fun `getDmChatFeed fails when no account cluster`() = runTest {
         every { userManager.accountCluster } returns null
 
-        val result = controller.getDmChatFeed()
+        val result = controller.getDmChatFeed(ChatType.CONTACT_DM)
 
         assertTrue(result.isFailure)
     }
@@ -98,7 +98,7 @@ class ChatControllerTest {
         stubOwner()
         repository.getDmChatFeedResult = Result.success(ChatFeedPage(emptyList(), null, false))
 
-        controller.getDmChatFeed()
+        controller.getDmChatFeed(ChatType.CONTACT_DM)
 
         assertEquals(QueryOptions(), repository.lastQueryOptions)
     }
@@ -110,11 +110,21 @@ class ChatControllerTest {
         val options = QueryOptions(limit = 25, token = token, descending = false)
         repository.getDmChatFeedResult = Result.success(ChatFeedPage(emptyList(), null, false))
 
-        controller.getDmChatFeed(options)
+        controller.getDmChatFeed(ChatType.CONTACT_DM, options)
 
         assertEquals(25, repository.lastQueryOptions?.limit)
         assertEquals(token, repository.lastQueryOptions?.token)
         assertEquals(false, repository.lastQueryOptions?.descending)
+    }
+
+    @Test
+    fun `getDmChatFeed forwards chat type filter`() = runTest {
+        stubOwner()
+        repository.getDmChatFeedResult = Result.success(ChatFeedPage(emptyList(), null, false))
+
+        controller.getDmChatFeed(ChatType.TIP_DM)
+
+        assertEquals(ChatType.TIP_DM, repository.lastChatType)
     }
 
     @Test
@@ -130,7 +140,7 @@ class ChatControllerTest {
         )
         repository.getDmChatFeedResult = Result.success(page)
 
-        val result = controller.getDmChatFeed()
+        val result = controller.getDmChatFeed(ChatType.CONTACT_DM)
 
         val returned = result.getOrThrow()
         assertEquals(2, returned.chats.size)
@@ -144,7 +154,7 @@ class ChatControllerTest {
         val cause = RuntimeException("server error")
         repository.getDmChatFeedResult = Result.failure(cause)
 
-        val result = controller.getDmChatFeed()
+        val result = controller.getDmChatFeed(ChatType.CONTACT_DM)
 
         assertTrue(result.isFailure)
         assertSame(cause, result.exceptionOrNull())
@@ -172,14 +182,20 @@ private class FakeChatRepository : ChatRepository {
     var getDmChatFeedResult: Result<ChatFeedPage> = Result.failure(RuntimeException("not configured"))
     var lastChatId: ChatId? = null
     var lastQueryOptions: QueryOptions? = null
+    var lastChatType: ChatType? = null
 
     override suspend fun getChat(owner: Ed25519.KeyPair, chatId: ChatId): Result<ChatMetadata> {
         lastChatId = chatId
         return getChatResult
     }
 
-    override suspend fun getDmChatFeed(owner: Ed25519.KeyPair, queryOptions: QueryOptions): Result<ChatFeedPage> {
+    override suspend fun getDmChatFeed(
+        owner: Ed25519.KeyPair,
+        queryOptions: QueryOptions,
+        chatType: ChatType,
+    ): Result<ChatFeedPage> {
         lastQueryOptions = queryOptions
+        lastChatType = chatType
         return getDmChatFeedResult
     }
 }

--- a/services/flipcash/src/test/kotlin/com/flipcash/services/controllers/ProfileControllerTest.kt
+++ b/services/flipcash/src/test/kotlin/com/flipcash/services/controllers/ProfileControllerTest.kt
@@ -6,6 +6,8 @@ import com.flipcash.services.models.SocialAccountLinkRequest
 import com.flipcash.services.models.SocialAccountUnlinkRequest
 import com.flipcash.services.models.UserProfile
 import com.flipcash.services.models.VerifiableContactMethod
+import com.flipcash.services.models.chat.BlobId
+import com.flipcash.services.models.chat.MediaItem
 import com.flipcash.services.repository.ProfileRepository
 import com.flipcash.services.user.UserManager
 import com.getcode.ed25519.Ed25519
@@ -299,11 +301,13 @@ class ProfileControllerTest {
 private class FakeProfileRepository : ProfileRepository {
     var getProfileResult: Result<UserProfile> = Result.failure(RuntimeException("not configured"))
     var setDisplayNameResult: Result<Unit> = Result.success(Unit)
+    var setProfilePictureResult: Result<MediaItem> = Result.failure(RuntimeException("not configured"))
     var linkSocialAccountResult: Result<SocialAccount> = Result.failure(RuntimeException("not configured"))
     var unlinkSocialAccountResult: Result<Unit> = Result.success(Unit)
 
     override suspend fun getProfile(userId: ID, owner: Ed25519.KeyPair) = getProfileResult
     override suspend fun setDisplayName(displayName: String, owner: Ed25519.KeyPair) = setDisplayNameResult
+    override suspend fun setProfilePicture(blobId: BlobId, owner: Ed25519.KeyPair) = setProfilePictureResult
     override suspend fun linkSocialAccount(request: SocialAccountLinkRequest, owner: Ed25519.KeyPair) =
         linkSocialAccountResult
     override suspend fun unlinkSocialAccount(request: SocialAccountUnlinkRequest, owner: Ed25519.KeyPair) =

--- a/services/flipcash/src/test/kotlin/com/flipcash/services/internal/domain/UserProfileMapperTest.kt
+++ b/services/flipcash/src/test/kotlin/com/flipcash/services/internal/domain/UserProfileMapperTest.kt
@@ -1,14 +1,18 @@
 package com.flipcash.services.internal.domain
 
+import com.codeinc.flipcash.gen.blob.v1.Model as BlobModel
 import com.codeinc.flipcash.gen.email.v1.emailAddress
 import com.codeinc.flipcash.gen.phone.v1.phoneNumber
 import com.codeinc.flipcash.gen.profile.v1.Model
 import com.codeinc.flipcash.gen.profile.v1.socialProfile
 import com.codeinc.flipcash.gen.profile.v1.xProfile
 import com.flipcash.services.models.SocialAccount
+import com.flipcash.services.models.chat.MediaItemRendition
+import com.google.protobuf.ByteString
 import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
 class UserProfileMapperTest {
@@ -80,5 +84,30 @@ class UserProfileMapperTest {
         val result = mapper.map(proto)
         assertNull(result.verifiedPhoneNumber)
         assertNull(result.verifiedEmailAddress)
+    }
+
+    @Test
+    fun `maps profile picture renditions`() {
+        val proto = userProfile {
+            displayName = "Grace"
+            profilePicture = BlobModel.Media.newBuilder()
+                .addRenditions(
+                    BlobModel.Rendition.newBuilder()
+                        .setRole(BlobModel.Rendition.Role.DISPLAY)
+                        .setBlobId(BlobModel.BlobId.newBuilder().setValue(ByteString.copyFrom(ByteArray(4) { 1 })))
+                )
+                .build()
+        }
+
+        val result = mapper.map(proto)
+        val picture = assertNotNull(result.profilePicture)
+        assertEquals(1, picture.renditions.size)
+        assertEquals(MediaItemRendition.Role.DISPLAY, picture.renditions.first().role)
+    }
+
+    @Test
+    fun `no profile picture returns null`() {
+        val proto = userProfile { displayName = "Heidi" }
+        assertNull(mapper.map(proto).profilePicture)
     }
 }


### PR DESCRIPTION
## Summary

Builds out the net-new (P3) service-layer features enabled by the flipcash proto sync (#1105). Two commits, two coherent bundles:

1. **`feat(profile)`** — profile pictures
2. **`feat(chat,resolver)`** — tip DM support

No UI is wired yet; this is the service/domain/persistence plumbing the upcoming features will consume.

## Profile pictures
- **SetProfilePicture** RPC scaffolded across the stack: `ProfileApi` → `ProfileService` → `ProfileRepository`/`InternalProfileRepository` → `ProfileController`, with a `SetProfilePictureError` sealed type covering every proto result (`DENIED`, `BLOB_NOT_FOUND`, `BLOB_NOT_READY`, `BLOB_REJECTED`, `INVALID_BLOB`). The response `blob.v1.Media` maps to the domain `MediaItem`.
- **`UserProfile.profilePicture`** propagated end-to-end: domain model, `UserProfileMapper`, the inline chat-member profile builder, and persistence (`UserProfileSerialized` + compat DTO + entity mappers).

## Tip DMs
- **`buildTipDmPaymentMetadata()`** builds the intent `AppMetadata` for a user-id↔user-id tip payment (no phone source/destination).
- **Resolver by user ID** via the resolver `Identifier.user_id` arm. The `Identifier` oneof is modeled as a domain `ResolveIdentifier` (`Phone` | `UserId`), so `ResolverApi`/`ResolverService`/`ResolverRepository` each expose a single `resolve(owner, identifier)` — the phone-vs-user-id branch lives in exactly one place (proto construction). `ResolverController` keeps two ergonomic entry points (`resolve(phone)` / `resolveByUserId(userId)`) that delegate to it, so existing callers (e.g. `ContactCoordinator`) are unchanged.
- **`getDmChatFeed(chatType)`** now takes a **required** `ChatType` so callers filter `CONTACT_DM` vs `TIP_DM` explicitly (threaded through Api/Service/Repo/Controller). No default — the server maps a missing/`UNKNOWN` value to `CONTACT_DM`, so a silent default would hide intent. Feed sync passes `CONTACT_DM`, preserving current behaviour.

## Tests
- New `UserProfileMapper` cases for profile-picture mapping (present + absent).
- New `ChatController` test asserting the chat-type filter is forwarded; existing feed tests updated for the required param.
- Test doubles updated (`FakeProfileRepository`, `FakeChatRepository`, chat-coordinator mocks).

## Verification
`:services:flipcash:testDebugUnitTest`, `:apps:flipcash:shared:chat:testDebugUnitTest`, and `:apps:flipcash:shared:persistence:db:testDebugUnitTest` all pass; `:apps:flipcash:shared:contacts` (the `resolve(phone)` caller) compiles.

## Deferred
UI consumers, and actually consuming `EventStreamingController.blobUpdates` for upload-completion, remain for the feature work that builds on this.