### PR TITLE
feat(services): blob storage upload client + upload policy

### DIFF
--- a/services/flipcash/src/main/kotlin/com/flipcash/services/BlobUploader.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/BlobUploader.kt
@@ -1,0 +1,12 @@
+package com.flipcash.services
+
+import com.flipcash.services.models.blob.UploadTarget
+
+/**
+ * Uploads raw bytes directly to object storage using a presigned [UploadTarget] minted by
+ * `BlobStorage.initiateExternalUpload`. The gRPC layer never carries the bytes — this is a plain
+ * HTTP PUT (raw body) or POST (multipart/form-data) straight to the storage provider.
+ */
+interface BlobUploader {
+    suspend fun upload(bytes: ByteArray, mimeType: String, target: UploadTarget): Result<Unit>
+}

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/controllers/BlobStorageController.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/controllers/BlobStorageController.kt
@@ -1,0 +1,85 @@
+package com.flipcash.services.controllers
+
+import com.flipcash.services.BlobUploader
+import com.flipcash.services.models.BlobNotReadyException
+import com.flipcash.services.models.BlobRejectedException
+import com.flipcash.services.models.blob.UploadPolicy
+import com.flipcash.services.models.chat.BlobId
+import com.flipcash.services.models.chat.BlobStatus
+import com.flipcash.services.repository.BlobStorageRepository
+import com.flipcash.services.user.UserManager
+import com.getcode.ed25519.Ed25519
+import kotlinx.coroutines.delay
+import javax.inject.Inject
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Client for blob-storage uploads. [upload] performs the entire direct-to-storage handshake behind a
+ * single call — reserve, PUT/POST the bytes, advise completion, and poll until the blob is READY —
+ * returning the durable [BlobId] to hand to e.g. `ProfileController.setProfilePicture`. Callers use
+ * [getUploadPolicy] up front to filter selection and validate size before uploading.
+ */
+class BlobStorageController @Inject constructor(
+    private val repository: BlobStorageRepository,
+    private val uploader: BlobUploader,
+    private val userManager: UserManager,
+) {
+
+    private companion object {
+        val POLL_INTERVAL = 500.milliseconds
+        val POLL_TIMEOUT = 30.seconds
+    }
+
+    /** The server's current upload constraints (accepted MIME types + size ceilings). */
+    suspend fun getUploadPolicy(): Result<UploadPolicy> {
+        val owner = owner() ?: return noAccount()
+        return repository.getUploadPolicy(owner)
+    }
+
+    /**
+     * Uploads [bytes] to storage and returns the READY [BlobId]. Reserves a presigned target,
+     * PUTs/POSTs the bytes directly to storage, signals completion, and polls until the server
+     * finishes validating/transcoding — so callers never orchestrate the individual steps.
+     */
+    suspend fun upload(bytes: ByteArray, mimeType: String): Result<BlobId> {
+        val owner = owner() ?: return noAccount()
+
+        val reservation = repository.initiateExternalUpload(mimeType, bytes.size.toLong(), owner)
+            .getOrElse { return Result.failure(it) }
+
+        uploader.upload(bytes, mimeType, reservation.target)
+            .getOrElse { return Result.failure(it) }
+
+        // Advisory — the storage-completion event finalizes the blob even if this is skipped/fails.
+        repository.completeExternalUpload(reservation.blobId, owner)
+
+        return awaitReady(reservation.blobId, owner)
+    }
+
+    private suspend fun awaitReady(blobId: BlobId, owner: Ed25519.KeyPair): Result<BlobId> {
+        var elapsed: Duration = Duration.ZERO
+        while (elapsed < POLL_TIMEOUT) {
+            // A single-id query resolves to at most one blob, so first() is the one we asked for.
+            val blob = repository.getBlobs(listOf(blobId), owner)
+                .getOrElse { return Result.failure(it) }
+                .firstOrNull()
+
+            when (blob?.status) {
+                BlobStatus.READY -> return Result.success(blobId)
+                BlobStatus.REJECTED -> return Result.failure(BlobRejectedException(blob.rejection))
+                else -> {
+                    delay(POLL_INTERVAL)
+                    elapsed += POLL_INTERVAL
+                }
+            }
+        }
+        return Result.failure(BlobNotReadyException())
+    }
+
+    private fun owner(): Ed25519.KeyPair? = userManager.accountCluster?.authority?.keyPair
+
+    private fun <T> noAccount(): Result<T> =
+        Result.failure(Throwable("No account cluster in UserManager"))
+}

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/inject/FlipcashModule.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/inject/FlipcashModule.kt
@@ -12,8 +12,11 @@ import com.flipcash.services.internal.domain.SocialAccountMapper
 import com.flipcash.services.internal.domain.TextModerationResponseMapper
 import com.flipcash.services.internal.domain.UserProfileMapper
 import com.flipcash.services.internal.domain.ChatMetadataMapper
+import com.flipcash.services.BlobUploader
+import com.flipcash.services.internal.network.HttpBlobUploader
 import com.flipcash.services.internal.network.services.AccountService
 import com.flipcash.services.internal.network.services.ActivityFeedService
+import com.flipcash.services.internal.network.services.BlobStorageService
 import com.flipcash.services.internal.network.services.ChatService
 import com.flipcash.services.internal.network.services.EventStreamingService
 import com.flipcash.services.internal.network.services.ChatMessagingService
