### PR TITLE
feat(tips): auto-enable tipping when resolving a scanned or deeplinked tip card

### DIFF
--- a/apps/flipcash/shared/tipping/build.gradle.kts
+++ b/apps/flipcash/shared/tipping/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
 
     implementation(project(":apps:flipcash:shared:analytics"))
     implementation(project(":apps:flipcash:shared:chat"))
+    implementation(project(":apps:flipcash:shared:featureflags"))
     implementation(project(":apps:flipcash:shared:payments"))
     implementation(project(":apps:flipcash:shared:funding"))
     implementation(project(":apps:flipcash:shared:region-selection:core"))

--- a/apps/flipcash/shared/tipping/src/main/kotlin/com/flipcash/shared/tipping/TippingCoordinator.kt
+++ b/apps/flipcash/shared/tipping/src/main/kotlin/com/flipcash/shared/tipping/TippingCoordinator.kt
@@ -9,6 +9,8 @@ import com.flipcash.app.core.tipping.TipEvent
 import com.flipcash.app.core.tipping.TipSelectionHolder
 import com.flipcash.app.core.tipping.TipSelectionState
 import com.flipcash.app.currency.PreferredCurrencyController
+import com.flipcash.app.featureflags.FeatureFlag
+import com.flipcash.app.featureflags.FeatureFlagController
 import com.flipcash.app.funding.PurchaseMethodController
 import com.flipcash.app.tokens.TokenCoordinator
 import com.flipcash.services.controllers.ProfileController
@@ -74,6 +76,7 @@ class TippingCoordinator @Inject constructor(
     private val purchaseMethodController: PurchaseMethodController,
     private val analytics: FlipcashAnalyticsService,
     private val vibrator: Vibrator,
+    private val featureFlagController: FeatureFlagController,
 ) : TipSelectionHolder {
     /** The signed-in user's id ([UserManager.accountId]), or null if unavailable. */
     val currentUserId: ID?
@@ -283,6 +286,11 @@ class TippingCoordinator @Inject constructor(
     suspend fun resolveTipCard(userId: ID): Result<Scannable.TipCard> =
         resolveProfile(userId)
             .onSuccess {
+                // Encountering someone else's tip card — by scan or by tip deeplink, both of which
+                // land here — opts the viewer into tipping so they can reciprocate without first
+                // digging the flag out of beta settings themselves.
+                featureFlagController.set(FeatureFlag.Tipping, true)
+
                 // Dual gating, like the send / currency-creator flows: the presentation gate only
                 // asks "is there any giveable balance?" (no amount threshold, so it stays currency-
                 // agnostic). The minimum-tip and per-amount affordability are enforced downstream —

--- a/apps/flipcash/shared/tipping/src/test/kotlin/com/flipcash/shared/tipping/TippingCoordinatorTest.kt
+++ b/apps/flipcash/shared/tipping/src/test/kotlin/com/flipcash/shared/tipping/TippingCoordinatorTest.kt
@@ -1,6 +1,8 @@
 package com.flipcash.shared.tipping
 
 import com.flipcash.app.analytics.FlipcashAnalyticsService
+import com.flipcash.app.featureflags.FeatureFlag
+import com.flipcash.app.featureflags.FeatureFlagController
 import com.flipcash.app.funding.PurchaseMethodController
 import com.flipcash.app.tokens.TokenCoordinator
 import com.flipcash.services.controllers.ProfileController
@@ -10,9 +12,11 @@ import com.flipcash.shared.payments.TipPaymentDelegate
 import com.getcode.opencode.exchange.Exchange
 import com.getcode.opencode.exchange.VerifiedFiatCalculator
 import com.getcode.util.resources.ResourceHelper
+import com.getcode.util.vibration.Vibrator
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -29,6 +33,8 @@ class TippingCoordinatorTest {
     private val resources = mockk<ResourceHelper>(relaxed = true)
     private val purchaseMethodController = mockk<PurchaseMethodController>(relaxed = true)
     private val analytics = mockk<FlipcashAnalyticsService>(relaxed = true)
+    private val vibrator = mockk<Vibrator>(relaxed = true)
+    private val featureFlagController = mockk<FeatureFlagController>(relaxed = true)
 
     private fun buildCoordinator() = TippingCoordinator(
         profileController,
@@ -40,6 +46,8 @@ class TippingCoordinatorTest {
         resources,
         purchaseMethodController,
         analytics,
+        vibrator,
+        featureFlagController,
     )
 
     private val coordinator = buildCoordinator()
@@ -81,6 +89,29 @@ class TippingCoordinatorTest {
         val result = coordinator.currentUserProfile()
 
         assertSame(fetched, result.getOrNull())
+    }
+
+    @Test
+    fun `resolveTipCard enables the tipping flag on success`() = runTest {
+        val userId = List<Byte>(16) { it.toByte() }
+        coEvery { profileController.getProfileForUser(userId) } returns Result.success(profile("Bob"))
+
+        // The flag is flipped in resolveProfile's onSuccess, before the tip card itself is
+        // assembled — assembling the card derives an Ed25519 rendezvous key via native crypto
+        // that isn't available under Robolectric, so guard that downstream step.
+        runCatching { coordinator.resolveTipCard(userId) }
+
+        verify { featureFlagController.set(FeatureFlag.Tipping, true) }
+    }
+
+    @Test
+    fun `resolveTipCard leaves the tipping flag untouched when resolution fails`() = runTest {
+        val userId = listOf<Byte>(7, 8, 9)
+        coEvery { profileController.getProfileForUser(userId) } returns Result.failure(RuntimeException("nope"))
+
+        coordinator.resolveTipCard(userId)
+
+        verify(exactly = 0) { featureFlagController.set(FeatureFlag.Tipping, true) }
     }
 
     @Test


### PR DESCRIPTION
## What

When a user encounters someone else's tip card — either by **scanning** it or opening a **tip deeplink** — we now auto-enable the `Tipping` beta flag for them so they can reciprocate without first digging the flag out of beta settings.

Both entry points funnel through a single method, so the flag flip lives in one place:

- Scan → `CodeScanDelegate.Event.TipCardScanned` → `resolveTipCard(userId)`
- Deeplink → `DeeplinkAction.PresentTipCard` → `resolveTipCard(userId)`

## How

- Injected `FeatureFlagController` into `TippingCoordinator` and call `set(FeatureFlag.Tipping, true)` in `resolveTipCard(userId)`'s `onSuccess` block (only after the counterparty's profile resolves successfully; before the tip card itself is assembled).
- `FeatureFlag.Tipping` is what drives `isTippingEnabled` in `RealSessionController`, so this opts the viewer into the full tipping experience.
- Added the `:apps:flipcash:shared:featureflags` module dependency to `shared:tipping`.

The flip is a no-op when the flag is already on, and does not fire when profile resolution fails.

## Tests

Added coverage to `TippingCoordinatorTest`:
- flag enabled on successful resolve
- flag untouched when resolution fails

Also wired the `vibrator` constructor arg the existing test was missing after the earlier vibrate change. All 6 tests in the module pass.
