### PR TITLE
refactor(profile): make UserProfile.displayName non-nullable

### DIFF
--- a/apps/flipcash/features/direct-send/src/main/kotlin/com/flipcash/app/directsend/internal/ContactListBuilder.kt
+++ b/apps/flipcash/features/direct-send/src/main/kotlin/com/flipcash/app/directsend/internal/ContactListBuilder.kt
@@ -84,7 +84,7 @@ internal class ContactListBuilder @Inject constructor(
                     .firstOrNull { !isSelf(it) } ?: return@mapNotNull null
                 val phone = otherMember.userProfile.verifiedPhoneNumber
                 val formattedPhone = phone?.let { phoneUtils.formatNumber(it) }
-                val displayName = otherMember.userProfile.displayName?.takeIf { it.isNotBlank() }
+                val displayName = otherMember.userProfile.displayName.takeIf { it.isNotBlank() }
                     ?: formattedPhone
                     ?: return@mapNotNull null
 

--- a/apps/flipcash/features/messenger/src/main/kotlin/com/flipcash/app/messenger/internal/ChatParticipant.kt
+++ b/apps/flipcash/features/messenger/src/main/kotlin/com/flipcash/app/messenger/internal/ChatParticipant.kt
@@ -23,6 +23,6 @@ internal sealed interface ChatParticipant {
     }
 
     data class TipUser(val userId: ID, val profile: UserProfile) : ChatParticipant {
-        override val displayName: String get() = profile.displayName.orEmpty()
+        override val displayName: String get() = profile.displayName
     }
 }

