### PR TITLE
fix(messenger): center the contact info card vertically

### DIFF
--- a/apps/flipcash/features/messenger/src/main/kotlin/com/flipcash/app/messenger/internal/screens/components/ContactInfoContainer.kt
+++ b/apps/flipcash/features/messenger/src/main/kotlin/com/flipcash/app/messenger/internal/screens/components/ContactInfoContainer.kt
@@ -8,8 +8,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -123,7 +121,7 @@ private fun Indicator(
             onClick = onClick
         )
 
-        else -> Spacer(modifier = modifier.fillMaxWidth())
+        else -> Unit
     }
 }
 
@@ -248,8 +246,6 @@ private fun Preview_AllStates() {
         ContactInfoContainer(participant = knownContact, modifier = cardWidth)
         ContactInfoContainer(participant = unknownContact, modifier = cardWidth)
         ContactInfoContainer(participant = tipUser, modifier = cardWidth)
-        // Null participant: loading / unknown fallback avatar, name empty, no pill.
-        ContactInfoContainer(participant = null, modifier = cardWidth)
     }
 }
 


### PR DESCRIPTION
Removes the full-width `Spacer` in the non-contact (tip/unknown) branch of the contact info card so it sizes to its content and is centered vertically rather than stretched.

Extracted from the chat-profile branch to PR on its own.

## Testing
`:apps:flipcash:features:messenger:compileDebugKotlin` — green.