### PR TITLE
feat(tipping): render tip code image in the Android share sheet

### DIFF
--- a/apps/flipcash/app/src/main/kotlin/com/flipcash/app/FlipcashApp.kt
+++ b/apps/flipcash/app/src/main/kotlin/com/flipcash/app/FlipcashApp.kt
@@ -13,7 +13,9 @@ import coil3.request.CachePolicy
 import coil3.request.crossfade
 import com.flipcash.app.auth.AuthManager
 import okio.Path.Companion.toOkioPath
+import com.flipcash.app.core.android.ActivityProvider
 import com.flipcash.app.currency.PreferredCurrencyController
+import com.flipcash.app.tipping.internal.share.TipCodePreviewCache
 import com.getcode.opencode.repositories.EventRepository
 import com.getcode.utils.trace
 import dev.bmcreations.phantom.connect.PhantomSdk
@@ -35,6 +37,12 @@ class FlipcashApp : Application(), Configuration.Provider, SingletonImageLoader.
     @Inject
     lateinit var workerFactory: HiltWorkerFactory
 
+    @Inject
+    lateinit var activityProvider: ActivityProvider
+
+    @Inject
+    lateinit var tipCodePreviewCache: TipCodePreviewCache
+
     override val workManagerConfiguration: Configuration
         get() = Configuration.Builder()
             .setWorkerFactory(workerFactory)
@@ -45,6 +53,11 @@ class FlipcashApp : Application(), Configuration.Provider, SingletonImageLoader.
         super.onCreate()
         PhantomSdk.init(this)
         authManager.init()
+
+        // Track the foreground Activity so the tip-code share preview can render offscreen.
+        registerActivityLifecycleCallbacks(activityProvider)
+        // Bound the on-disk footprint of cached share previews accumulated across sessions.
+        tipCodePreviewCache.pruneOnStartup()
 
         AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES)
         trace("app onCreate end")

--- a/apps/flipcash/app/src/main/res/xml/file_paths.xml
+++ b/apps/flipcash/app/src/main/res/xml/file_paths.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths>
     <files-path name="traces" path="traces/" />
+    <!-- Rendered tip-code Sharesheet previews (cacheDir/share_previews/). -->
+    <cache-path name="share_previews" path="share_previews/" />
 </paths>

--- a/apps/flipcash/core/src/main/kotlin/com/flipcash/app/core/android/ActivityProvider.kt
+++ b/apps/flipcash/core/src/main/kotlin/com/flipcash/app/core/android/ActivityProvider.kt
@@ -1,0 +1,38 @@
+package com.flipcash.app.core.android
+
+import android.app.Activity
+import android.app.Application
+import android.os.Bundle
+import java.lang.ref.WeakReference
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Tracks the currently-foreground [Activity] so app-scoped services that need a live window can
+ * reach one without holding a strong reference or being handed an Activity through every call.
+ *
+ * Register once from the `Application` via [Application.registerActivityLifecycleCallbacks]. The
+ * reference is weak and cleared on pause, so this never leaks an Activity.
+ */
+@Singleton
+class ActivityProvider @Inject constructor() : Application.ActivityLifecycleCallbacks {
+
+    private var reference: WeakReference<Activity>? = null
+
+    /** The resumed Activity, or null when the app has none in the foreground. */
+    val current: Activity? get() = reference?.get()
+
+    override fun onActivityResumed(activity: Activity) {
+        reference = WeakReference(activity)
+    }
+
+    override fun onActivityPaused(activity: Activity) {
+        if (reference?.get() === activity) reference = null
+    }
+
+    override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) = Unit
+    override fun onActivityStarted(activity: Activity) = Unit
+    override fun onActivityStopped(activity: Activity) = Unit
+    override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) = Unit
+    override fun onActivityDestroyed(activity: Activity) = Unit
+}

