### PR TITLE
fix(tips): optically center share icon in tip card button

### DIFF
--- a/apps/flipcash/features/tipping/src/main/kotlin/com/flipcash/app/tipping/internal/screens/TipCardScreen.kt
+++ b/apps/flipcash/features/tipping/src/main/kotlin/com/flipcash/app/tipping/internal/screens/TipCardScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.material3.Icon
@@ -75,7 +76,12 @@ internal fun TipCardScreen() {
                             painter = painterResource(R.drawable.ic_remote_send),
                             contentDescription = null,
                             tint = Color.White,
-                            modifier = Modifier.requiredSize(size),
+                            // The send glyph is bottom-heavy (wide tray below a thin arrow),
+                            // so geometric centering leaves it sitting visually low in the
+                            // circle. Nudge it up slightly to optically center it.
+                            modifier = Modifier
+                                .requiredSize(size)
+                                .offset(y = (-1.5).dp),
                         )
                     }
                     Text(


### PR DESCRIPTION
## Summary

The share icon button on the Tip Card screen renders its icon visually low in the circle.

The `CircularIconButton` container centers the icon's canvas correctly — the off-centering comes from the `ic_remote_send` drawable itself. Within its 28×28 viewport the glyph is **bottom-heavy**: a wide upload tray sits beneath a thin up-arrow, putting the stroke centroid ~10% below the viewport center. Geometric centering therefore leaves it looking like it sits toward the bottom of the circle.

## Fix

Nudge the icon up ~1.5dp at the Tip Card call site to optically center it. The shared `ic_remote_send` drawable is untouched, so its other usages (`TitleBar`, `BillState`) are unaffected.

## Notes

- The 1.5dp value is derived from the glyph geometry (between the ~0.6dp bounding-box offset and the ~2.9dp full-centroid offset at the 30dp render size) and may want a small visual tweak once seen on-device.
- Tipping module compiles cleanly.