@@ -29,6 +32,7 @@ import com.flipcash.services.internal.network.services.SettingsService
 import com.flipcash.services.internal.network.services.ThirdPartyService
 import com.flipcash.services.internal.repositories.InternalAccountRepository
 import com.flipcash.services.internal.repositories.InternalActivityFeedRepository
+import com.flipcash.services.internal.repositories.InternalBlobStorageRepository
 import com.flipcash.services.internal.repositories.InternalChatRepository
 import com.flipcash.services.internal.repositories.InternalEventStreamingRepository
 import com.flipcash.services.internal.repositories.InternalChatMessagingRepository
@@ -52,6 +56,7 @@ import com.flipcash.services.repository.ModerationRepository
 import com.flipcash.services.repository.ProfileRepository
 import com.flipcash.services.repository.PurchaseRepository
 import com.flipcash.services.repository.PushRepository
+import com.flipcash.services.repository.BlobStorageRepository
 import com.flipcash.services.repository.ResolverRepository
 import com.flipcash.services.repository.SettingsRepository
 import com.flipcash.services.repository.ThirdPartyRepository
@@ -171,6 +176,16 @@ internal object FlipcashModule {
     internal fun providesResolverRepository(
         service: ResolverService,
     ): ResolverRepository = InternalResolverRepository(service)
+
+    @Provides
+    internal fun providesBlobStorageRepository(
+        service: BlobStorageService,
+    ): BlobStorageRepository = InternalBlobStorageRepository(service)
+
+    @Provides
+    internal fun providesBlobUploader(
+        uploader: HttpBlobUploader,
+    ): BlobUploader = uploader
 
     @Provides
     internal fun providesAccountRepository(

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/internal/network/HttpBlobUploader.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/internal/network/HttpBlobUploader.kt
@@ -1,0 +1,57 @@
+package com.flipcash.services.internal.network
+
+import com.flipcash.services.BlobUploader
+import com.flipcash.services.models.blob.UploadTarget
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.MultipartBody
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+internal class HttpBlobUploader @Inject constructor() : BlobUploader {
+
+    private val client = OkHttpClient()
+
+    override suspend fun upload(
+        bytes: ByteArray,
+        mimeType: String,
+        target: UploadTarget,
+    ): Result<Unit> = withContext(Dispatchers.IO) {
+        runCatching {
+            val media = mimeType.toMediaTypeOrNull()
+            val request = when (target.method) {
+                UploadTarget.Method.PUT -> {
+                    Request.Builder()
+                        .url(target.url)
+                        .apply { target.headers.forEach { (k, v) -> header(k, v) } }
+                        .put(bytes.toRequestBody(media))
+                        .build()
+                }
+                UploadTarget.Method.POST -> {
+                    // multipart/form-data: the signed policy form fields MUST precede the file part.
+                    val body = MultipartBody.Builder().setType(MultipartBody.FORM).apply {
+                        target.formFields.forEach { (k, v) -> addFormDataPart(k, v) }
+                        addFormDataPart("file", "upload", bytes.toRequestBody(media))
+                    }.build()
+                    Request.Builder()
+                        .url(target.url)
+                        .apply { target.headers.forEach { (k, v) -> header(k, v) } }
+                        .post(body)
+                        .build()
+                }
+                UploadTarget.Method.UNKNOWN ->
+                    throw IllegalStateException("Unknown upload method for target ${target.url}")
+            }
+
+            client.newCall(request).execute().use { response ->
+                check(response.isSuccessful) { "Blob upload failed: HTTP ${response.code}" }
+            }
+            Unit
+        }
+    }
+}

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/internal/network/api/BlobStorageApi.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/internal/network/api/BlobStorageApi.kt
@@ -1,0 +1,102 @@
+package com.flipcash.services.internal.network.api
+
+import com.codeinc.flipcash.gen.blob.v1.BlobStorageGrpcKt
+import com.codeinc.flipcash.gen.blob.v1.BlobStorageService as RpcBlobStorageService
+import com.codeinc.flipcash.gen.blob.v1.Model
+import com.codeinc.flipcash.gen.blob.v1.validate
+import com.flipcash.services.internal.annotations.FlipcashManagedChannel
+import com.flipcash.services.internal.network.extensions.authenticate
+import com.flipcash.services.models.chat.BlobId
+import com.getcode.ed25519.Ed25519
+import com.getcode.opencode.internal.network.core.GrpcApi
+import com.getcode.utils.toByteString
+import dev.bmcreations.protovalidate.orThrow
+import io.grpc.ManagedChannel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Wraps the BlobStorage gRPC service — direct-to-storage uploads. The bytes never travel through
+ * gRPC: [initiateExternalUpload] reserves a [Model.BlobId] and returns a presigned target the client
+ * uploads to over plain HTTP, [completeExternalUpload] advises the server the upload finished, and
+ * [getBlobs] resolves ids to their status + a fresh download URL.
+ */
+@Singleton
+internal class BlobStorageApi @Inject constructor(
+    @FlipcashManagedChannel
+    managedChannel: ManagedChannel,
+) : GrpcApi(managedChannel) {
+
+    private val api = BlobStorageGrpcKt.BlobStorageCoroutineStub(managedChannel)
+        .withWaitForReady()
+
+    suspend fun getUploadPolicy(owner: Ed25519.KeyPair): RpcBlobStorageService.GetUploadPolicyResponse {
+        val request = RpcBlobStorageService.GetUploadPolicyRequest.newBuilder()
+            .apply { setAuth(authenticate(owner)) }
+            .build()
+
+        request.validate().orThrow()
+
+        return withContext(Dispatchers.IO) {
+            api.getUploadPolicy(request)
+        }
+    }
+
+    suspend fun initiateExternalUpload(
+        mimeType: String,
+        sizeBytes: Long,
+        owner: Ed25519.KeyPair,
+    ): RpcBlobStorageService.InitiateExternalUploadResponse {
+        val request = RpcBlobStorageService.InitiateExternalUploadRequest.newBuilder()
+            .setMimeType(mimeType)
+            .setSizeBytes(sizeBytes)
+            .apply { setAuth(authenticate(owner)) }
+            .build()
+
+        request.validate().orThrow()
+
+        return withContext(Dispatchers.IO) {
+            api.initiateExternalUpload(request)
+        }
+    }
+
+    suspend fun completeExternalUpload(
+        blobId: BlobId,
+        owner: Ed25519.KeyPair,
+    ): RpcBlobStorageService.CompleteExternalUploadResponse {
+        val request = RpcBlobStorageService.CompleteExternalUploadRequest.newBuilder()
+            .setBlobId(blobId.toProto())
+            .apply { setAuth(authenticate(owner)) }
+            .build()
+
+        request.validate().orThrow()
+
+        return withContext(Dispatchers.IO) {
+            api.completeExternalUpload(request)
+        }
+    }
+
+    suspend fun getBlobs(
+        blobIds: List<BlobId>,
+        owner: Ed25519.KeyPair,
+    ): RpcBlobStorageService.GetBlobsResponse {
+        val request = RpcBlobStorageService.GetBlobsRequest.newBuilder()
+            .setBlobIds(
+                Model.BlobIdBatch.newBuilder()
+                    .addAllBlobIds(blobIds.map { it.toProto() })
+            )
+            .apply { setAuth(authenticate(owner)) }
+            .build()
+
+        request.validate().orThrow()
+
+        return withContext(Dispatchers.IO) {
+            api.getBlobs(request)
+        }
+    }
+
+    private fun BlobId.toProto(): Model.BlobId =
+        Model.BlobId.newBuilder().setValue(bytes.toByteString()).build()
+}

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/internal/network/extensions/ProtobufToLocal.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/internal/network/extensions/ProtobufToLocal.kt
@@ -25,6 +25,10 @@ import com.flipcash.services.models.chat.ChatType
 import com.flipcash.services.models.chat.ChatUpdate
 import com.flipcash.services.models.chat.Emoji
 import com.flipcash.services.models.chat.EmojiReaction
+import com.flipcash.services.models.blob.ImageConstraints
+import com.flipcash.services.models.blob.MimeTypeConstraints
+import com.flipcash.services.models.blob.UploadPolicy
+import com.flipcash.services.models.blob.UploadTarget
 import com.flipcash.services.models.chat.BlobId
 import com.flipcash.services.models.chat.BlobMetadata
 import com.flipcash.services.models.chat.BlobRejection
@@ -51,6 +55,8 @@ import com.getcode.solana.keys.Checksum
 import com.getcode.solana.keys.Mint
 import com.getcode.solana.keys.PublicKey
 import com.getcode.solana.keys.Signature
+import kotlin.time.Duration.Companion.nanoseconds
+import kotlin.time.Duration.Companion.seconds
 import kotlin.time.Instant
 import com.codeinc.flipcash.gen.activity.v1.Model as ActivityModels
 import com.codeinc.flipcash.gen.chat.v1.Model as ChatModel
@@ -389,6 +395,40 @@ internal fun com.codeinc.flipcash.gen.blob.v1.Model.Blob.toBlobState(): BlobStat
         status = status.toBlobStatus(),
         metadata = if (hasMetadata()) metadata.toBlobMetadata() else null,
         rejection = if (hasRejection()) rejection.toBlobRejection() else null,
+    )
+}
+
+internal fun com.codeinc.flipcash.gen.blob.v1.Model.UploadPolicy.toUploadPolicy(): UploadPolicy {
+    return UploadPolicy(
+        version = version.value,
+        ttl = ttl.seconds.seconds + ttl.nanos.nanoseconds,
+        mimeTypeConstraints = mimeTypeConstraintsList.map { constraint ->
+            MimeTypeConstraints(
+                mimeTypePattern = constraint.mimeTypePattern,
+                maxSizeBytes = constraint.maxSizeBytes,
+                image = if (constraint.hasImage()) {
+                    ImageConstraints(
+                        maxWidth = constraint.image.maxWidth,
+                        maxHeight = constraint.image.maxHeight,
+                        maxPixels = constraint.image.maxPixels,
+                    )
+                } else null,
+            )
+        },
+    )
+}
+
+internal fun com.codeinc.flipcash.gen.blob.v1.Model.UploadTarget.toUploadTarget(): UploadTarget {
+    return UploadTarget(
+        method = when (method) {
+            com.codeinc.flipcash.gen.blob.v1.Model.UploadTarget.Method.PUT -> UploadTarget.Method.PUT
+            com.codeinc.flipcash.gen.blob.v1.Model.UploadTarget.Method.POST -> UploadTarget.Method.POST
+            else -> UploadTarget.Method.UNKNOWN
+        },
+        url = url,
+        headers = headersMap,
+        formFields = formFieldsMap,
+        expiresAt = Instant.fromEpochSeconds(expiresAt.seconds, expiresAt.nanos.toLong()),
     )
 }
 

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/internal/network/services/BlobStorageService.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/internal/network/services/BlobStorageService.kt
@@ -1,0 +1,127 @@
+package com.flipcash.services.internal.network.services
+
+import com.codeinc.flipcash.gen.blob.v1.BlobStorageService as RpcBlobStorageService
+import com.flipcash.services.internal.network.api.BlobStorageApi
+import com.flipcash.services.internal.network.extensions.toBlobState
+import com.flipcash.services.internal.network.extensions.toBlobStatus
+import com.flipcash.services.internal.network.extensions.toUploadPolicy
+import com.flipcash.services.internal.network.extensions.toUploadTarget
+import com.flipcash.services.models.CompleteExternalUploadError
+import com.flipcash.services.models.GetBlobsError
+import com.flipcash.services.models.GetUploadPolicyError
+import com.flipcash.services.models.InitiateExternalUploadError
+import com.flipcash.services.models.blob.UploadPolicy
+import com.flipcash.services.models.blob.UploadReservation
+import com.flipcash.services.models.chat.BlobId
+import com.flipcash.services.models.chat.BlobState
+import com.flipcash.services.models.chat.BlobStatus
+import com.getcode.ed25519.Ed25519
+import com.getcode.opencode.internal.network.extensions.foldWithSuppression
+import com.getcode.opencode.utils.toValidationOrElse
+import javax.inject.Inject
+
+internal class BlobStorageService @Inject constructor(
+    private val api: BlobStorageApi,
+) {
+
+    suspend fun getUploadPolicy(owner: Ed25519.KeyPair): Result<UploadPolicy> {
+        return runCatching { api.getUploadPolicy(owner) }
+            .foldWithSuppression(
+                onSuccess = { response ->
+                    when (response.result) {
+                        RpcBlobStorageService.GetUploadPolicyResponse.Result.OK ->
+                            Result.success(response.policy.toUploadPolicy())
+                        RpcBlobStorageService.GetUploadPolicyResponse.Result.DENIED ->
+                            Result.failure(GetUploadPolicyError.Denied())
+                        else -> Result.failure(GetUploadPolicyError.Unrecognized())
+                    }
+                },
+                onFailure = { cause ->
+                    Result.failure(cause.toValidationOrElse { GetUploadPolicyError.Other(cause = it) })
+                }
+            )
+    }
+
+    suspend fun initiateExternalUpload(
+        mimeType: String,
+        sizeBytes: Long,
+        owner: Ed25519.KeyPair,
+    ): Result<UploadReservation> {
+        return runCatching { api.initiateExternalUpload(mimeType, sizeBytes, owner) }
+            .foldWithSuppression(
+                onSuccess = { response ->
+                    when (response.result) {
+                        RpcBlobStorageService.InitiateExternalUploadResponse.Result.OK ->
+                            Result.success(
+                                UploadReservation(
+                                    blobId = BlobId(response.blobId.value.toByteArray()),
+                                    target = response.uploadTarget.toUploadTarget(),
+                                )
+                            )
+                        RpcBlobStorageService.InitiateExternalUploadResponse.Result.UNSUPPORTED_TYPE ->
+                            Result.failure(InitiateExternalUploadError.UnsupportedType(response.policyVersionOrNull()))
+                        RpcBlobStorageService.InitiateExternalUploadResponse.Result.TOO_LARGE ->
+                            Result.failure(InitiateExternalUploadError.TooLarge(response.policyVersionOrNull()))
+                        RpcBlobStorageService.InitiateExternalUploadResponse.Result.QUOTA_EXCEEDED ->
+                            Result.failure(InitiateExternalUploadError.QuotaExceeded())
+                        RpcBlobStorageService.InitiateExternalUploadResponse.Result.DENIED ->
+                            Result.failure(InitiateExternalUploadError.Denied())
+                        else -> Result.failure(InitiateExternalUploadError.Unrecognized())
+                    }
+                },
+                onFailure = { cause ->
+                    Result.failure(cause.toValidationOrElse { InitiateExternalUploadError.Other(cause = it) })
+                }
+            )
+    }
+
+    suspend fun completeExternalUpload(
+        blobId: BlobId,
+        owner: Ed25519.KeyPair,
+    ): Result<BlobStatus> {
+        return runCatching { api.completeExternalUpload(blobId, owner) }
+            .foldWithSuppression(
+                onSuccess = { response ->
+                    when (response.result) {
+                        RpcBlobStorageService.CompleteExternalUploadResponse.Result.OK ->
+                            Result.success(response.status.toBlobStatus())
+                        RpcBlobStorageService.CompleteExternalUploadResponse.Result.NOT_FOUND ->
+                            Result.failure(CompleteExternalUploadError.NotFound())
+                        RpcBlobStorageService.CompleteExternalUploadResponse.Result.NOT_UPLOADED ->
+                            Result.failure(CompleteExternalUploadError.NotUploaded())
+                        else -> Result.failure(CompleteExternalUploadError.Unrecognized())
+                    }
+                },
+                onFailure = { cause ->
+                    Result.failure(cause.toValidationOrElse { CompleteExternalUploadError.Other(cause = it) })
+                }
+            )
+    }
+
+    suspend fun getBlobs(
+        blobIds: List<BlobId>,
+        owner: Ed25519.KeyPair,
+    ): Result<List<BlobState>> {
+        return runCatching { api.getBlobs(blobIds, owner) }
+            .foldWithSuppression(
+                onSuccess = { response ->
+                    when (response.result) {
+                        RpcBlobStorageService.GetBlobsResponse.Result.OK ->
+                            Result.success(
+                                if (response.hasBlobs()) response.blobs.blobsList.map { it.toBlobState() }
+                                else emptyList()
+                            )
+                        RpcBlobStorageService.GetBlobsResponse.Result.DENIED ->
+                            Result.failure(GetBlobsError.Denied())
+                        else -> Result.failure(GetBlobsError.Unrecognized())
+                    }
+                },
+                onFailure = { cause ->
+                    Result.failure(cause.toValidationOrElse { GetBlobsError.Other(cause = it) })
+                }
+            )
+    }
+
+    private fun RpcBlobStorageService.InitiateExternalUploadResponse.policyVersionOrNull(): String? =
+        if (hasPolicyVersion()) policyVersion.value else null
+}

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/internal/repositories/InternalBlobStorageRepository.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/internal/repositories/InternalBlobStorageRepository.kt
@@ -1,0 +1,39 @@
+package com.flipcash.services.internal.repositories
+
+import com.flipcash.services.internal.network.services.BlobStorageService
+import com.flipcash.services.models.blob.UploadPolicy
+import com.flipcash.services.models.blob.UploadReservation
+import com.flipcash.services.models.chat.BlobId
+import com.flipcash.services.models.chat.BlobState
+import com.flipcash.services.models.chat.BlobStatus
+import com.flipcash.services.repository.BlobStorageRepository
+import com.getcode.ed25519.Ed25519
+import com.getcode.utils.ErrorUtils
+
+internal class InternalBlobStorageRepository(
+    private val service: BlobStorageService,
+) : BlobStorageRepository {
+
+    override suspend fun getUploadPolicy(owner: Ed25519.KeyPair): Result<UploadPolicy> =
+        service.getUploadPolicy(owner)
+            .onFailure { ErrorUtils.handleError(it) }
+
+    override suspend fun initiateExternalUpload(
+        mimeType: String,
+        sizeBytes: Long,
+        owner: Ed25519.KeyPair,
+    ): Result<UploadReservation> = service.initiateExternalUpload(mimeType, sizeBytes, owner)
+        .onFailure { ErrorUtils.handleError(it) }
+
+    override suspend fun completeExternalUpload(
+        blobId: BlobId,
+        owner: Ed25519.KeyPair,
+    ): Result<BlobStatus> = service.completeExternalUpload(blobId, owner)
+        .onFailure { ErrorUtils.handleError(it) }
+
+    override suspend fun getBlobs(
+        blobIds: List<BlobId>,
+        owner: Ed25519.KeyPair,
+    ): Result<List<BlobState>> = service.getBlobs(blobIds, owner)
+        .onFailure { ErrorUtils.handleError(it) }
+}

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/models/Errors.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/models/Errors.kt
@@ -493,3 +493,52 @@ sealed class GetReactionSummariesError(
     class Unrecognized : GetReactionSummariesError("Unrecognized"), NotifiableError
     data class Other(override val cause: Throwable? = null) : GetReactionSummariesError(message = cause?.message, cause = cause), NotifiableError
 }
