### PR TITLE
test(session): fix SessionController unit test compilation (tippingDelegate)

### DIFF
--- a/apps/flipcash/shared/session/src/test/kotlin/com/flipcash/app/session/internal/SessionControllerEventRoutingTest.kt
+++ b/apps/flipcash/shared/session/src/test/kotlin/com/flipcash/app/session/internal/SessionControllerEventRoutingTest.kt
@@ -102,6 +102,7 @@ class SessionControllerEventRoutingTest {
             cashLinkDelegate = cashLinkDelegate,
             depositDelegate = mockk(relaxed = true),
             giftCardDelegate = giftCardDelegate,
+            tippingDelegate = mockk(relaxed = true),
             stateHolder = SessionStateHolder(),
             billController = billController,
             userManager = userManager,

--- a/apps/flipcash/shared/session/src/test/kotlin/com/flipcash/app/session/internal/SessionControllerGiftCardErrorTest.kt
+++ b/apps/flipcash/shared/session/src/test/kotlin/com/flipcash/app/session/internal/SessionControllerGiftCardErrorTest.kt
@@ -125,6 +125,7 @@ class SessionControllerGiftCardErrorTest {
             cashLinkDelegate = cashLinkDelegate,
             depositDelegate = mockk(relaxed = true),
             giftCardDelegate = giftCardDelegate,
+            tippingDelegate = mockk(relaxed = true),
             stateHolder = stateHolder,
             billController = billController,
             userManager = userManager,


### PR DESCRIPTION
## What

Adds the required `tippingDelegate` argument to the two `RealSessionController` construction sites in the session module's unit tests.

## Why

`RealSessionController` gained a required constructor parameter `tippingDelegate: TipCardDelegate` (tip card resolution/presentation), but `SessionControllerEventRoutingTest` and `SessionControllerGiftCardErrorTest` still constructed it without that argument. This broke `:apps:flipcash:shared:session:compileDebugUnitTestKotlin`, which failed the whole `./gradlew test` build:

```
e: SessionControllerEventRoutingTest.kt:124:13 No value passed for parameter 'tippingDelegate'.
e: SessionControllerGiftCardErrorTest.kt:147:13 No value passed for parameter 'tippingDelegate'.
```

## Fix

Pass `tippingDelegate = mockk(relaxed = true)`, matching how the other delegates (`depositDelegate`, etc.) are supplied in these tests.

## Testing

- `./gradlew :apps:flipcash:shared:session:testDebugUnitTest` — passes
- `./gradlew test --continue` — BUILD SUCCESSFUL (no remaining failures)