--- a/apps/flipcash/core/src/main/kotlin/com/flipcash/app/core/share/TipCodePreview.kt
+++ b/apps/flipcash/core/src/main/kotlin/com/flipcash/app/core/share/TipCodePreview.kt
@@ -1,0 +1,36 @@
+package com.flipcash.app.core.share
+
+import android.net.Uri
+import com.flipcash.app.core.bill.Scannable
+import java.security.MessageDigest
+
+/**
+ * A pair of pre-rendered images of a tip code, used to give the Android Sharesheet a rich preview.
+ *
+ * These are *previews only* — the thing actually shared stays the tip URL (see the share entry
+ * point). [heroUri] is a ~1200x630 landscape image (the shape link-unfurlers expect); [squareUri]
+ * is a 1:1 recomposition for surfaces that want a square thumbnail. Both are `content://` URIs
+ * backed by the app's `FileProvider`.
+ *
+ * [signature] is a stable content hash of the source card — it names the backing files and lets the
+ * cache detect when a cached preview no longer matches the current card (see [tipCodePreviewSignature]).
+ */
+data class TipCodePreview(
+    val heroUri: Uri,
+    val squareUri: Uri,
+    val signature: String,
+)
+
+/**
+ * Stable, deterministic content hash of a tip card. Same visible content -> same signature across
+ * processes, so rendered files can be reused and cache freshness can be checked by comparison.
+ *
+ * Hashes only the scannable payload — the share image is just the code, so it's independent of the
+ * display name. Kept in `core` (not the renderer) so the cache and every renderer agree on it.
+ */
+fun tipCodePreviewSignature(card: Scannable.TipCard): String {
+    val digest = MessageDigest.getInstance("SHA-256")
+        .digest(card.data.toByteArray())
+    // 8 bytes of hex is ample to avoid collisions for a per-user preview cache.
+    return digest.take(8).joinToString("") { "%02x".format(it) }
+}

--- a/apps/flipcash/core/src/main/kotlin/com/flipcash/app/core/share/TipCodePreviewRenderer.kt
+++ b/apps/flipcash/core/src/main/kotlin/com/flipcash/app/core/share/TipCodePreviewRenderer.kt
@@ -1,0 +1,18 @@
+package com.flipcash.app.core.share
+
+import com.flipcash.app.core.bill.Scannable
+
+/**
+ * Renders a tip code into shareable preview images (see [TipCodePreview]).
+ *
+ * This is the seam that keeps the Sharesheet plumbing renderer-agnostic: the Compose-backed
+ * implementation lives in `:apps:flipcash:shared:bills`, and a future CMP/shared-UI renderer can be
+ * bound in its place without touching the cache or the share intent.
+ *
+ * Implementations must be resilient: rendering may not be possible right now (e.g. no foreground
+ * window). Return `null` in that case rather than throwing — the caller degrades to sharing the URL
+ * alone and never blocks the Sharesheet.
+ */
+interface TipCodePreviewRenderer {
+    suspend fun render(card: Scannable.TipCard): TipCodePreview?
+}

--- a/apps/flipcash/core/src/main/kotlin/com/flipcash/app/core/share/TipCodePreviewStorage.kt
+++ b/apps/flipcash/core/src/main/kotlin/com/flipcash/app/core/share/TipCodePreviewStorage.kt
@@ -1,0 +1,64 @@
+package com.flipcash.app.core.share
+
+import android.content.Context
+import android.net.Uri
+import androidx.core.content.FileProvider
+import java.io.File
+
+/**
+ * Single source of truth for *where* tip-code share previews live on disk and how they map to
+ * `content://` URIs. Shared by the renderer (which writes the files) and the cache (which prunes
+ * them) so the two never disagree on paths.
+ *
+ * Files live under `cacheDir/share_previews/` and are named by the card's content [signature]
+ * ([tipCodePreviewSignature]) so identical content reuses the same files and stale content is
+ * naturally superseded.
+ */
+object TipCodePreviewStorage {
+    const val SUBDIR = "share_previews"
+
+    fun dir(context: Context): File =
+        File(context.cacheDir, SUBDIR).apply { if (!exists()) mkdirs() }
+
+    fun heroFile(context: Context, signature: String): File =
+        File(dir(context), "${signature}_hero.png")
+
+    fun squareFile(context: Context, signature: String): File =
+        File(dir(context), "${signature}_square.png")
+
+    /** The authority declared for the `FileProvider` in the app manifest. */
+    fun authority(context: Context): String = "${context.packageName}.fileprovider"
+
+    fun uriFor(context: Context, file: File): Uri =
+        FileProvider.getUriForFile(context, authority(context), file)
+
+    /**
+     * Bounds the on-disk footprint of cached previews. Deletes anything older than [maxAge], then —
+     * newest first — keeps files until [maxTotalBytes] is reached and deletes the rest. Cheap to
+     * call on app start; previews are re-rendered on demand, so over-pruning only costs a re-render.
+     *
+     * Safe to call off the main thread. Never throws — cleanup failures are best-effort.
+     */
+    fun prune(
+        context: Context,
+        maxTotalBytes: Long = DEFAULT_MAX_TOTAL_BYTES,
+        maxAge: Long = DEFAULT_MAX_AGE_MILLIS,
+        now: Long = System.currentTimeMillis(),
+    ) {
+        runCatching {
+            val files = dir(context).listFiles()?.sortedByDescending { it.lastModified() }
+                ?: return
+            var kept = 0L
+            for (file in files) {
+                val expired = now - file.lastModified() > maxAge
+                kept += file.length()
+                if (expired || kept > maxTotalBytes) {
+                    file.delete()
+                }
+            }
+        }
+    }
+
+    private const val DEFAULT_MAX_TOTAL_BYTES = 8L * 1024 * 1024 // 8 MiB
+    private const val DEFAULT_MAX_AGE_MILLIS = 24L * 60 * 60 * 1000 // 1 day
+}

