### PR TITLE
fix(messenger): dismiss keyboard before send/navigation

### DIFF
--- a/apps/flipcash/features/messenger/src/main/kotlin/com/flipcash/app/messenger/ChatFlowScreen.kt
+++ b/apps/flipcash/features/messenger/src/main/kotlin/com/flipcash/app/messenger/ChatFlowScreen.kt
@@ -28,6 +28,7 @@ import com.getcode.navigation.results.NavResultStateRegistry
 import com.getcode.navigation.results.navigateForResult
 import com.getcode.navigation.results.resultBackNavigator
 import com.getcode.navigation.scenes.LocalSheetNavigator
+import com.getcode.ui.utils.rememberKeyboardController
 import kotlinx.coroutines.flow.filterIsInstance
 
 @Composable
@@ -67,6 +68,7 @@ private fun FlowConversationScreen(identifier: ChatIdentifier, openKeyboard: Boo
     // inspects/mutates this navigator's own back stack), so it can't ride the type dispatcher and
     // must target the sheet navigator explicitly.
     val sheetNavigator = LocalSheetNavigator.current
+    val keyboard = rememberKeyboardController()
 
     LaunchedEffect(viewModel, identifier) {
         viewModel.dispatchEvent(ChatViewModel.Event.OnChatOpened(identifier))
@@ -100,16 +102,18 @@ private fun FlowConversationScreen(identifier: ChatIdentifier, openKeyboard: Boo
         viewModel.eventFlow
             .filterIsInstance<ChatViewModel.Event.OpenScreen>()
             .collect { (route, asSheet) ->
-                if (asSheet) {
-                    // Dismiss this chat sheet and open [route] as a fresh sheet. openAsSheet on the
-                    // sheet-owning navigator animates the current sheet closed (via pendingSheetDismiss)
-                    // before opening the new one.
-                    sheetNavigator?.openAsSheet(route)
-                } else {
-                    // A full AppRoute (never a ChatStep) -> the dispatcher bubbles it up the parent
-                    // chain to the outer app nav host, the same destination as the old
-                    // outerNavigator.navigate(route).
-                    navigator.navigate(route)
+                keyboard.hideIfVisible {
+                    if (asSheet) {
+                        // Dismiss this chat sheet and open [route] as a fresh sheet. openAsSheet on the
+                        // sheet-owning navigator animates the current sheet closed (via pendingSheetDismiss)
+                        // before opening the new one.
+                        sheetNavigator?.openAsSheet(route)
+                    } else {
+                        // A full AppRoute (never a ChatStep) -> the dispatcher bubbles it up the parent
+                        // chain to the outer app nav host, the same destination as the old
+                        // outerNavigator.navigate(route).
+                        navigator.navigate(route)
+                    }
                 }
             }
     }

--- a/apps/flipcash/features/messenger/src/main/kotlin/com/flipcash/app/messenger/internal/screens/components/ChatBottomBar.kt
+++ b/apps/flipcash/features/messenger/src/main/kotlin/com/flipcash/app/messenger/internal/screens/components/ChatBottomBar.kt
@@ -160,7 +160,11 @@ internal fun UserControlBottomBar(
                         state = state,
                         hazeState = hazeState,
                         hazeMaterial = material,
-                        onClick = { dispatch(ChatViewModel.Event.OnSendCash) }
+                        onClick = {
+                            keyboard.hideIfVisible {
+                                dispatch(ChatViewModel.Event.OnSendCash)
+                            }
+                        }
                     )
 
                     if (canType) {


### PR DESCRIPTION
When the message bar is pulled up and you tap the send-cash ($) button without a balance, the keyboard was covering the insufficient-balance alert. Now the keyboard is dismissed first (via `keyboard.hideIfVisible { … }`) on the $ button and when navigating away from the conversation, so the alert / destination screen is visible.

Extracted from the chat-profile branch to PR on its own.

## Testing
`:apps:flipcash:features:messenger:compileDebugKotlin` — green.