### PR TITLE
fix(tips): show unread tip count on the scanner Tips tab badge

### DIFF
--- a/apps/flipcash/features/scanner/src/main/kotlin/com/flipcash/app/scanner/internal/ui/components/ScannerNavigationBar.kt
+++ b/apps/flipcash/features/scanner/src/main/kotlin/com/flipcash/app/scanner/internal/ui/components/ScannerNavigationBar.kt
@@ -51,6 +51,7 @@ internal fun ScannerNavigationBar(
         config = effectiveConfig,
         state = NavigationBarState(
             contactDmUnreadCount = state.contactDmUnreadCount,
+            tipUnreadCount = state.tipsUnreadCount,
             showToast = billState.showToast && billState.toast != null,
             toastText = billState.toast?.formattedAmount,
             isPaused = isPaused,


### PR DESCRIPTION
## Problem

Tip chat push notifications don't update the badge on the scanner's **Tips** tab. In fact the badge never shows a count at all — it's effectively pinned to `0`.

## Root cause

The unread-count data flows correctly right up to the last hop, then gets dropped:

- `RealSessionController` observes `chatCoordinator.observeUnreadConversations(ChatType.TIP_DM)` and keeps `SessionState.tipsUnreadCount` current.
- A tip push (`NavigationTrigger.Chat.ById`) calls `chatCoordinator.refreshFeed()`, which re-syncs the DB; Room re-emits and `tipsUnreadCount` updates. So the data side already works.
- **But** `ScannerNavigationBar` built its `NavigationBarState(...)` **without** passing `tipsUnreadCount`, so `NavigationBarState.tipUnreadCount` kept its default `0`. The `Tips` nav button reads `state.tipUnreadCount` → always `0` → the badge never appears or updates.

## Fix

Forward the count in `ScannerNavigationBar`:

```kotlin
state = NavigationBarState(
    contactDmUnreadCount = state.contactDmUnreadCount,
    tipUnreadCount = state.tipsUnreadCount,   // ← added
    ...
)
```

Note the easy-to-miss naming mismatch: `SessionState.tipsUnreadCount` (with an `s`) vs `NavigationBarState.tipUnreadCount` (no `s`).

## Result

The Tips tab badge now reflects unread tip conversations — updating on a tip push (via the existing feed refresh) as well as on cold start.

## Testing

- `:apps:flipcash:features:scanner` compiles clean.
- Manual: with unread tip DMs, the Tips tab shows the count; receiving a tip push while on the scanner bumps the badge.