--- a/apps/flipcash/features/tipping/src/main/kotlin/com/flipcash/app/tipping/internal/TipFlowViewModel.kt
+++ b/apps/flipcash/features/tipping/src/main/kotlin/com/flipcash/app/tipping/internal/TipFlowViewModel.kt
@@ -7,7 +7,9 @@ import com.flipcash.app.core.extensions.onResult
 import com.flipcash.app.core.tipping.TipStep
 import com.flipcash.app.shareable.ShareSheetController
 import com.flipcash.app.shareable.Shareable
+import com.flipcash.app.tipping.internal.share.TipCodePreviewCache
 import com.flipcash.app.tokens.TokenCoordinator
+import com.flipcash.features.tipping.R
 import com.flipcash.services.models.chat.ChatType
 import com.flipcash.services.user.UserManager
 import com.flipcash.shared.chat.ChatCoordinator
@@ -32,6 +34,7 @@ internal class TipFlowViewModel @Inject constructor(
     tippingCoordinator: TippingCoordinator,
     tokenCoordinator: TokenCoordinator,
     shareable: ShareSheetController,
+    tipCodePreviewCache: TipCodePreviewCache,
     private val resources: ResourceHelper,
 ) : BaseViewModel<TipFlowViewModel.State, TipFlowViewModel.Event>(
     initialState = State(),
@@ -84,7 +87,11 @@ internal class TipFlowViewModel @Inject constructor(
             .mapNotNull { it.userProfile }
             .distinctUntilChanged()
             .map { tippingCoordinator.resolveTipCard() }
-            .onResult(onSuccess = { card -> dispatchEvent(Event.OnTipCardPopulated(card)) })
+            .onResult(onSuccess = { card ->
+                dispatchEvent(Event.OnTipCardPopulated(card))
+                // Render the Sharesheet preview eagerly so it's ready by the time the user taps share.
+                tippingCoordinator.currentUserId?.let { tipCodePreviewCache.prepare(it, card) }
+            })
             .launchIn(viewModelScope)
 
         combine(
@@ -99,7 +106,13 @@ internal class TipFlowViewModel @Inject constructor(
         eventFlow
             .filterIsInstance<Event.ShareTipCard>()
             .mapNotNull { tippingCoordinator.currentUserId }
-            .map { shareable.present(Shareable.TipCard(it)) }
+            .map { userId ->
+                // Title shown above the link, e.g. "Tip X" (same label as the card).
+                val title = stateFlow.value.tipCard?.user?.displayName
+                    ?.let { resources.getString(R.string.label_tipUser, it) }
+                // Attach the eagerly-rendered preview if it's ready; null shares the URL alone.
+                shareable.present(Shareable.TipCard(userId, tipCodePreviewCache.get(userId), title))
+            }
             .launchIn(viewModelScope)
     }
 

--- a/apps/flipcash/features/tipping/src/main/kotlin/com/flipcash/app/tipping/internal/share/ComposeTipCodePreviewRenderer.kt
+++ b/apps/flipcash/features/tipping/src/main/kotlin/com/flipcash/app/tipping/internal/share/ComposeTipCodePreviewRenderer.kt
@@ -1,0 +1,176 @@
+package com.flipcash.app.tipping.internal.share
+
+import android.app.Activity
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color as AndroidColor
+import android.view.Choreographer
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.unit.Density
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import com.flipcash.app.core.android.ActivityProvider
+import com.flipcash.app.core.bill.Scannable
+import com.flipcash.app.core.share.TipCodePreview
+import com.flipcash.app.core.share.TipCodePreviewRenderer
+import com.flipcash.app.core.share.TipCodePreviewStorage
+import com.flipcash.app.core.share.tipCodePreviewSignature
+import com.flipcash.app.theme.FlipcashTheme
+import com.flipcash.libs.coroutines.DispatcherProvider
+import com.getcode.utils.trace
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.io.FileOutputStream
+import javax.inject.Inject
+import kotlin.coroutines.resume
+
+/**
+ * Renders [TipCodeShareCard] offscreen into shareable bitmaps.
+ *
+ * Approach: a [ComposeView] is attached (invisibly) to the current Activity's content view, measured
+ * at an explicit pixel size with a pinned [Density], then drawn into a software [Canvas]. Attaching
+ * to the live content view (rather than a detached view) is required because the tip code graphic is
+ * a real Android `View` (`KikCodeContentView` via `AndroidView`) that only lays out and draws once
+ * attached to a window — and it inherits the Activity's lifecycle / saved-state owners for free.
+ *
+ * A `rememberGraphicsLayer()` capture was rejected: it only works while the layer is live on screen,
+ * whereas we render eagerly at a fixed, off-screen size (and in two aspect ratios) that never appears
+ * on screen.
+ */
+class ComposeTipCodePreviewRenderer @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val activityProvider: ActivityProvider,
+    private val dispatchers: DispatcherProvider,
+) : TipCodePreviewRenderer {
+
+    override suspend fun render(card: Scannable.TipCard): TipCodePreview? {
+        val activity = activityProvider.current ?: run {
+            trace("tip preview: no foreground activity; skipping render")
+            return null
+        }
+        val signature = tipCodePreviewSignature(card)
+
+        // View work must happen on the main thread.
+        val hero = withContext(dispatchers.Main) {
+            runCatching { drawOffscreen(activity, card, TipCodeShareVariant.Hero) }.getOrNull()
+        } ?: return null
+        val square = withContext(dispatchers.Main) {
+            runCatching { drawOffscreen(activity, card, TipCodeShareVariant.Square) }.getOrNull()
+        } ?: run {
+            hero.recycle()
+            return null
+        }
+
+        // Compress + persist off the main thread.
+        return withContext(dispatchers.IO) {
+            runCatching {
+                val heroFile = TipCodePreviewStorage.heroFile(context, signature)
+                val squareFile = TipCodePreviewStorage.squareFile(context, signature)
+                writePng(hero, heroFile)
+                writePng(square, squareFile)
+                TipCodePreview(
+                    heroUri = TipCodePreviewStorage.uriFor(context, heroFile),
+                    squareUri = TipCodePreviewStorage.uriFor(context, squareFile),
+                    signature = signature,
+                )
+            }.getOrNull().also {
+                hero.recycle()
+                square.recycle()
+            }
+        }
+    }
+
+    private suspend fun drawOffscreen(
+        activity: Activity,
+        card: Scannable.TipCard,
+        variant: TipCodeShareVariant,
+    ): Bitmap? {
+        val root = activity.findViewById<ViewGroup>(android.R.id.content) ?: return null
+        val width = variant.widthPx
+        val height = variant.heightPx
+
+        val composeView = ComposeView(activity).apply {
+            // Dispose the composition as soon as we detach it below.
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnDetachedFromWindow)
+            // Present but never visible; alpha 0 still draws into our canvas, unlike GONE/INVISIBLE.
+            alpha = 0f
+            // Never steal focus or touches during the brief window it's attached.
+            isClickable = false
+            isFocusable = false
+            // Neutralise window insets so the card's statusBar padding is zero offscreen.
+            ViewCompat.setOnApplyWindowInsetsListener(this) { _, _ -> WindowInsetsCompat.CONSUMED }
+            setContent {
+                // Pin density + force the app's (dark) scheme so output is device-independent.
+                CompositionLocalProvider(LocalDensity provides Density(RENDER_DENSITY)) {
+                    FlipcashTheme {
+                        TipCodeShareCard(card = card, variant = variant)
+                    }
+                }
+            }
+        }
+
+        root.addView(composeView, ViewGroup.LayoutParams(width, height))
+        try {
+            awaitRendered(composeView, width, height)
+            val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+            Canvas(bitmap).apply {
+                // Solid opaque underlay beneath the (opaque) Compose fill.
+                drawColor(AndroidColor.BLACK)
+                composeView.draw(this)
+            }
+            return bitmap
+        } finally {
+            root.removeView(composeView)
+        }
+    }
+
+    /**
+     * Suspends until [view] has been laid out at the exact target size and its (AndroidView) content
+     * has had a couple of frames to draw, or a frame budget is exhausted. Frame-driven so both the
+     * framework layout pass and Compose recomposition can settle.
+     */
+    private suspend fun awaitRendered(view: View, width: Int, height: Int) {
+        var frames = 0
+        while (frames < MAX_FRAMES) {
+            awaitFrame()
+            frames++
+            val laidOut = view.width == width && view.height == height &&
+                view.isLaidOut && !view.isLayoutRequested
+            if (laidOut) {
+                // Let AndroidView children (the KikCode view) draw their content.
+                awaitFrame()
+                awaitFrame()
+                return
+            }
+        }
+    }
+
+    private suspend fun awaitFrame() = suspendCancellableCoroutine { continuation ->
+        val callback = Choreographer.FrameCallback { continuation.resume(Unit) }
+        Choreographer.getInstance().postFrameCallback(callback)
+        continuation.invokeOnCancellation {
+            Choreographer.getInstance().removeFrameCallback(callback)
+        }
+    }
+
+    private fun writePng(bitmap: Bitmap, file: File) {
+        FileOutputStream(file).use { out ->
+            bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)
+        }
+    }
+
+    private companion object {
+        // Fixed density so a dp-defined card rasterises identically on every device.
+        const val RENDER_DENSITY = 3f
+        // ~upper bound of frames to wait for layout before giving up (best-effort preview).
+        const val MAX_FRAMES = 20
+    }
+}

