### PR TITLE
fix(maestro): correct give-button label and sheet dismissal

### DIFF
--- a/maestro/helpers/close_open_sheet.yaml
+++ b/maestro/helpers/close_open_sheet.yaml
@@ -1,7 +1,23 @@
 appId: com.flipcash.app.android
 ---
-- swipe:
-    direction: DOWN
-- extendedWaitUntil:
-      visible:
-          id: scanner_screen
+# Return to the scanner, which is always the root behind the single open sheet. Opening a
+# destination inside a sheet (e.g. wallet -> token info) pushes it onto that sheet's own nav
+# stack, so one dismiss only pops a layer. Press Back until the scanner is revealed: each
+# Back pops the sheet's nav stack and the final one dismisses the sheet itself.
+#
+# Bounded (times) rather than an open while-loop so a stuck sheet can't hang CI, and each
+# Back is guarded on the scanner not already showing — so it's a safe no-op on a clean home
+# screen and never backs out of the app once the scanner is reached.
+- repeat:
+    times: 5
+    commands:
+      - runFlow:
+          when:
+            notVisible:
+              id: scanner_screen
+          commands:
+            - pressKey: Back
+            - waitForAnimationToEnd:
+                timeout: 1500
+- assertVisible:
+    id: scanner_screen

--- a/maestro/open_token_info_deeplink.yaml
+++ b/maestro/open_token_info_deeplink.yaml
@@ -1,16 +1,22 @@
 appId: com.flipcash.app.android
+name: "Token Info deeplink → opens & dismisses to scanner"
+tags:
+  - tokens
 ---
+# A token deeplink opens the token-info screen (pushed into a sheet's nav stack over the
+# scanner) and can be dismissed cleanly back to the scanner. Re-firing the same deeplink is
+# a no-op (the app dedupes it), so this verifies the open + dismiss, which is the meaningful
+# path.
 - runFlow: subflows/login_with_deeplink.yaml
-- runFlow: 
-   file: helpers/launch_deeplink.yaml
-   env:       
+
+- runFlow:
+    file: helpers/launch_deeplink.yaml
+    env:
       deeplink: https://app.flipcash.com/token/5APqK9YUZupKt7rRUrpYy6WV3RPuxA71ZtKJffDUMdPP
 - extendedWaitUntil:
-   visible:
+    visible:
       id: token_info_screen
+    timeout: 8000
+
+# Dismiss the sheet back to the scanner (unwinds the sheet's nav stack, then dismisses it).
 - runFlow: helpers/close_open_sheet.yaml
-- pressKey: home
-- runFlow: 
-   file: helpers/launch_deeplink.yaml
-   env:       
-      deeplink: https://app.flipcash.com/token/5APqK9YUZupKt7rRUrpYy6WV3RPuxA71ZtKJffDUMdPP

--- a/maestro/subflows/pull_out_bill.yaml
+++ b/maestro/subflows/pull_out_bill.yaml
@@ -1,7 +1,9 @@
 appId: com.flipcash.app.android
 ---
 - runFlow: ../helpers/close_open_sheet.yaml
-- tapOn: Give
+# The give/cash nav button's label is config-driven (GiveButtonLabel: "Give" or "Cash");
+# it currently renders "Cash" (action_cash).
+- tapOn: Cash
 - extendedWaitUntil:
       visible: Float
 - extendedWaitUntil:


### PR DESCRIPTION
Fixes two pre-existing Maestro flow failures on `code/cash` (surfaced while running the full journey suite as a regression check; unrelated to the beta-flag removal).

## Give button label
The give nav button renders **"Cash"** (`GiveButtonLabel.Cash` → `action_cash`), not "Give", so `pull_out_bill.yaml`'s `tapOn: Give` never matched. Now taps "Cash".

## Sheet dismissal
`close_open_sheet.yaml` swiped down once and asserted the scanner. But a destination opened **inside** a sheet (e.g. wallet → token info) is pushed onto that sheet's **own nav stack**, so one dismiss only pops a layer — leaving the wallet, not the scanner. It now presses Back until the scanner (the root behind the single open sheet) is revealed:
- **Bounded** (`repeat times: 5`) so a stuck sheet can't hang CI.
- **Guarded** (each Back only fires when the scanner isn't already visible) so it's a safe no-op on a clean home screen and never backs out of the app.

This fixes `open_token_info_deeplink.yaml`, which also drops its final unasserted deeplink "reopen" — re-firing the same token deeplink is a no-op (the app dedupes it), so the step silently did nothing.

## Verified
- `open_token_info_deeplink` → **passes** (opens token info via deeplink, dismisses cleanly to the scanner).
- `claim_cashlink` / `show_bill_and_put_back_in_wallet` → now tap Cash correctly, but still require an account with a **giveable balance** (the give flow otherwise shows a deposit/discover prompt instead of the amount keypad). That's a provisioning dependency like `send_to_contact` — tracked separately, not a selector/flow bug.
