### PR TITLE
fix(chat): allow swipe-to-dismiss on the conversation sheet

### DIFF
--- a/apps/flipcash/features/messenger/src/main/kotlin/com/flipcash/app/messenger/internal/screens/components/MessageList.kt
+++ b/apps/flipcash/features/messenger/src/main/kotlin/com/flipcash/app/messenger/internal/screens/components/MessageList.kt
@@ -47,7 +47,6 @@ import com.flipcash.shared.chat.models.SeparatorConfig
 import com.flipcash.shared.chat.ui.bubblePositionOf
 import com.getcode.theme.CodeTheme
 import com.getcode.ui.utils.rememberKeyboardController
-import com.getcode.ui.utils.sheetResignmentBehavior
 import com.getcode.util.vibration.LocalVibrator
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -122,8 +121,14 @@ internal fun MessageList(
         }
 
         LazyColumn(
+            // NB: no sheetResignmentBehavior here. That guard is built for top-anchored lists,
+            // where index0/offset0 is the scroll edge that abuts the sheet's downward dismiss drag.
+            // This list is reverseLayout=true, so index0/offset0 is the *resting* position (newest),
+            // and a downward drag there scrolls into history rather than overscrolling. Applying the
+            // guard would flip the sheet's allowDismiss to false at rest and never cleanly re-enable
+            // it, so the sheet snaps back instead of dismissing. Dismiss here comes from the
+            // header/handle drag, scrim tap, and back — all gated by that same allowDismiss flag.
             modifier = modifier
-                .sheetResignmentBehavior(listState)
                 .pointerInput(Unit) {
                     detectTapGestures { keyboard.hide() }
                 },


### PR DESCRIPTION
## Problem

Swiping down on a chat sheet starts to move it but snaps back before reaching the dismiss threshold — the sheet can't be dismissed by drag.

## Root cause

The chat message list (`MessageList.kt`) is a `reverseLayout = true` `LazyColumn` (newest at the bottom, index `0` = bottom), but it had `.sheetResignmentBehavior(listState)` applied. That modifier is built for **top-anchored** lists — and this was the only reversed-list usage among the 9 in the app.

The guard decides "am I at the sheet's downward dismiss boundary?" via `firstVisibleItemIndex == 0 && firstVisibleItemScrollOffset == 0`. For a normal list that's the top scroll edge. For the reversed chat list, index0/offset0 is the **resting position (newest message)**, not a scroll edge:

1. At rest the guard forces the sheet's `allowDismiss` flag to `false` (it gates `confirmDetentChange` for the whole sheet).
2. Swiping down lets the reversed list consume the drag as a **history scroll** → `firstVisibleItemScrollOffset` changes → the modifier flips into `onScrolledAway()`, which disables gestures with no auto-reset and cancels the 700 ms re-enable timer.
3. `allowDismiss` stays `false`, so the sheet can't settle to `Hidden` and snaps back — even for header/handle drags.

## Fix

Remove `.sheetResignmentBehavior(listState)` (and its now-unused import) from the chat list. Its model — "only allow dismiss at the list's scroll edge" — doesn't fit a chat: a downward drag on messages already scrolls history via nested scroll, and dismiss is meant to come from the header/handle drag, scrim tap, and back.

## Testing

- `:apps:flipcash:features:messenger:compileDebugKotlin` passes.
- Manual: open a chat, swipe the sheet down — it now reaches the threshold and dismisses.