--- a/apps/flipcash/features/tipping/src/main/kotlin/com/flipcash/app/tipping/internal/share/TipCodePreviewCache.kt
+++ b/apps/flipcash/features/tipping/src/main/kotlin/com/flipcash/app/tipping/internal/share/TipCodePreviewCache.kt
@@ -1,0 +1,98 @@
+package com.flipcash.app.tipping.internal.share
+
+import android.content.Context
+import com.flipcash.app.core.bill.Scannable
+import com.flipcash.app.core.share.TipCodePreview
+import com.flipcash.app.core.share.TipCodePreviewRenderer
+import com.flipcash.app.core.share.TipCodePreviewStorage
+import com.flipcash.app.core.share.tipCodePreviewSignature
+import com.flipcash.libs.coroutines.DispatcherProvider
+import com.getcode.opencode.model.core.ID
+import com.getcode.opencode.model.core.uuid
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * App-scoped cache of rendered tip-code share previews, keyed by user id.
+ *
+ * Previews are rendered eagerly ([prepare]) when a tip card is populated so the Sharesheet has one
+ * ready at share time, then read synchronously ([get]) when the share intent is built. Rendering is
+ * best-effort: if it hasn't finished or failed, [get] returns null and the caller shares the URL
+ * alone.
+ *
+ * Freshness is content-addressed via [tipCodePreviewSignature]: a card whose content changed yields
+ * a new signature, so [prepare] re-renders and the superseded files are deleted. [invalidate] drops
+ * a preview outright (e.g. on regenerate/redeem/expiry). [pruneOnStartup] bounds the on-disk
+ * footprint at launch.
+ */
+@Singleton
+class TipCodePreviewCache @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val renderer: TipCodePreviewRenderer,
+    private val dispatchers: DispatcherProvider,
+) {
+    private val scope = CoroutineScope(SupervisorJob() + dispatchers.Default)
+    private val entries = ConcurrentHashMap<String, TipCodePreview>()
+    private val inFlight = ConcurrentHashMap<String, Deferred<TipCodePreview?>>()
+
+    private fun keyFor(userId: ID): String? = userId.uuid?.toString()
+
+    /** Eagerly render + cache the preview for [card] under [userId]. Idempotent per content. */
+    fun prepare(userId: ID, card: Scannable.TipCard) {
+        val key = keyFor(userId) ?: return
+        val signature = tipCodePreviewSignature(card)
+
+        val cached = entries[key]
+        if (cached != null && cached.signature == signature && filesExist(cached)) return
+        if (inFlight.containsKey(key)) return
+
+        val deferred = scope.async { renderer.render(card) }
+        inFlight[key] = deferred
+        scope.launch {
+            val preview = runCatching { deferred.await() }.getOrNull()
+            inFlight.remove(key, deferred)
+            if (preview != null) {
+                val previous = entries.put(key, preview)
+                if (previous != null && previous.signature != preview.signature) {
+                    deleteFiles(previous)
+                }
+            }
+        }
+    }
+
+    /** Returns the cached preview for [userId], or null if none is ready / its files are gone. */
+    fun get(userId: ID): TipCodePreview? {
+        val key = keyFor(userId) ?: return null
+        return entries[key]?.takeIf { filesExist(it) }
+    }
+
+    /** Drops the cached preview for [userId] and deletes its files. */
+    fun invalidate(userId: ID) {
+        val key = keyFor(userId) ?: return
+        inFlight.remove(key)?.cancel()
+        entries.remove(key)?.let { deleteFiles(it) }
+    }
+
+    /** Bounds the on-disk preview footprint; safe to call once at app start. */
+    fun pruneOnStartup() {
+        scope.launch(dispatchers.IO) { TipCodePreviewStorage.prune(context) }
+    }
+
+    private fun filesExist(preview: TipCodePreview): Boolean =
+        TipCodePreviewStorage.heroFile(context, preview.signature).exists() &&
+            TipCodePreviewStorage.squareFile(context, preview.signature).exists()
+
+    private fun deleteFiles(preview: TipCodePreview) {
+        runCatching {
+            TipCodePreviewStorage.heroFile(context, preview.signature).delete()
+            TipCodePreviewStorage.squareFile(context, preview.signature).delete()
+        }
+    }
+}