+sealed class InitiateExternalUploadError(
+    override val message: String? = null,
+    override val cause: Throwable? = null
+) : CodeServerError(message, cause) {
+    class Denied : InitiateExternalUploadError("Denied")
+    // policyVersion is echoed by the server on a policy-driven denial so the client can detect a
+    // stale cached upload policy and re-fetch it.
+    class UnsupportedType(val policyVersion: String? = null) : InitiateExternalUploadError("Unsupported type")
+    class TooLarge(val policyVersion: String? = null) : InitiateExternalUploadError("Too large")
+    class QuotaExceeded : InitiateExternalUploadError("Quota exceeded")
+    class Unrecognized : InitiateExternalUploadError("Unrecognized"), NotifiableError
+    data class Other(override val cause: Throwable? = null) : InitiateExternalUploadError(message = cause?.message, cause = cause), NotifiableError
+}
+
+sealed class CompleteExternalUploadError(
+    override val message: String? = null,
+    override val cause: Throwable? = null
+) : CodeServerError(message, cause) {
+    class NotFound : CompleteExternalUploadError("Not found")
+    class NotUploaded : CompleteExternalUploadError("Not uploaded")
+    class Unrecognized : CompleteExternalUploadError("Unrecognized"), NotifiableError
+    data class Other(override val cause: Throwable? = null) : CompleteExternalUploadError(message = cause?.message, cause = cause), NotifiableError
+}
+
+sealed class GetBlobsError(
+    override val message: String? = null,
+    override val cause: Throwable? = null
+) : CodeServerError(message, cause) {
+    class Denied : GetBlobsError("Denied")
+    class Unrecognized : GetBlobsError("Unrecognized"), NotifiableError
+    data class Other(override val cause: Throwable? = null) : GetBlobsError(message = cause?.message, cause = cause), NotifiableError
+}
+
+sealed class GetUploadPolicyError(
+    override val message: String? = null,
+    override val cause: Throwable? = null
+) : CodeServerError(message, cause) {
+    class Denied : GetUploadPolicyError("Denied")
+    class Unrecognized : GetUploadPolicyError("Unrecognized"), NotifiableError
+    data class Other(override val cause: Throwable? = null) : GetUploadPolicyError(message = cause?.message, cause = cause), NotifiableError
+}
+
+// Thrown when a reserved blob failed server-side finalization (moderation / decode / size).
+// Terminal: the client must reserve a fresh upload to retry.
+class BlobRejectedException(val rejection: com.flipcash.services.models.chat.BlobRejection?) :
+    Exception("Blob rejected: ${rejection?.reason}")
+
+// Thrown when a blob did not reach READY within the client's polling window.
+class BlobNotReadyException : Exception("Blob did not become ready in time")

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/models/blob/UploadPolicy.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/models/blob/UploadPolicy.kt
@@ -1,0 +1,52 @@
+package com.flipcash.services.models.blob
+
+import kotlinx.serialization.Serializable
+import kotlin.time.Duration
+
+/**
+ * The upload constraints the server enforces, surfaced so the client can filter selection and
+ * resize/transcode BEFORE reserving an upload. Advisory and cacheable ([ttl] / [version]);
+ * `initiateExternalUpload` remains authoritative.
+ */
+@Serializable
+data class UploadPolicy(
+    val version: String,
+    val ttl: Duration,
+    // Ordered most-specific-first: the first entry whose pattern matches wins.
+    val mimeTypeConstraints: List<MimeTypeConstraints>,
+) {
+    /** The constraints governing [mimeType], or null if the type is not accepted. */
+    fun constraintsFor(mimeType: String): MimeTypeConstraints? =
+        mimeTypeConstraints.firstOrNull { it.matches(mimeType) }
+
+    /** Whether [mimeType] is accepted for upload at all. */
+    fun accepts(mimeType: String): Boolean = constraintsFor(mimeType) != null
+
+    /** Concrete (non-wildcard) MIME types the policy explicitly names — useful for selection filters. */
+    val explicitMimeTypes: List<String>
+        get() = mimeTypeConstraints
+            .map { it.mimeTypePattern }
+            .filter { !it.contains('*') }
+}
+
+@Serializable
+data class MimeTypeConstraints(
+    // "image/jpeg" (exact), "image/*" (subtype wildcard), or "*/*" (catch-all).
+    val mimeTypePattern: String,
+    val maxSizeBytes: Long,
+    val image: ImageConstraints?,
+) {
+    fun matches(mimeType: String): Boolean = when {
+        mimeTypePattern == "*/*" -> true
+        mimeTypePattern.endsWith("/*") ->
+            mimeType.substringBefore('/').equals(mimeTypePattern.substringBefore('/'), ignoreCase = true)
+        else -> mimeTypePattern.equals(mimeType, ignoreCase = true)
+    }
+}
+
+@Serializable
+data class ImageConstraints(
+    val maxWidth: Int,
+    val maxHeight: Int,
+    val maxPixels: Long,
+)

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/models/blob/UploadTarget.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/models/blob/UploadTarget.kt
@@ -1,0 +1,33 @@
+package com.flipcash.services.models.blob
+
+import com.flipcash.services.models.chat.BlobId
+import kotlinx.serialization.Serializable
+import kotlin.time.Instant
+
+/**
+ * A short-lived, presigned target for a direct-to-storage upload. The client issues the described
+ * HTTP request (PUT raw body, or POST multipart with [formFields]) straight to [url] — the server
+ * never proxies the bytes. Treat it as a bearer credential: do not persist or share it, and re-mint
+ * via [BlobStorageController.initiateExternalUpload][com.flipcash.services.controllers.BlobStorageController.initiateExternalUpload]
+ * once [expiresAt] passes.
+ */
+@Serializable
+data class UploadTarget(
+    val method: Method,
+    val url: String,
+    val headers: Map<String, String>,
+    val formFields: Map<String, String>,
+    val expiresAt: Instant,
+) {
+    enum class Method { UNKNOWN, PUT, POST }
+}
+
+/**
+ * The result of reserving an upload: the durable [blobId] handle to reference the bytes once
+ * uploaded, and the presigned [target] to upload them to.
+ */
+@Serializable
+data class UploadReservation(
+    val blobId: BlobId,
+    val target: UploadTarget,
+)

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/repository/BlobStorageRepository.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/repository/BlobStorageRepository.kt
@@ -1,0 +1,22 @@
+package com.flipcash.services.repository
+
+import com.flipcash.services.models.blob.UploadPolicy
+import com.flipcash.services.models.blob.UploadReservation
+import com.flipcash.services.models.chat.BlobId
+import com.flipcash.services.models.chat.BlobState
+import com.flipcash.services.models.chat.BlobStatus
+import com.getcode.ed25519.Ed25519
+
+interface BlobStorageRepository {
+    suspend fun getUploadPolicy(owner: Ed25519.KeyPair): Result<UploadPolicy>
+
+    suspend fun initiateExternalUpload(
+        mimeType: String,
+        sizeBytes: Long,
+        owner: Ed25519.KeyPair,
+    ): Result<UploadReservation>
+
+    suspend fun completeExternalUpload(blobId: BlobId, owner: Ed25519.KeyPair): Result<BlobStatus>
+
+    suspend fun getBlobs(blobIds: List<BlobId>, owner: Ed25519.KeyPair): Result<List<BlobState>>
+}

