### PR TITLE
fix(amount-entry): reset amount when the selected token changes

### DIFF
--- a/apps/flipcash/features/cash/src/main/kotlin/com/flipcash/app/cash/internal/CashScreenViewModel.kt
+++ b/apps/flipcash/features/cash/src/main/kotlin/com/flipcash/app/cash/internal/CashScreenViewModel.kt
@@ -87,6 +87,7 @@ internal class CashScreenViewModel @Inject constructor(
         loadingState = stateFlow.map { it.generatingBill }
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), LoadingSuccessState()),
         maxAmount = maxForGiveFlow,
+        tokenChanges = tokenCoordinator.observeSelectedTokenMint(),
     )
     private val tokenInitialized = CompletableDeferred<Mint?>()
 

--- a/apps/flipcash/features/messenger/src/main/kotlin/com/flipcash/app/messenger/internal/ChatViewModel.kt
+++ b/apps/flipcash/features/messenger/src/main/kotlin/com/flipcash/app/messenger/internal/ChatViewModel.kt
@@ -281,6 +281,7 @@ internal class ChatViewModel @Inject constructor(
                 .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), LoadingSuccessState()),
             maxAmount = maxAmountFlow,
             minimumAmount = minAmountFlow,
+            tokenChanges = tokenCoordinator.observeSelectedTokenMint(),
         )
     }
 

--- a/apps/flipcash/shared/amount-entry/src/main/kotlin/com/flipcash/shared/amountentry/AmountEntryDelegate.kt
+++ b/apps/flipcash/shared/amount-entry/src/main/kotlin/com/flipcash/shared/amountentry/AmountEntryDelegate.kt
@@ -8,13 +8,18 @@ import com.getcode.ui.components.text.AmountAnimatedInputUiModel
 import com.getcode.ui.components.text.NumberInputHelper
 import com.getcode.view.LoadingSuccessState
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.scan
 import kotlinx.coroutines.flow.stateIn
@@ -29,6 +34,10 @@ class AmountEntryDelegate(
     loadingState: StateFlow<LoadingSuccessState> = MutableStateFlow(LoadingSuccessState()),
     maxAmount: StateFlow<Fiat?> = MutableStateFlow(null),
     minimumAmount: StateFlow<Fiat?> = MutableStateFlow(null),
+    // Emits whenever the selected token changes. Like a region/currency change, switching
+    // tokens re-denominates the entry, so the typed amount is reset (see init). Defaults to a
+    // no-op for flows without a token concept.
+    tokenChanges: Flow<*> = emptyFlow<Any?>(),
 ) : AmountEntryController {
     constructor(
         exchange: Exchange,
@@ -38,7 +47,8 @@ class AmountEntryDelegate(
         loadingState: StateFlow<LoadingSuccessState> = MutableStateFlow(LoadingSuccessState()),
         maxAmount: StateFlow<Fiat?> = MutableStateFlow(null),
         minimumAmount: StateFlow<Fiat?> = MutableStateFlow(null),
-    ) : this(exchange, scope, maxLength, MutableStateFlow(style), loadingState, maxAmount, minimumAmount)
+        tokenChanges: Flow<*> = emptyFlow<Any?>(),
+    ) : this(exchange, scope, maxLength, MutableStateFlow(style), loadingState, maxAmount, minimumAmount, tokenChanges)
 
     data class State(
         val currency: CurrencyHolder = CurrencyHolder(),
@@ -106,13 +116,13 @@ class AmountEntryDelegate(
     init {
         numberInputHelper.reset()
 
-        exchange.observePreferredRate()
-            .onEach {
-                numberInputHelper.reset()
-                _state.update { s ->
-                    s.copy(amountAnimatedModel = AmountAnimatedInputUiModel())
-                }
-            }.launchIn(scope)
+        // Reset the typed amount whenever the entry is re-denominated: a preferred
+        // currency/region change (rate) or a selected-token change. `drop(1)` on the token
+        // stream skips its initial value so an in-flight prefill isn't wiped on construction.
+        merge(
+            exchange.observePreferredRate(),
+            tokenChanges.distinctUntilChanged().drop(1),
+        ).onEach { reset() }.launchIn(scope)
     }
 
     fun onCurrencyChanged(currency: Currency) {

--- a/apps/flipcash/shared/tipping/src/main/kotlin/com/flipcash/shared/tipping/TippingCoordinator.kt
+++ b/apps/flipcash/shared/tipping/src/main/kotlin/com/flipcash/shared/tipping/TippingCoordinator.kt
@@ -39,10 +39,14 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -112,6 +116,17 @@ class TippingCoordinator @Inject constructor(
             tipPaymentDelegate.tipPresets,
         ) { state, presets -> state.copy(presets = presets) }
             .stateIn(scope, SharingStarted.WhileSubscribed(5_000), TipSelectionState())
+
+    init {
+        // Switching the tip token re-denominates the tip, so clear any amount chosen in the modal
+        // (preset or custom) — mirroring how the amount-entry keypad resets on a token/region
+        // change. `drop(1)` skips the initial token resolution so startup doesn't clear anything.
+        tokenCoordinator.observeSelectedTokenMint()
+            .distinctUntilChanged()
+            .drop(1)
+            .onEach { selectAmount(null) }
+            .launchIn(scope)
+    }
 
     /** The largest tippable amount (send-limit ∧ balance), surfaced by the amount entry. */
     val maxTipAmount: StateFlow<Fiat?> get() = tipPaymentDelegate.maxTipAmount


### PR DESCRIPTION
## What

Reset the entered/selected amount when the **token** changes, mirroring the existing behaviour for a **region/currency** change.

Previously, switching tokens re-denominated an amount entry but left the typed value in place, so an amount entered in one token was silently reinterpreted in another.

## Changes

- **`AmountEntryDelegate`** — new optional `tokenChanges: Flow<*>` trigger. Its `init` now resets the keypad on _either_ a preferred-rate change (region/currency, existing) _or_ a token change, via `merge(observePreferredRate(), tokenChanges.distinctUntilChanged().drop(1))`. `drop(1)` skips the initial token emission so an in-flight prefill isn't wiped on construction.
- **Give-cash** (`CashScreenViewModel`) and **chat amount entry** (`ChatViewModel`) pass `tokenChanges = tokenCoordinator.observeSelectedTokenMint()` — both are driven by the global selected token.
- **Tip user modal** (`TippingCoordinator`) — new `init` observer on the selected token that clears the modal's selected `TipAmount` (`selectAmount(null)`), the non-keypad counterpart to the delegate reset.

## Intentionally excluded

- **Withdrawal** and **Swap** — their token is **pinned per-flow** (e.g. `WithdrawalStep.Amount(mint)`), not the global selected token, so a global change must not reset their amount.
- **Tip amount-entry keypad** — no in-screen token picker; the ViewModel is recreated per open.

## Testing

- `:apps:flipcash:shared:amount-entry`, `:shared:tipping`, `:features:cash`, `:features:messenger` compile.
- `:shared:tipping` and `:features:cash` unit tests pass.
