### PR TITLE
test(auth): fix AuthManager onboarding-resume tests for display-name gate

### DIFF
--- a/apps/flipcash/shared/authentication/src/test/kotlin/com/flipcash/app/auth/AuthManagerTest.kt
+++ b/apps/flipcash/shared/authentication/src/test/kotlin/com/flipcash/app/auth/AuthManagerTest.kt
@@ -16,6 +16,7 @@ import com.flipcash.services.controllers.AccountController
 import com.flipcash.services.controllers.ProfileController
 import com.flipcash.services.controllers.PushController
 import com.flipcash.services.models.UserFlags
+import com.flipcash.services.models.UserProfile
 import com.flipcash.services.user.AuthState
 import com.flipcash.services.user.UserManager
 import io.mockk.coEvery
@@ -75,6 +76,11 @@ class AuthManagerTest {
         Dispatchers.setMain(testDispatcher)
 
         every { userManager.state } returns userManagerState
+        // Default to a profile that already has a display name so onboarding resume falls through
+        // to the post-access-key path. Tests exercising the DisplayName step override this.
+        every { userManager.profile } returns mockk<UserProfile>(relaxed = true) {
+            every { displayName } returns "Test User"
+        }
         every { networkConnectivityListener.isConnected } returns true
         coEvery { pushTokenProvider.getToken() } returns "fake-token"
 
@@ -286,6 +292,30 @@ class AuthManagerTest {
         assertTrue(result.isSuccess)
         verify { userManager.set(flags) }
         verify { userManager.set(AuthState.Onboarding(AuthState.ResumePoint.PostAccessKey)) }
+    }
+
+    @Test
+    fun `login resumes at DisplayName when access key seen but no display name set`() = runTest {
+        val entropy = "dGVzdGVudHJvcHkxMjM0NQ=="
+        val accountMetadata: AccountMetadata = mockk(relaxed = true)
+        val testId = listOf<Byte>(1, 2, 3)
+        every { accountMetadata.id } returns testId
+
+        coEvery { credentialManager.login(entropy, any()) } returns Result.success(accountMetadata)
+        coEvery { credentialManager.hasCompletedOnboarding() } returns false
+        // Access key seen, registered, but the display name hasn't been set yet.
+        every { userManager.profile } returns mockk<UserProfile>(relaxed = true) {
+            every { displayName } returns ""
+        }
+
+        val flags = UserFlags.Default.copy(isRegistered = true)
+        coEvery { accountController.getUserFlags() } returns Result.success(flags)
+
+        val result = authManager.login(entropyB64 = entropy)
+
+        assertTrue(result.isSuccess)
+        verify { userManager.set(flags) }
+        verify { userManager.set(AuthState.Onboarding(AuthState.ResumePoint.DisplayName)) }
     }
 
     @Test


### PR DESCRIPTION
## What

Fixes the two `AuthManagerTest` failures that landed on `code/cash` after the onboarding display-name change was merged.

Failing on CI:
- `AuthManagerTest > login resumes at PostAccessKey when registered but onboarding not completed`
- `AuthManagerTest > login falls back to Onboarding when flags exhausted and onboarding not completed`

## Why

The onboarding change reordered `AuthManager.login()`'s resume logic so a missing display name resumes at `ResumePoint.DisplayName` (after the access key) before falling through to `PostAccessKey`. These tests mock a relaxed `UserManager` whose `profile` is `null`, so `displayNameMissing` was `true` and both cases resolved to `DisplayName` instead of the asserted `PostAccessKey`.

The onboarding PR updated its own modules' tests (login, app) but didn't touch `AuthManagerTest` in the `authentication` module, so this failure surfaced only after merge.

## How

- Default the mocked profile in `setUp` to one that already has a display name, so the post-access-key resume paths behave as before.
- Add a test for the new `DisplayName` resume path (access key seen, registered, no display name set).

## Testing

- `:apps:flipcash:shared:authentication:testDebugUnitTest --tests AuthManagerTest` — green (incl. the new case).
- Also ran unit tests for the other onboarding-touched modules (`login`, `app`, `services/flipcash`, `session`, `user-profile`) — all green.
