### PR TITLE
fix(deeplink): resolve tip card deeplinks on cold launch

### DIFF
--- a/apps/flipcash/app/src/main/kotlin/com/flipcash/app/internal/ui/App.kt
+++ b/apps/flipcash/app/src/main/kotlin/com/flipcash/app/internal/ui/App.kt
@@ -233,6 +233,8 @@ internal fun App(
                                                     when (action) {
                                                         is DeeplinkAction.OpenCashLink ->
                                                             session.openCashLink(action.entropy)
+                                                        is DeeplinkAction.PresentTipCard ->
+                                                            session.resolveTipCard(action.userId)
                                                         is DeeplinkAction.Login ->
                                                             viewModel.handleLoginEntropy(
                                                                 action.entropy,


### PR DESCRIPTION
## Problem

Tip-card deeplinks (`tip/{userId}`) are silently dropped on a **cold app launch**. They work fine when the app is already running (warm launch). Cash links, which went through the same cold-launch hardening earlier, are unaffected.

## Root cause

On cold launch, `MainRoot.buildNavGraphForLaunch` bundles a tip-card deeplink into `pendingAction` (alongside `OpenCashLink` and `Login`) and `MainRoot` fires it eagerly through `App.kt`'s `onPendingAction` callback. But that callback only handled `OpenCashLink` and `Login` — `PresentTipCard` fell into the no-op `else` branch and was dropped. The subsequent `deepLink = null` then erased the link before the fallback `LaunchedEffect(deepLink, currentRoute)` (which *does* handle `PresentTipCard`) could recover it.

Warm launches are past `Loading`, so the fallback effect processes the link directly — which is why the bug only shows on cold start.

The gap was introduced in c46c130eb (#1127): it wired `PresentTipCard` into `buildNavGraphForLaunch` and the fallback effect, but not the eager `onPendingAction` dispatcher.

## Fix

Add the missing `PresentTipCard` branch to `onPendingAction` so it calls `session.resolveTipCard(userId)` eagerly, mirroring the cash-link path. One line, exactly matching the already-working fallback handler.

## Testing

- Traced the full cold-launch deeplink flow end-to-end; the downstream `TipCardDelegate → BillPresentationDelegate` chain is sound and only ever lacked the `resolveTipCard` call.
- The new branch call is identical to the already-verified warm-path handler.