--- a/apps/flipcash/features/tipping/src/main/kotlin/com/flipcash/app/tipping/internal/share/TipCodePreviewModule.kt
+++ b/apps/flipcash/features/tipping/src/main/kotlin/com/flipcash/app/tipping/internal/share/TipCodePreviewModule.kt
@@ -1,0 +1,19 @@
+package com.flipcash.app.tipping.internal.share
+
+import com.flipcash.app.core.share.TipCodePreviewRenderer
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+internal abstract class TipCodePreviewModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindTipCodePreviewRenderer(
+        impl: ComposeTipCodePreviewRenderer,
+    ): TipCodePreviewRenderer
+}

--- a/apps/flipcash/features/tipping/src/main/kotlin/com/flipcash/app/tipping/internal/share/TipCodeShareCard.kt
+++ b/apps/flipcash/features/tipping/src/main/kotlin/com/flipcash/app/tipping/internal/share/TipCodeShareCard.kt
@@ -1,0 +1,61 @@
+package com.flipcash.app.tipping.internal.share
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.min
+import com.flipcash.app.bills.TipCodeGraphic
+import com.flipcash.app.core.bill.Scannable
+import com.getcode.theme.CodeTheme
+
+/**
+ * Output shapes for the share preview. [widthPx]/[heightPx] are the exact bitmap dimensions the
+ * renderer targets; [codeFraction] is how much of the canvas's smaller side the (square) code fills.
+ * The square is a genuine recomposition, not a center-crop of the hero.
+ */
+enum class TipCodeShareVariant(
+    val widthPx: Int,
+    val heightPx: Int,
+    val codeFraction: Float,
+) {
+    // Landscape unfurl shape (OpenGraph-style); the code is limited by the shorter (height) side.
+    Hero(widthPx = 1200, heightPx = 630, codeFraction = 0.9f),
+    // 1:1 for the Sharesheet thumbnail slot.
+    Square(widthPx = 1080, heightPx = 1080, codeFraction = 0.82f),
+}
+
+/**
+ * A dedicated, fixed-size rendering of a tip code for the Android Sharesheet preview: just the
+ * scannable code, large and centered on an opaque background. No card chrome, no name.
+ *
+ * Unlike the on-screen card, this does not size itself off its container — the caller measures it at
+ * an explicit pixel size with a pinned density, so output is identical across devices.
+ */
+@Composable
+fun TipCodeShareCard(
+    card: Scannable.TipCard,
+    variant: TipCodeShareVariant,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            // Opaque background — same brand tone that sits behind the live card.
+            .background(CodeTheme.colors.brand),
+        contentAlignment = Alignment.Center,
+    ) {
+        BoxWithConstraints(contentAlignment = Alignment.Center) {
+            // Square code, sized off the shorter side so it stays large but never clips.
+            val codeSize = min(maxWidth, maxHeight) * variant.codeFraction
+            TipCodeGraphic(
+                payloadData = card.data,
+                modifier = Modifier.size(codeSize),
+            )
+        }
+    }
+}

