### PR TITLE
fix(tips): pad tip code payload with incrementing digits instead of zeros

### DIFF
--- a/services/opencode/src/androidTest/kotlin/com/getcode/opencode/model/core/OpenCodePayloadTests.kt
+++ b/services/opencode/src/androidTest/kotlin/com/getcode/opencode/model/core/OpenCodePayloadTests.kt
@@ -60,7 +60,8 @@ class OpenCodePayloadTests {
 
         assertEquals(PayloadKind.Tip.value, encoded[0].toInt())
         assertEquals(userId, encoded.subList(1, 17))
-        // Trailing bytes reserved / zero.
-        assertEquals(listOf<Byte>(0, 0, 0), encoded.subList(17, 20))
+        // Trailing reserved bytes are filled with incrementing digits (1, 2, 3) rather than
+        // zeros, so the native scanner can't drop them as trailing padding.
+        assertEquals(listOf<Byte>(1, 2, 3), encoded.subList(17, 20))
     }
 }

--- a/services/opencode/src/main/kotlin/com/getcode/opencode/model/core/OpenCodePayload.kt
+++ b/services/opencode/src/main/kotlin/com/getcode/opencode/model/core/OpenCodePayload.kt
@@ -85,10 +85,12 @@ data class OpenCodePayload(
 
    0   1   2   3   4   5   6   7   8   9  10  11  12  13  14  15  16  17  18  19
  +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
- | T |                     User ID (16 bytes)                     |  reserved (0) |
+ | T |                     User ID (16 bytes)                     | 1 | 2 | 3 |
  +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
 
  (T) Type (1 byte) — PayloadKind.Tip (2).
  User ID (16 bytes) — the recipient's user id (a UUID) so others can tip them. Raw bytes,
    no rendezvous keypair. Matches the iOS TipCode.Payload frame.
+ Reserved (3 bytes) — filled with incrementing digits (1, 2, 3) instead of zeros so the
+   native scanner doesn't strip them as trailing zero padding.
 */

--- a/services/opencode/src/main/kotlin/com/getcode/opencode/model/core/PayloadKind.kt
+++ b/services/opencode/src/main/kotlin/com/getcode/opencode/model/core/PayloadKind.kt
@@ -70,8 +70,9 @@ sealed interface PayloadKind {
 
     /**
      * A profile "tip code": the recipient's [UserId] (a 16-byte UUID) written raw at offset 1,
-     * with the trailing bytes reserved. Carries no nonce and derives no rendezvous — matches the
-     * iOS `TipCode.Payload` frame.
+     * with the trailing reserved bytes filled with incrementing digits (1, 2, 3, ...) so the
+     * native scanner can't drop them as trailing zero padding. Carries no nonce and derives no
+     * rendezvous — matches the iOS `TipCode.Payload` frame.
      */
     data object Tip : PayloadKind {
         override val value: Int = 2
@@ -83,6 +84,14 @@ sealed interface PayloadKind {
             val userId = (value as UserId).value
             userId.take(OpenCodePayload.USER_ID_LENGTH).forEachIndexed { index, byte ->
                 data[index + OpenCodePayload.OFFSET_USER_ID] = byte
+            }
+
+            // Fill the reserved trailing space with incrementing digits (1, 2, 3, ...) rather
+            // than zeros, so `Scanner.decode` can't drop them as trailing zero padding and the
+            // frame round-trips at full length.
+            val reservedStart = OpenCodePayload.OFFSET_USER_ID + OpenCodePayload.USER_ID_LENGTH
+            for (index in reservedStart until OpenCodePayload.LENGTH) {
+                data[index] = (index - reservedStart + 1).toByte()
             }
             return data
         }


### PR DESCRIPTION
## Summary

The tip code scan frame (`PayloadKind.Tip`, kind byte `2`) wrote a 16-byte user id at offset 1 and left the 3 reserved trailing bytes (17–19) as zeros. The native Kik scanner strips trailing zero bytes on decode, so those frames came back short.

This fills the reserved trailing space with incrementing digits (`1, 2, 3`) instead of zeros, so the frame always ends non-zero and round-trips at full length.

## Changes

- `PayloadKind.Tip.encode` — fill the reserved region (offset 17 onward) with `1, 2, 3` instead of leaving zeros.
- `OpenCodePayload.kt` — updated the Layout 2 frame diagram/comment.
- `OpenCodePayloadTests.kt` — updated the assertion from `listOf<Byte>(0, 0, 0)` to `listOf<Byte>(1, 2, 3)`.

Decoding is unaffected — `Tip.decode` reads only the 16-byte user id and ignores the reserved bytes. The cash frames are unchanged (they already fill all 20 bytes with currency/quarks/nonce).

## Testing

- `:services:opencode:compileDebugKotlin` ✅
- `:services:opencode:compileDebugAndroidTestKotlin` ✅