### PR TITLE
fix(resolver): drop in-memory resolution cache

### DIFF
--- a/services/flipcash/src/main/kotlin/com/flipcash/services/controllers/ResolverController.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/controllers/ResolverController.kt
@@ -6,7 +6,6 @@ import com.flipcash.services.repository.ResolverRepository
 import com.flipcash.services.user.UserManager
 import com.getcode.opencode.model.core.ID
 import com.getcode.solana.keys.PublicKey
-import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -15,13 +14,6 @@ class ResolverController @Inject constructor(
     private val repository: ResolverRepository,
     private val userManager: UserManager,
 ) {
-    // Memoizes successful resolutions for the process lifetime. An identity's on-chain address is
-    // effectively immutable, and callers commonly resolve the same identity twice in quick
-    // succession (e.g. a chat pre-resolves the recipient to gate the send button, then the payment
-    // delegate resolves it again at send time) — the cache turns the second into a no-op. Failures
-    // are never cached, so an unresolvable identity is retried.
-    private val cache = ConcurrentHashMap<ResolveIdentifier, PublicKey>()
-
     /** Resolves a phone number to its on-chain address. */
     suspend fun resolve(phone: ContactMethod.Phone): Result<PublicKey> =
         resolve(ResolveIdentifier.Phone(phone))
@@ -31,10 +23,8 @@ class ResolverController @Inject constructor(
         resolve(ResolveIdentifier.UserId(userId))
 
     private suspend fun resolve(identifier: ResolveIdentifier): Result<PublicKey> {
-        cache[identifier]?.let { return Result.success(it) }
         val owner = userManager.accountCluster?.authority?.keyPair
             ?: return Result.failure(Throwable("No account cluster in UserManager"))
         return repository.resolve(owner, identifier)
-            .onSuccess { cache[identifier] = it }
     }
 }


### PR DESCRIPTION
## Problem

Sending money inside a chat via a **contact DM** fails with the server error:

```
InvalidIntent(reasons=[payments to external destinations must be withdrawals])
```

This regressed at the delegate refactor (#1130), whose only *behavioral* change (the rest was pure code-moving) was adding a process-lifetime in-memory cache to `ResolverController`.

## Root cause

The cache could hand back a stale/incorrect on-chain `PublicKey` for a phone number or user id. That address flows into `TransactionController.directTransfer` → `TimelockDerivedAccounts.newInstance(owner = destinationOwner, token)`, deriving the wrong destination vault. The server sees a vault it doesn't manage and rejects the transfer as an external destination that must be a withdrawal.

This matches the observed device/version signal — fine on an S25 at an earlier build, broken on a Pixel 10 emulator at the next — since a caching bug surfaces per-process/session rather than uniformly.

## Fix

Always resolve fresh against the repository. The cache was only ever a network round-trip optimization with no correctness benefit, so removing it restores the reliable pre-refactor behavior. Public API is unchanged; nothing else depended on the cache.