--- a/apps/flipcash/shared/bills/src/main/kotlin/com/flipcash/app/bills/TipCodeGraphic.kt
+++ b/apps/flipcash/shared/bills/src/main/kotlin/com/flipcash/app/bills/TipCodeGraphic.kt
@@ -1,0 +1,23 @@
+package com.flipcash.app.bills
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.flipcash.app.bills.components.ScannableCode
+
+/**
+ * Just the scannable tip-code graphic (with the default Flipcash logo), no card chrome or label.
+ *
+ * Public entry point over the internal [ScannableCode] so callers outside this module — e.g. the
+ * offscreen share-preview renderer — can draw the code on its own at an explicit size.
+ */
+@Composable
+fun TipCodeGraphic(
+    payloadData: List<Byte>,
+    modifier: Modifier = Modifier,
+) {
+    ScannableCode(
+        modifier = modifier,
+        data = payloadData,
+        icon = null,
+    )
+}

--- a/apps/flipcash/shared/shareable/src/main/kotlin/com/flipcash/app/shareable/ShareSheetController.kt
+++ b/apps/flipcash/shared/shareable/src/main/kotlin/com/flipcash/app/shareable/ShareSheetController.kt
@@ -2,6 +2,7 @@ package com.flipcash.app.shareable
 
 import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.staticCompositionLocalOf
