### PR TITLE
fix(chat): tip amount-entry — enforce minimum on send + simplify slide label

### DIFF
--- a/apps/flipcash/core/src/main/res/values/strings.xml
+++ b/apps/flipcash/core/src/main/res/values/strings.xml
@@ -899,8 +899,8 @@
     <string name="action_swipeToTip">Swipe to Tip</string>
     <string name="content_description_customTipAmount">Enter a custom amount</string>
     <string name="subtitle_tipHintMinimum">Minimum tip %1$s</string>
-    <string name="error_title_tipMinimum">Tips Start at %1$s</string>
-    <string name="error_description_tipMinimum">Enter a larger amount to send this tip</string>
+    <string name="error_title_tipMinimum">%1$s Minimum</string>
+    <string name="error_description_tipMinimum">Increase the amount to send</string>
     <string name="label_viaTipCard">via Tip Card</string>
 
     <string name="title_block">Block</string>

--- a/apps/flipcash/features/messenger/src/main/kotlin/com/flipcash/app/messenger/internal/ChatViewModel.kt
+++ b/apps/flipcash/features/messenger/src/main/kotlin/com/flipcash/app/messenger/internal/ChatViewModel.kt
@@ -121,7 +121,7 @@ internal class ChatViewModel @Inject constructor(
     }
 
     data class State(
-        val separatorConfig: SeparatorConfig= SeparatorConfig.Continuous(),
+        val separatorConfig: SeparatorConfig = SeparatorConfig.Continuous(),
         val chatId: ChatId? = null,
         val participant: ChatParticipant? = null,
         // The kind of DM this conversation is, resolved from the fast local contact lookup ahead of
@@ -268,7 +268,7 @@ internal class ChatViewModel @Inject constructor(
     // tip (from the tip payment delegate); a contact DM swipes to *send* with no minimum.
     private fun amountStyle(isTip: Boolean) = AmountEntryStyle(
         actionLabel = AmountEntryLabel.Plain(
-            resources.getString(if (isTip) R.string.action_swipeToTip else R.string.action_swipeToSend)
+            resources.getString(R.string.action_swipeToSend)
         ),
         actionStyle = ConfirmationStyle.Slide,
         infoHint = { resources.getString(R.string.subtitle_sendHint, it) },

--- a/apps/flipcash/features/messenger/src/main/kotlin/com/flipcash/app/messenger/internal/ChatViewModel.kt
+++ b/apps/flipcash/features/messenger/src/main/kotlin/com/flipcash/app/messenger/internal/ChatViewModel.kt
@@ -665,6 +665,17 @@ internal class ChatViewModel @Inject constructor(
                     val source = owner.withTimelockForToken(token)
 
                     val balance = tokenCoordinator.balanceForToken(token)
+
+                    val minimum = minAmountFlow.value
+                    if (minimum != null && amount.valueLessThan(minimum)) {
+                        dispatchEvent(Event.SendStateUpdated())
+                        BottomBarManager.showAlert(
+                            title = resources.getString(R.string.error_title_tipMinimum, minimum.formatted()),
+                            message = resources.getString(R.string.error_description_tipMinimum),
+                        )
+                        return@launch
+                    }
+
                     val verifiedFiat = verifiedFiatCalculator.compute(
                         amount = amount,
                         token = token,

--- a/apps/flipcash/features/messenger/src/main/kotlin/com/flipcash/app/messenger/internal/screens/cash/ChatAmountEntryScreen.kt
+++ b/apps/flipcash/features/messenger/src/main/kotlin/com/flipcash/app/messenger/internal/screens/cash/ChatAmountEntryScreen.kt
@@ -4,12 +4,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.flipcash.app.core.AppRoute
-import com.flipcash.app.core.chat.ChatIdentifier
 import com.flipcash.app.core.tokens.TokenPurpose
 import com.flipcash.app.core.ui.TokenSelectionPill
 import com.flipcash.app.messenger.internal.ChatViewModel
@@ -26,30 +22,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
-
-/**
- * Standalone amount entry screen — used when navigating directly from the contact list
- * (messenger disabled). Creates its own [ChatViewModel] scoped to this nav entry.
- */
-@Composable
-fun ChatAmountEntryScreen(identifier: ChatIdentifier) {
-    val viewModel = hiltViewModel<ChatViewModel>()
-    val state by viewModel.stateFlow.collectAsStateWithLifecycle()
-
-    val navigator = LocalCodeNavigator.current
-    LaunchedEffect(viewModel, identifier) {
-        viewModel.dispatchEvent(ChatViewModel.Event.OnChatOpened(identifier))
-    }
-
-    ChatAmountEntryContent(
-        amountDelegate = viewModel.amountDelegate,
-        resolveState = state.resolveState,
-        token = state.token,
-        eventFlow = viewModel.eventFlow,
-        onExit = { navigator.pop() },
-        onConfirm = { viewModel.dispatchEvent(ChatViewModel.Event.OnConfirmRequested) },
-    )
-}
 
 @Composable
 internal fun ChatAmountEntryContent(


### PR DESCRIPTION
## What

Tightens up the messenger tip amount-entry flow:

### Enforce tip minimum on send
Guard the send path so a tip DM below its minimum can't go through: when the entered amount is under `minAmountFlow`, show a **"<min> Minimum"** alert and abort the send. Previously the minimum was only hinted (`belowMinHint`) and not enforced at send time. Reworded the two tip-minimum error strings to match (`error_title_tipMinimum`, `error_description_tipMinimum`).

### Simplify slide label
Always use `action_swipeToSend` for the amount-entry slide action instead of switching to `action_swipeToTip` for tip DMs. With enforcement now happening at send time, the dedicated tip label is redundant. Tip minimum behavior is unchanged aside from the label text.

### Cleanup
- Remove the unused standalone `ChatAmountEntryScreen(identifier)` composable and its now-dead imports (no remaining call sites; the flow-scoped `FlowAmountEntryScreen` → `ChatAmountEntryContent` path is the only entry point).
- Minor whitespace fix on `State.separatorConfig`.

## Testing

- `:apps:flipcash:features:messenger:compileDebugKotlin` passes.
- Manual: enter a tip below the minimum and swipe to send → alert shown, send aborted; enter ≥ minimum → sends normally.