--- a/services/flipcash/src/test/kotlin/com/flipcash/services/controllers/BlobStorageControllerTest.kt
+++ b/services/flipcash/src/test/kotlin/com/flipcash/services/controllers/BlobStorageControllerTest.kt
@@ -1,0 +1,168 @@
+package com.flipcash.services.controllers
+
+import com.flipcash.services.BlobUploader
+import com.flipcash.services.models.BlobNotReadyException
+import com.flipcash.services.models.BlobRejectedException
+import com.flipcash.services.models.blob.UploadReservation
+import com.flipcash.services.models.blob.UploadTarget
+import com.flipcash.services.models.chat.BlobId
+import com.flipcash.services.models.chat.BlobState
+import com.flipcash.services.models.chat.BlobStatus
+import com.flipcash.services.repository.BlobStorageRepository
+import com.flipcash.services.user.UserManager
+import com.getcode.ed25519.Ed25519
+import com.getcode.opencode.model.accounts.AccountCluster
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlin.time.Instant
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class BlobStorageControllerTest {
+
+    private val repository = mockk<BlobStorageRepository>()
+    private val uploader = mockk<BlobUploader>()
+    private val userManager = mockk<UserManager>(relaxed = true)
+    private val controller = BlobStorageController(repository, uploader, userManager)
+
+    private val blobId = BlobId(ByteArray(16) { 1 })
+    private val target = UploadTarget(
+        method = UploadTarget.Method.PUT,
+        url = "https://storage.example/upload",
+        headers = emptyMap(),
+        formFields = emptyMap(),
+        expiresAt = Instant.fromEpochSeconds(10_000),
+    )
+
+    private fun stubOwner() {
+        val keyPair = mockk<Ed25519.KeyPair>(relaxed = true)
+        val cluster = mockk<AccountCluster>(relaxed = true) {
+            every { authority } returns mockk { every { this@mockk.keyPair } returns keyPair }
+        }
+        every { userManager.accountCluster } returns cluster
+    }
+
+    private fun blobState(status: BlobStatus) =
+        BlobState(id = blobId, status = status, metadata = null, rejection = null)
+
+    private fun happyPathStubs() {
+        coEvery { repository.initiateExternalUpload(any(), any(), any()) } returns
+            Result.success(UploadReservation(blobId, target))
+        coEvery { uploader.upload(any(), any(), any()) } returns Result.success(Unit)
+        coEvery { repository.completeExternalUpload(any(), any()) } returns Result.success(BlobStatus.PROCESSING)
+    }
+
+    @Test
+    fun `upload fails when there is no account cluster`() = runTest {
+        every { userManager.accountCluster } returns null
+
+        val result = controller.upload(byteArrayOf(1, 2, 3), "image/png")
+
+        assertTrue(result.isFailure)
+        coVerify(exactly = 0) { repository.initiateExternalUpload(any(), any(), any()) }
+    }
+
+    @Test
+    fun `upload returns the blob id once READY`() = runTest {
+        stubOwner()
+        happyPathStubs()
+        coEvery { repository.getBlobs(any(), any()) } returns Result.success(listOf(blobState(BlobStatus.READY)))
+
+        val result = controller.upload(byteArrayOf(1, 2, 3), "image/png")
+
+        assertEquals(blobId, result.getOrNull())
+    }
+
+    @Test
+    fun `upload polls until the blob becomes READY`() = runTest {
+        stubOwner()
+        happyPathStubs()
+        coEvery { repository.getBlobs(any(), any()) } returnsMany listOf(
+            Result.success(listOf(blobState(BlobStatus.PENDING))),
+            Result.success(listOf(blobState(BlobStatus.PROCESSING))),
+            Result.success(listOf(blobState(BlobStatus.READY))),
+        )
+
+        val result = controller.upload(byteArrayOf(1, 2, 3), "image/png")
+
+        assertEquals(blobId, result.getOrNull())
+        coVerify(exactly = 3) { repository.getBlobs(any(), any()) }
+    }
+
+    @Test
+    fun `upload fails with BlobRejectedException when the blob is REJECTED`() = runTest {
+        stubOwner()
+        happyPathStubs()
+        coEvery { repository.getBlobs(any(), any()) } returns Result.success(listOf(blobState(BlobStatus.REJECTED)))
+
+        val result = controller.upload(byteArrayOf(1, 2, 3), "image/png")
+
+        assertIs<BlobRejectedException>(result.exceptionOrNull())
+    }
+
+    @Test
+    fun `upload times out with BlobNotReadyException when never READY`() = runTest {
+        stubOwner()
+        happyPathStubs()
+        coEvery { repository.getBlobs(any(), any()) } returns Result.success(listOf(blobState(BlobStatus.PROCESSING)))
+
+        val result = controller.upload(byteArrayOf(1, 2, 3), "image/png")
+
+        assertIs<BlobNotReadyException>(result.exceptionOrNull())
+    }
+
+    @Test
+    fun `upload fails and does not PUT when initiate fails`() = runTest {
+        stubOwner()
+        coEvery { repository.initiateExternalUpload(any(), any(), any()) } returns
+            Result.failure(RuntimeException("initiate denied"))
+
+        val result = controller.upload(byteArrayOf(1, 2, 3), "image/png")
+
+        assertTrue(result.isFailure)
+        coVerify(exactly = 0) { uploader.upload(any(), any(), any()) }
+    }
+
+    @Test
+    fun `upload fails and does not complete when the byte upload fails`() = runTest {
+        stubOwner()
+        coEvery { repository.initiateExternalUpload(any(), any(), any()) } returns
+            Result.success(UploadReservation(blobId, target))
+        coEvery { uploader.upload(any(), any(), any()) } returns Result.failure(RuntimeException("network"))
+
+        val result = controller.upload(byteArrayOf(1, 2, 3), "image/png")
+
+        assertTrue(result.isFailure)
+        coVerify(exactly = 0) { repository.completeExternalUpload(any(), any()) }
+    }
+
+    @Test
+    fun `upload still succeeds when the advisory complete call fails`() = runTest {
+        stubOwner()
+        coEvery { repository.initiateExternalUpload(any(), any(), any()) } returns
+            Result.success(UploadReservation(blobId, target))
+        coEvery { uploader.upload(any(), any(), any()) } returns Result.success(Unit)
+        coEvery { repository.completeExternalUpload(any(), any()) } returns
+            Result.failure(RuntimeException("complete failed"))
+        coEvery { repository.getBlobs(any(), any()) } returns Result.success(listOf(blobState(BlobStatus.READY)))
+
+        val result = controller.upload(byteArrayOf(1, 2, 3), "image/png")
+
+        assertEquals(blobId, result.getOrNull())
+    }
+
+    @Test
+    fun `getUploadPolicy fails without an account`() = runTest {
+        every { userManager.accountCluster } returns null
+
+        assertTrue(controller.getUploadPolicy().isFailure)
+        coVerify(exactly = 0) { repository.getUploadPolicy(any()) }
+    }
+}