+import com.flipcash.app.core.share.TipCodePreview
 import com.getcode.ed25519.Ed25519
 import com.getcode.opencode.model.accounts.GiftCardAccount
 import com.getcode.opencode.model.core.ID
@@ -43,7 +44,11 @@ sealed interface Shareable {
     }
 
     data class TipCard(
-        val userId: ID
+        val userId: ID,
+        // Optional pre-rendered Sharesheet preview. Null degrades to sharing the URL alone.
+        val preview: TipCodePreview? = null,
+        // Optional Sharesheet title shown above the link (e.g. "Tip Brandon McAnsh").
+        val title: String? = null,
     ): Shareable {
         override val pendingData: ShareablePendingData? = null
     }

--- a/apps/flipcash/shared/shareable/src/main/kotlin/com/flipcash/app/shareable/internal/InternalShareSheetController.kt
+++ b/apps/flipcash/shared/shareable/src/main/kotlin/com/flipcash/app/shareable/internal/InternalShareSheetController.kt
@@ -2,6 +2,7 @@ package com.flipcash.app.shareable.internal
 
 import android.app.PendingIntent
 import android.content.BroadcastReceiver
+import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.ComponentName
 import android.content.Context
@@ -22,7 +23,6 @@ import com.flipcash.app.shareable.ShareablePendingData.CashLink
 import com.flipcash.shared.shareable.R
 import com.getcode.opencode.model.accounts.GiftCardAccount
 import com.getcode.opencode.model.accounts.entropy
-import com.getcode.opencode.model.core.ID
 import com.getcode.opencode.model.financial.Fiat
 import com.getcode.opencode.model.financial.LocalFiat
 import com.getcode.opencode.model.financial.Token
@@ -148,7 +148,7 @@ internal class InternalShareSheetController(
                 shareInviteLink()
             }
 
-            is Shareable.TipCard -> shareTipCard(shareable.userId)
+            is Shareable.TipCard -> shareTipCard(shareable)
         }
     }
 
@@ -288,16 +288,34 @@ internal class InternalShareSheetController(
         context.startActivity(share)
     }
 