--- a/apps/flipcash/features/messenger/src/main/kotlin/com/flipcash/app/messenger/internal/ChatViewModel.kt
+++ b/apps/flipcash/features/messenger/src/main/kotlin/com/flipcash/app/messenger/internal/ChatViewModel.kt
@@ -422,7 +422,7 @@ internal class ChatViewModel @Inject constructor(
                 val other = members.firstOrNull { it.userId != selfId }
                 if (other != null) {
                     val profile = other.userProfile
-                    val hasIdentity = !profile.displayName.isNullOrBlank() ||
+                    val hasIdentity = profile.displayName.isNotBlank() ||
                         !profile.verifiedPhoneNumber.isNullOrBlank()
                     !hasIdentity
                 } else false

--- a/apps/flipcash/features/myaccount/src/main/kotlin/com/flipcash/app/myaccount/internal/UserProfileScreenContent.kt
+++ b/apps/flipcash/features/myaccount/src/main/kotlin/com/flipcash/app/myaccount/internal/UserProfileScreenContent.kt
@@ -264,7 +264,7 @@ internal fun UserProfileScreenContent(
 
 @Composable
 private fun ProfileHeader(
-    displayName: String?,
+    displayName: String,
     profilePicture: MediaItem?,
     onEditName: () -> Unit,
     onEditPhoto: () -> Unit,
@@ -290,7 +290,7 @@ private fun ProfileHeader(
             horizontalArrangement = Arrangement.spacedBy(CodeTheme.dimens.grid.x1),
         ) {
             Text(
-                text = displayName?.takeIf { it.isNotEmpty() }
+                text = displayName.takeIf { it.isNotEmpty() }
                     ?: stringResource(R.string.subtitle_noDisplayName),
                 style = CodeTheme.typography.textLarge,
                 color = CodeTheme.colors.textMain,

--- a/apps/flipcash/features/myaccount/src/main/kotlin/com/flipcash/app/myaccount/internal/UserProfileViewModel.kt
+++ b/apps/flipcash/features/myaccount/src/main/kotlin/com/flipcash/app/myaccount/internal/UserProfileViewModel.kt
@@ -45,7 +45,7 @@ internal class UserProfileViewModel @Inject constructor(
     defaultDispatcher = dispatchers.Default,
 ) {
     internal data class State(
-        val displayName: String? = null,
+        val displayName: String = "",
         val profilePicture: MediaItem? = null,
         val phone: VerifiableContactMethod? = null,
         val email: VerifiableContactMethod? = null,
@@ -58,7 +58,7 @@ internal class UserProfileViewModel @Inject constructor(
 
     internal sealed interface Event {
         data class OnProfileUpdated(
-            val displayName: String?,
+            val displayName: String,
             val profilePicture: MediaItem?,
             val phone: VerifiableContactMethod?,
             val email: VerifiableContactMethod?,
@@ -102,7 +102,7 @@ internal class UserProfileViewModel @Inject constructor(
 
             dispatchEvent(
                 Event.OnProfileUpdated(
-                    displayName = profile?.displayName,
+                    displayName = profile?.displayName.orEmpty(),
                     profilePicture = profile?.profilePicture,
                     // Carry the contact (value + verified) so unverified entries still show.
                     phone = profile?.phoneNumber,

--- a/apps/flipcash/features/myaccount/src/test/kotlin/com/flipcash/app/myaccount/internal/ContactMethodsViewModelStateTest.kt
+++ b/apps/flipcash/features/myaccount/src/test/kotlin/com/flipcash/app/myaccount/internal/ContactMethodsViewModelStateTest.kt
@@ -15,7 +15,7 @@ class ContactMethodsViewModelStateTest {
     @Test
     fun `default state has null profile fields`() {
         val state = UserProfileViewModel.State()
-        assertNull(state.displayName)
+        assertTrue(state.displayName.isEmpty())
         assertNull(state.phone)
         assertNull(state.email)
         assertFalse(state.phoneLinkedForPayment)
@@ -58,7 +58,7 @@ class ContactMethodsViewModelStateTest {
     fun `OnProfileUpdated with null values`() {
         val updated = reduce(
             UserProfileViewModel.Event.OnProfileUpdated(
-                displayName = null,
+                displayName = "",
                 profilePicture = null,
                 phone = null,
                 email = null,
@@ -66,7 +66,7 @@ class ContactMethodsViewModelStateTest {
                 socialAccounts = emptyList(),
             )
         )(UserProfileViewModel.State())
-        assertNull(updated.displayName)
+        assertTrue(updated.displayName.isEmpty())
         assertNull(updated.phone)
         assertNull(updated.email)
         assertFalse(updated.phoneLinkedForPayment)

--- a/apps/flipcash/features/myaccount/src/test/kotlin/com/flipcash/app/myaccount/internal/UserProfileScreenContentTest.kt
+++ b/apps/flipcash/features/myaccount/src/test/kotlin/com/flipcash/app/myaccount/internal/UserProfileScreenContentTest.kt
@@ -42,12 +42,6 @@ class UserProfileScreenContentTest {
     }
 
     @Test
-    fun `no display name placeholder when null`() {
-        setScreen(UserProfileViewModel.State(displayName = null))
-        composeTestRule.onNodeWithText("No display name set").assertIsDisplayed()
-    }
-
-    @Test
     fun `no display name placeholder when empty`() {
         setScreen(UserProfileViewModel.State(displayName = ""))
         composeTestRule.onNodeWithText("No display name set").assertIsDisplayed()

--- a/apps/flipcash/features/tipping/src/main/kotlin/com/flipcash/app/tipping/internal/TipFlowViewModel.kt
+++ b/apps/flipcash/features/tipping/src/main/kotlin/com/flipcash/app/tipping/internal/TipFlowViewModel.kt
@@ -64,7 +64,7 @@ internal class TipFlowViewModel @Inject constructor(
             stateFlow.map { it.resumed }.distinctUntilChanged(),
         ) { profile, resumed ->
             buildList {
-                val hasProfile = profile?.displayName != null // TODO: explicitly not required right now && profile.profilePicture != null
+                val hasProfile = !profile?.displayName.isNullOrEmpty() // TODO: explicitly not required right now && profile.profilePicture != null
                 when {
                     // Post-setup handoff: land on TipCard alone, with a close affordance. No Tips
                     // underneath — closing exits, and reopening from home lands on the Tips list.

--- a/apps/flipcash/shared/chat/src/main/kotlin/com/flipcash/shared/chat/internal/delegates/FeedSyncDelegate.kt
+++ b/apps/flipcash/shared/chat/src/main/kotlin/com/flipcash/shared/chat/internal/delegates/FeedSyncDelegate.kt
@@ -91,7 +91,7 @@ class FeedSyncDelegate @Inject constructor(
                     // identified by user id and have no phone by design, so they are never dropped.
                     if (chatType == ChatType.CONTACT_DM) {
                         val profile = otherMember.userProfile
-                        val hasIdentity = !profile.displayName.isNullOrBlank() ||
+                        val hasIdentity = profile.displayName.isNotBlank() ||
                             !profile.verifiedPhoneNumber.isNullOrBlank()
                         if (!hasIdentity) return@mapNotNull null
                     }

--- a/apps/flipcash/shared/persistence/sources/src/main/kotlin/com/flipcash/app/persistence/sources/mapper/chat/ChatEntityMapper.kt
+++ b/apps/flipcash/shared/persistence/sources/src/main/kotlin/com/flipcash/app/persistence/sources/mapper/chat/ChatEntityMapper.kt
@@ -150,12 +150,7 @@ class ChatEntityMapper @Inject constructor() {
     fun toMember(entity: ChatMemberEntity): ChatMember {
         return ChatMember(
             userId = entity.userIdHex.hexToId(),
-            userProfile = entity.userProfileJson?.toDomain() ?: UserProfile(
-                displayName = null,
-                socialAccounts = emptyList(),
-                phoneNumber = null,
-                email = null,
-            ),
+            userProfile = entity.userProfileJson?.toDomain() ?: UserProfile.Empty,
             pointers = entity.pointersJson?.map { it.toDomain() } ?: emptyList(),
         )
     }
@@ -284,7 +279,7 @@ private fun UserProfile.toSerialized(): UserProfileSerialized = UserProfileSeria
 )
 
 private fun UserProfileSerialized.toDomain(): UserProfile = UserProfile(
-    displayName = displayName,
+    displayName = displayName.orEmpty(),
     socialAccounts = socialAccounts.map { it.toDomain() },
     phoneNumber = phoneNumber,
     email = email,

--- a/apps/flipcash/shared/profile/src/main/kotlin/com/flipcash/shared/profile/ProfileCoordinator.kt
+++ b/apps/flipcash/shared/profile/src/main/kotlin/com/flipcash/shared/profile/ProfileCoordinator.kt
@@ -82,7 +82,7 @@ private data class CachedProfile(
     val email: VerifiableContactMethod? = null,
 ) {
     fun toDomain(): UserProfile = UserProfile(
-        displayName = displayName,
+        displayName = displayName.orEmpty(),
         socialAccounts = socialAccounts.mapNotNull { it.toDomain() },
         phoneNumber = phoneNumber,
         email = email,

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/controllers/ProfileController.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/controllers/ProfileController.kt
@@ -51,9 +51,7 @@ class ProfileController @Inject constructor(
                     throw error
                 }
 
-                UserProfile(
-                    displayName = null,
-                    socialAccounts = emptyList(),
+                UserProfile.Empty.copy(
                     phoneNumber = unverifiedPhone,
                     email = unverifiedEmail,
                 )

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/models/UserProfile.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/models/UserProfile.kt
@@ -3,7 +3,7 @@ package com.flipcash.services.models
 import com.flipcash.services.models.chat.MediaItem
 
 data class UserProfile(
-    val displayName: String?,
+    val displayName: String,
     val socialAccounts: List<SocialAccount>,
     val phoneNumber: VerifiableContactMethod?,
     val email: VerifiableContactMethod?,
@@ -19,7 +19,7 @@ data class UserProfile(
 
     companion object {
         val Empty = UserProfile(
-            displayName = null,
+            displayName = "",
             socialAccounts = emptyList(),
             phoneNumber = null,
             email = null,


### PR DESCRIPTION
## What

`UserProfile.displayName` was declared nullable but the backing proto always provides a value (empty string when unset, never absent). This makes the field non-nullable to match, then cleans up the fallout.

## Changes

- **Model**: `UserProfile.displayName: String?` → `String`; `Empty.displayName = ""`.
- **Construction sites** updated to satisfy the non-null contract:
  - `ProfileController` — fallback now uses `UserProfile.Empty.copy(...)`.
  - `ChatEntityMapper` — member fallback uses `UserProfile.Empty`; serialized→domain coerces cached nullable name via `orEmpty()`.
  - `ProfileCoordinator` — cached (nullable) name coerced via `orEmpty()` when mapping to domain.
- **Redundant null handling removed** where the receiver is a non-null `UserProfile`:
  - `ChatParticipant` — `profile.displayName.orEmpty()` → `profile.displayName`.
  - `ChatViewModel` / `FeedSyncDelegate` — `!displayName.isNullOrBlank()` → `displayName.isNotBlank()`.
  - `ContactListBuilder`, `UserProfileScreenContent`, `UserProfileViewModel`, `TipFlowViewModel` — dropped `?`/elvis at non-null sites.
- **Tests** updated for the non-null field; removed a now-impossible "null display name" screen test that duplicated the existing "empty" case.

Sites where `displayName` is reached through a nullable `profile`/`member` were intentionally left as-is — their nullability comes from the receiver, not the field.

## Testing

- `compileDebugKotlin` green across all affected modules.
- `myaccount` debug unit-test sources compile.