--- a/services/flipcash/src/test/kotlin/com/flipcash/services/models/blob/UploadPolicyTest.kt
+++ b/services/flipcash/src/test/kotlin/com/flipcash/services/models/blob/UploadPolicyTest.kt
@@ -1,0 +1,75 @@
+package com.flipcash.services.models.blob
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.hours
+
+class UploadPolicyTest {
+
+    private fun constraint(pattern: String, maxSize: Long = 1_000) =
+        MimeTypeConstraints(mimeTypePattern = pattern, maxSizeBytes = maxSize, image = null)
+
+    private fun policy(vararg constraints: MimeTypeConstraints) =
+        UploadPolicy(version = "v1", ttl = 1.hours, mimeTypeConstraints = constraints.toList())
+
+    @Test
+    fun `exact pattern matches only that type, case-insensitively`() {
+        val c = constraint("image/jpeg")
+        assertTrue(c.matches("image/jpeg"))
+        assertTrue(c.matches("IMAGE/JPEG"))
+        assertFalse(c.matches("image/png"))
+    }
+
+    @Test
+    fun `subtype wildcard matches same top-level type only`() {
+        val c = constraint("image/*")
+        assertTrue(c.matches("image/png"))
+        assertTrue(c.matches("image/jpeg"))
+        assertFalse(c.matches("video/mp4"))
+    }
+
+    @Test
+    fun `catch-all matches anything`() {
+        val c = constraint("*/*")
+        assertTrue(c.matches("image/png"))
+        assertTrue(c.matches("application/pdf"))
+    }
+
+    @Test
+    fun `constraintsFor returns the first matching entry (most-specific-first)`() {
+        val exact = constraint("image/png", maxSize = 100)
+        val wildcard = constraint("image/*", maxSize = 999)
+        val p = policy(exact, wildcard)
+
+        assertSame(exact, p.constraintsFor("image/png"))
+        assertSame(wildcard, p.constraintsFor("image/jpeg"))
+    }
+
+    @Test
+    fun `constraintsFor is null for an unsupported type`() {
+        val p = policy(constraint("image/*"))
+        assertNull(p.constraintsFor("video/mp4"))
+    }
+
+    @Test
+    fun `accepts reflects constraintsFor`() {
+        val p = policy(constraint("image/*"))
+        assertTrue(p.accepts("image/png"))
+        assertFalse(p.accepts("text/plain"))
+    }
+
+    @Test
+    fun `explicitMimeTypes excludes wildcard patterns`() {
+        val p = policy(
+            constraint("image/jpeg"),
+            constraint("image/png"),
+            constraint("image/*"),
+            constraint("*/*"),
+        )
+        assertEquals(listOf("image/jpeg", "image/png"), p.explicitMimeTypes)
+    }
+}


### PR DESCRIPTION
**Stacked PR 1/5** — base: \`code/cash\`

Foundation for direct-to-storage (presigned) blob uploads at the services layer.

### What
- \`BlobStorage\` gRPC client: Api → Service → Repository → Controller.
- \`HttpBlobUploader\` (OkHttp PUT/POST to presigned URLs).
- Domain models: \`UploadTarget\`/\`UploadReservation\`, \`UploadPolicy\` (MIME + image constraints) with proto converters.
- \`BlobStorageController.upload()\` coordinates the whole handshake behind one call: reserve → upload → complete → poll until READY. \`getUploadPolicy()\` exposes accepted MIME/size constraints.
- Error types + DI wiring.

### Tests
- \`UploadPolicyTest\` (constraint matching), \`BlobStorageControllerTest\` (upload orchestration + failure paths).

Nothing is wired into the UI yet — later PRs in the stack consume this.