### PR TITLE
fix(session): keep feature-flag-derived state across logout

### DIFF
--- a/apps/flipcash/shared/session/src/main/kotlin/com/flipcash/app/session/internal/SessionStateHolder.kt
+++ b/apps/flipcash/shared/session/src/main/kotlin/com/flipcash/app/session/internal/SessionStateHolder.kt
@@ -29,6 +29,24 @@ class SessionStateHolder @Inject constructor() {
     /** Atomically update the state via a transform function. */
     fun update(transform: (SessionState) -> SessionState) { _state.update(transform) }
 
-    /** Reset to the default [SessionState] (e.g. on logout). */
-    fun reset() { _state.value = SessionState() }
+    /**
+     * Reset account-scoped state on logout, preserving device-scoped fields that are
+     * derived purely from feature flags via `observe(flag)`.
+     *
+     * Those flag observers are hot [StateFlow]s that only re-emit on a *value change*.
+     * A blanket `SessionState()` reset would clobber these fields to their defaults, and
+     * the observer would not re-push its unchanged current value to repopulate them —
+     * leaving the UI desynced from the still-persisted flag (e.g. Tipping flag on, but the
+     * scanner Tips tab gone). Account/token/settings-derived fields are safe to reset:
+     * their sources re-emit when the account changes, so they self-heal.
+     */
+    fun reset() {
+        _state.update { prev ->
+            SessionState(
+                vibrateOnScan = prev.vibrateOnScan,
+                showNetworkOffline = prev.showNetworkOffline,
+                isTippingEnabled = prev.isTippingEnabled,
+            )
+        }
+    }
 }

--- a/apps/flipcash/shared/session/src/test/kotlin/com/flipcash/app/session/internal/SessionStateHolderTest.kt
+++ b/apps/flipcash/shared/session/src/test/kotlin/com/flipcash/app/session/internal/SessionStateHolderTest.kt
@@ -41,11 +41,28 @@ class SessionStateHolderTest {
     }
 
     @Test
-    fun `reset returns to default state`() {
+    fun `reset clears account-scoped state`() {
         val holder = holder()
-        holder.update { it.copy(vibrateOnScan = true, hasGiveableBalance = true) }
+        holder.update { it.copy(hasGiveableBalance = true, contactDmUnreadCount = 3, isPhoneNumberSendEnabled = true) }
         holder.reset()
-        assertEquals(SessionState(), holder.state.value)
+        val state = holder.state.value
+        assertEquals(false, state.hasGiveableBalance)
+        assertEquals(0, state.contactDmUnreadCount)
+        assertEquals(false, state.isPhoneNumberSendEnabled)
+    }
+
+    @Test
+    fun `reset preserves device-scoped feature-flag state`() {
+        // These are driven only by observe(flag) StateFlows, which won't re-emit an
+        // unchanged value to repopulate them after a blanket reset — so logout must
+        // keep them, or the UI desyncs from the still-persisted flag (e.g. Tips tab).
+        val holder = holder()
+        holder.update { it.copy(isTippingEnabled = true, vibrateOnScan = true, showNetworkOffline = true) }
+        holder.reset()
+        val state = holder.state.value
+        assertTrue(state.isTippingEnabled)
+        assertTrue(state.vibrateOnScan)
+        assertTrue(state.showNetworkOffline)
     }
 
     @Test


### PR DESCRIPTION
## Problem

Log out of an account with the **Tipping** beta flag on, log into another account, and you end up in a contradictory state: the beta flag is still on, but the scanner **Tips tab is gone** — and stays gone.

## Root cause

`SessionState.isTippingEnabled` (and `vibrateOnScan` / `showNetworkOffline`) are fed **only** by `featureFlagController.observe(flag)` — hot `StateFlow`s that dedup and re-emit only on a value *change*.

On logout (`AuthState.LoggedOut` in `RealSessionController`), `stateHolder.reset()` did a blanket `_state.value = SessionState()`, forcing `isTippingEnabled = false`. Because the observer's value was unchanged (the beta-flags store is device-level and shared across accounts, so `tipping_enabled` stays `true`), it **never re-pushed to repopulate the field**. `isTippingEnabled` was stuck at the reset default, so the scanner hid the Tips tab even though the flag was still enabled — a permanent desync until the flag value actually changed.

## Fix

`SessionStateHolder.reset()` now clears only **account-scoped** state and preserves the **device-scoped, feature-flag-derived** fields (`isTippingEnabled`, `vibrateOnScan`, `showNetworkOffline`), letting `observe(flag)` remain their single source of truth:

- If the flag genuinely clears, the observer emits `false` and the field follows.
- If the flag persists, the field stays consistent with it.

Either way `SessionState` can no longer desync from the flag. Account/token/settings-derived fields (`isPhoneNumberSendEnabled`, `hasGiveableBalance`, `autoStartCamera`, …) still reset — their sources re-emit on account switch and self-heal.

## Tests

`SessionStateHolderTest`: split the old `reset` test into `reset clears account-scoped state`, and added `reset preserves device-scoped feature-flag state`. All passing.

## Note

Distinct root cause from #1157 (that fixes the persisted nav-bar order lacking `Tips`). This one fixes session state desyncing from the flag on logout. The two together cover both ways the Tips tab could fail to appear.
