### PR TITLE
fix(ui): restore BottomBar padding after Modal migration

### DIFF
--- a/ui/components/src/main/kotlin/com/getcode/ui/components/Modal.kt
+++ b/ui/components/src/main/kotlin/com/getcode/ui/components/Modal.kt
@@ -3,6 +3,7 @@ package com.getcode.ui.components
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBars
@@ -21,6 +22,11 @@ import com.getcode.theme.CodeTheme
 fun Modal(
     modifier: Modifier = Modifier,
     backgroundColor: Color = CodeTheme.colors.brandContainer,
+    contentPadding: PaddingValues = PaddingValues(
+        horizontal = CodeTheme.dimens.inset,
+        vertical = CodeTheme.dimens.grid.x2
+    ),
+    horizontalAlignment: Alignment.Horizontal = Alignment.CenterHorizontally,
     verticalArrangement: Arrangement.Vertical = Arrangement.spacedBy(CodeTheme.dimens.grid.x2),
     content: @Composable ColumnScope.() -> Unit
 ) {
@@ -36,9 +42,9 @@ fun Modal(
             modifier = Modifier
                 .fillMaxWidth()
                 .wrapContentHeight()
-                .padding(horizontal = CodeTheme.dimens.inset, vertical = CodeTheme.dimens.grid.x2)
+                .padding(contentPadding)
                 .windowInsetsPadding(WindowInsets.navigationBars),
-            horizontalAlignment = Alignment.CenterHorizontally,
+            horizontalAlignment = horizontalAlignment,
             verticalArrangement = verticalArrangement,
         ) {
             content()

--- a/ui/components/src/main/kotlin/com/getcode/ui/components/bars/BottomBarContainer.kt
+++ b/ui/components/src/main/kotlin/com/getcode/ui/components/bars/BottomBarContainer.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -205,6 +206,13 @@ fun BottomBarView(
     ) {
         Modal(
             backgroundColor = bottomBarMessage.type.backgroundColor(),
+            contentPadding = PaddingValues(
+                top = CodeTheme.dimens.inset,
+                start = CodeTheme.dimens.inset,
+                end = CodeTheme.dimens.inset,
+            ),
+            horizontalAlignment = Alignment.Start,
+            verticalArrangement = Arrangement.spacedBy(CodeTheme.dimens.grid.x3),
         ) {
             if (bottomBarMessage.title.isNotEmpty()) {
                 CompositionLocalProvider(LocalContentColor provides White) {

--- a/ui/components/src/main/kotlin/com/getcode/ui/components/bars/BottomBarContainer.kt
+++ b/ui/components/src/main/kotlin/com/getcode/ui/components/bars/BottomBarContainer.kt
@@ -221,12 +221,12 @@ fun BottomBarView(
                         verticalArrangement = Arrangement.spacedBy(CodeTheme.dimens.grid.x2)
                     ) {
                         Text(
-                            style = CodeTheme.typography.textMedium,
+                            style = CodeTheme.typography.textLarge,
                             text = bottomBarMessage.title
                         )
                         if (bottomBarMessage.subtitle.isNotEmpty()) {
                             Text(
-                                style = CodeTheme.typography.textSmall,
+                                style = CodeTheme.typography.caption,
                                 text = bottomBarMessage.subtitle,
                                 color = LocalContentColor.current.copy(alpha = 0.8f)
                             )

--- a/ui/components/src/main/kotlin/com/getcode/ui/components/bars/BottomBarContainer.kt
+++ b/ui/components/src/main/kotlin/com/getcode/ui/components/bars/BottomBarContainer.kt
@@ -73,6 +73,14 @@ fun BottomBarContainer(
 ) {
     val scope = rememberCoroutineScope()
     val bottomBarMessage by barMessages.bottomBar.collectAsStateWithLifecycle()
+    // The manager clears the message immediately on close (see onClose) so other
+    // screens don't re-show it. Retain the last non-null message so the exit
+    // transition still has content to render, otherwise the bar blanks out and
+    // the slide-out animation isn't visible.
+    var exitingMessage by remember { mutableStateOf(bottomBarMessage) }
+    LaunchedEffect(bottomBarMessage) {
+        if (bottomBarMessage != null) exitingMessage = bottomBarMessage
+    }
     val bottomBarVisibleState = remember(bottomBarMessage?.id) { MutableTransitionState(false) }
     var bottomBarMessageDismissId by remember { mutableLongStateOf(0L) }
     val animationScale by rememberAnimationScale()
@@ -172,7 +180,7 @@ fun BottomBarContainer(
                 scope.launch { onClose(selection, false) }
             }
             BottomBarView(
-                bottomBarMessage = bottomBarMessage,
+                bottomBarMessage = exitingMessage,
                 onShown = onShown,
                 onClose = closeWith,
                 onBackPressed = { closeWith(SelectedBottomBarAction(-1)) }


### PR DESCRIPTION
## Problem

PR #1128 (`chore(ui): have BottomBarContainer render using Modal`) switched `BottomBarContainer` to the shared `Modal` composable. Because the old inline `Column` and `Modal` have different layout opinions, the bottom bar no longer renders the way it did before — most visibly in its padding and alignment.

Concrete differences it picked up from `Modal`'s defaults (example values for the NORMAL width class: `inset`=20, `grid.x2`=10, `grid.x3`=15):

| Aspect | Original inline `Column` | After Modal migration |
|---|---|---|
| Top padding | `inset` (20) | `grid.x2` (10) — halved |
| Bottom padding | 0 (nav bars only) | `grid.x2` (10) — extra gap on top of the last button's own bottom padding |
| Item spacing | `grid.x3` (15) | `grid.x2` (10) — tighter |
| Horizontal alignment | Start | CenterHorizontally — title/subtitle centered |

## Fix

`Modal`'s centered, symmetric-padding defaults are correct for its other caller (`ReceivedFundsConfirmation`), so rather than change the defaults:

- **`Modal`** gains two params — `contentPadding: PaddingValues` and `horizontalAlignment: Alignment.Horizontal` — whose defaults exactly match the previous hard-coded values, so all existing callers are unaffected.
- **`BottomBarContainer`** passes the original `BottomBarView` layout values: top/horizontal-only `inset` padding, `Alignment.Start`, and `grid.x3` item spacing.

## Testing

- `./gradlew :ui:components:compileDebugKotlin` compiles clean.
- Other `Modal` caller (`ReceivedFundsConfirmation`) uses `Modal {}` with no layout args → keeps unchanged defaults.

## Typography

Also aligns the bar's text styles with the design:
- Title: `textMedium` (16sp) → `textLarge` (20sp SemiBold)
- Message/subtitle: `textSmall` (14sp) → `caption` (12sp Medium)

## Exit animation

While verifying, the BottomBar's slide-out (exit) animation was missing — dismissing a modal made it vanish instantly instead of sliding down. Cause: `BottomBarManager.setMessageShown(id)` clears the active message immediately on close (so other screens don't re-show it), setting `bottomBarMessage` to `null` before the `AnimatedContent` exit transition completes. `BottomBarView` early-returns on a null message, so the outgoing frame rendered nothing.

Fix: retain the last non-null message and render it during the transition, so the outgoing content stays on screen to animate out. Verified with Maestro (Menu → My Account → Log Out → Cancel) by recording the dismissal — the modal now slides down and off-screen over several frames rather than disappearing in one.