-    private fun shareTipCard(userId: ID) {
-        val url = Linkify.tipcard(userId)
-        val intent = Intent().apply {
-            action = Intent.ACTION_SEND
-            putExtra(Intent.EXTRA_TEXT, url)
+    private fun shareTipCard(shareable: Shareable.TipCard) {
+        val url = Linkify.tipcard(shareable.userId)
+        val preview = shareable.preview
+
+        val intent = Intent(Intent.ACTION_SEND).apply {
+            // The shared payload is the link; the recipient still resolves its own preview from the
+            // URL's OG tags. type stays text/plain and the bitmap is NOT an EXTRA_STREAM.
             type = "text/plain"
+            putExtra(Intent.EXTRA_TEXT, url)
+            shareable.title?.let { putExtra(Intent.EXTRA_TITLE, it) }
+
+            if (preview != null) {
+                // Android draws the Sharesheet thumbnail from the intent's ClipData (a content:// URI),
+                // not from any extra. On API < 29 there's no preview surface — this is simply ignored.
+                // The Sharesheet's preview thumbnail slot is square, so use the 1:1 render (the hero
+                // is for URL-unfurl surfaces the recipient resolves from OG tags, not this slot). The
+                // ClipData description is a non-displayed a11y/clipboard label.
+                clipData = ClipData.newUri(context.contentResolver, "Tip code", preview.squareUri)
+                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            }
         }
 
         val share = Intent.createChooser(intent, null).apply {
-            flags = Intent.FLAG_ACTIVITY_NEW_TASK
+            // Use addFlags, not `flags =`. createChooser migrates the target's ClipData *and* its
+            // read-permission grant onto the chooser intent; assigning `flags` here would wipe that
+            // grant, and the Sharesheet's own preview process would be denied access to the image.
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            if (preview != null) addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
         }
 
         context.startActivity(share)


### PR DESCRIPTION
## What

Sharing a tip card now gives the Android Sharesheet a rich preview: the **scannable tip code rendered large** on an opaque background, with a **"Tip \<name\>" title** above the link.

The shared payload stays the **URL** — recipients receive a link, not an image (`type=text/plain`, `EXTRA_TEXT=url`, no `EXTRA_STREAM`) — so the receiving app still resolves its own unfurl from the URL's OG tags. This only affects the local Sharesheet preview (API 29+); API < 29 degrades silently.

## How

- **`TipCodeShareCard`** renders the code offscreen at a fixed size with a pinned `Density(3f)` (device-independent), via a `ComposeView` measured/laid-out and drawn into an opaque `ARGB_8888` bitmap. Two outputs: a `1200×630` hero and a `1:1` square (recomposed, not center-cropped).
- Rendering sits behind a renderer-agnostic **`TipCodePreviewRenderer`** so a CMP/shared-UI renderer can drop in later without touching the share plumbing.
- Previews render **eagerly** when the card is shown, are **cached** by a content signature, and **pruned** (age + size cap) at app start.
- The share intent attaches the square via **`ClipData`** (a `content://` FileProvider URI) with a read grant. Critically it uses `addFlags` on the chooser so the grant `createChooser` migrates for the ClipData is not clobbered (assigning `flags` was the cause of an initially-blank preview — the system preview process got a `SecurityException`).

## Layering

- **`core`** — neutral contract: `TipCodePreviewRenderer`, `TipCodePreview`, `TipCodePreviewStorage`, `ActivityProvider`.
- **`features/tipping`** — the Compose `TipCodeShareCard`, `ComposeTipCodePreviewRenderer` (+ Hilt binding), and `TipCodePreviewCache`; the ViewModel triggers eager render and supplies the title.
- **`shared/shareable`** — stays generic; `Shareable.TipCard` just carries an optional `preview` + `title`.
- **`shared/bills`** — exposes a small public `TipCodeGraphic` over the internal `ScannableCode`.

## Cache / invalidation / pruning

- Location: `cacheDir/share_previews/<sig>_{hero,square}.png`, served as `content://${applicationId}.fileprovider/...`.
- Signature is a content hash of the scannable payload (name-independent).
- Invalidation is content-addressed (regenerated card → new signature → re-render, stale files deleted); `invalidate(userId)` is exposed for any future redeem/expiry hook.
- Pruning: at app start, drop previews older than 1 day, then keep newest-first under an 8 MiB cap.

## Testing

- Full app compiles (Kotlin + KSP/Hilt graph).
- Verified on an Android 16 emulator: eager render writes both PNGs; chooser launches with `NEW_TASK | GRANT_READ_URI_PERMISSION`; no permission denial / image-load failure; the code thumbnail + "Tip \<name\>" title render, with the URL intact.
