### PR TITLE
refactor(money): consolidate fiat appreciation formatting

### DIFF
--- a/apps/flipcash/core/src/main/kotlin/com/flipcash/app/core/money/FormatUtils.kt
+++ b/apps/flipcash/core/src/main/kotlin/com/flipcash/app/core/money/FormatUtils.kt
@@ -43,3 +43,22 @@ fun Int.withCommas(): String {
 fun LocalFiat.formatted(formatting: Fiat.FormattingRule = Fiat.FormattingRule.None): String {
     return nativeAmount.formatted(rule = formatting)
 }
+
+/**
+ * Formats a fiat appreciation/depreciation with the shared sign convention used across the balance
+ * header ([com.flipcash.app.core.ui.CurrencyAppreciationLabel]) and the per-token cards: a leading
+ * "+" for a gain or a zero change (always "+$0.00"), and the formatter's own "-" for a loss.
+ *
+ * A change that rounds to zero is normalized to a positive zero before formatting — otherwise a
+ * tiny-negative amount would render as "-$0.00" (the formatter uses the raw value while
+ * [Fiat.valueNonZero]/[Fiat.toDouble] round to the currency's precision).
+ */
+fun Fiat.formattedAppreciation(): String {
+    val isZero = !valueNonZero()
+    val hasAppreciation = toDouble() >= 0
+    return when {
+        isZero -> copy(quarks = 0).formatted(extraPrefix = "+")
+        hasAppreciation -> formatted(extraPrefix = "+")
+        else -> formatted()
+    }
+}

--- a/apps/flipcash/core/src/main/kotlin/com/flipcash/app/core/ui/CurrencyAppreciationLabel.kt
+++ b/apps/flipcash/core/src/main/kotlin/com/flipcash/app/core/ui/CurrencyAppreciationLabel.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.flipcash.app.core.money.formattedAppreciation
 import com.flipcash.core.R
 import com.getcode.opencode.model.financial.Fiat
 import com.getcode.theme.CodeTheme
@@ -22,7 +23,6 @@ fun CurrencyAppreciationLabel(
     appreciation: Fiat,
     modifier: Modifier = Modifier,
 ) {
-    val isZero = !appreciation.valueNonZero()
     val hasAppreciation = appreciation.toDouble() >= 0
     val changeColor = if (hasAppreciation) {
         CodeTheme.colors.successText
@@ -45,13 +45,7 @@ fun CurrencyAppreciationLabel(
                     vertical = 2.dp,
                     horizontal = CodeTheme.dimens.grid.x1
                 ),
-            value = appreciation.formatted(
-                extraPrefix = when {
-                    isZero -> null
-                    hasAppreciation -> "+"
-                    else -> null
-                },
-            ),
+            value = appreciation.formattedAppreciation(),
             style = CodeTheme.typography.textSmall,
             color = changeColor,
         )

--- a/apps/flipcash/features/tokens/src/main/kotlin/com/flipcash/app/tokens/internal/TokenBuyReceiptScreen.kt
+++ b/apps/flipcash/features/tokens/src/main/kotlin/com/flipcash/app/tokens/internal/TokenBuyReceiptScreen.kt
@@ -196,7 +196,7 @@ private fun BuyReceipt(
                     modifier = Modifier.fillMaxWidth(),
                     label = stringResource(R.string.label_exchangeFee),
                     amount = feeAmount.formatted(
-                        extraPrefix = if (feeAmount.decimalValue < 0.01) "~" else null,
+                        extraPrefix = if (feeAmount.decimalValue < 0.01) "~ " else null,
                     )
                 )
             }

--- a/apps/flipcash/features/tokens/src/main/kotlin/com/flipcash/app/tokens/internal/TokenSellReceiptScreen.kt
+++ b/apps/flipcash/features/tokens/src/main/kotlin/com/flipcash/app/tokens/internal/TokenSellReceiptScreen.kt
@@ -145,7 +145,7 @@ private fun SellReceipt(
                     modifier = Modifier.fillMaxWidth(),
                     label = stringResource(R.string.label_percentFee, feePercentage.roundToInt()),
                     amount = feeAmount.formatted(
-                        extraPrefix = if (feeAmount.decimalValue < 0.01) "~" else null,
+                        extraPrefix = if (feeAmount.decimalValue < 0.01) "~ " else null,
                     ),
                 )
             }

--- a/apps/flipcash/features/tokens/src/main/kotlin/com/flipcash/app/tokens/internal/components/info/MarketCapSection.kt
+++ b/apps/flipcash/features/tokens/src/main/kotlin/com/flipcash/app/tokens/internal/components/info/MarketCapSection.kt
@@ -284,7 +284,7 @@ private fun MarketCapChangeLabel(
                 horizontal = CodeTheme.dimens.grid.x1
             ),
         text = change.formatted(
-            extraPrefix = if (change.decimalValue >= 0) "+" else null,
+            extraPrefix = if (change.decimalValue >= 0) "+ " else null,
             suffix = when (period) {
                 Period.All -> stringResource(R.string.label_marketCapAllTime)
                 Period.Day -> stringResource(R.string.label_marketCapDay)

--- a/apps/flipcash/features/withdrawal/src/main/kotlin/com/flipcash/app/withdrawal/internal/components/TransactionReceipt.kt
+++ b/apps/flipcash/features/withdrawal/src/main/kotlin/com/flipcash/app/withdrawal/internal/components/TransactionReceipt.kt
@@ -133,7 +133,7 @@ private fun LineItems(
             ReceiptLineItem(
                 modifier = Modifier.fillMaxWidth(),
                 label = AnnotatedString(stringResource(R.string.label_lessFee)),
-                amount = fee.formatted(extraPrefix = "-"),
+                amount = fee.formatted(extraPrefix = "- "),
             )
 
             val netAmount = remember(transferAmount) {

--- a/apps/flipcash/features/withdrawal/src/test/kotlin/com/flipcash/app/withdrawal/internal/confirmation/WithdrawalConfirmationScreenContentTest.kt
+++ b/apps/flipcash/features/withdrawal/src/test/kotlin/com/flipcash/app/withdrawal/internal/confirmation/WithdrawalConfirmationScreenContentTest.kt
@@ -224,7 +224,7 @@ class WithdrawalConfirmationScreenContentTest {
     @Test
     fun `receipt shows formatted USD fee with negative prefix`() {
         setScreen(testState(amount = 5.0, fee = Fiat(0.50, CurrencyCode.USD)))
-        // fee.formatted(extraPrefix = "-") → "- $0.50"
+        // fee.formatted(extraPrefix = "- ") → "- $0.50"
         composeTestRule.onNodeWithText("- $0.50", substring = true).assertIsDisplayed()
     }
 

--- a/services/opencode/src/main/kotlin/com/getcode/opencode/model/financial/Fiat.kt
+++ b/services/opencode/src/main/kotlin/com/getcode/opencode/model/financial/Fiat.kt
@@ -108,7 +108,7 @@ data class Fiat(
                 .orEmpty()
 
             val fullPrefix = if (extraPrefix != null) {
-                "$extraPrefix $prefix"
+                "$extraPrefix$prefix"
             } else {
                 prefix
             }

--- a/services/opencode/src/test/kotlin/com/getcode/opencode/model/financial/FiatTests.kt
+++ b/services/opencode/src/test/kotlin/com/getcode/opencode/model/financial/FiatTests.kt
@@ -566,7 +566,7 @@ class FiatTests {
     fun `formatted with extraPrefix and suffix`() {
         val fiat = Fiat(fiat = 10.0)
         val result = fiat.formatted(extraPrefix = "~", suffix = "USD")
-        assertEquals("~ $10.00 USD", result)
+        assertEquals("~$10.00 USD", result)
     }
 
     @Test


### PR DESCRIPTION
## What

Consolidate the fiat appreciation/depreciation sign convention into one shared helper, `Fiat.formattedAppreciation()` (in `core/money`), used by both the balance header (`CurrencyAppreciationLabel`) and the per-token cards.

- Always shows `+$0.00` for a zero change, normalizing a rounds-to-zero amount to a **positive zero** first — fixes the `+-$0.00` double sign a negative-zero value produced (the formatter renders `-0.0` as `-$0.00` while `>= 0` is true, and `toDouble()` rounds to the currency precision).
- Gains get `+`, losses keep the formatter's own `-`.

## Also

Dropped the stray space that `extraPrefix` inserted at the source in `Fiat.formatted` (`"+ $"` → `"+$"`). The four intentional callers that wanted the space now bake it into their prefix string:

- withdrawal fee → `extraPrefix = "- "`
- buy/sell receipt approx → `extraPrefix = "~ "`
- market-cap change → `extraPrefix = "+ "`

Tests updated: `FiatTests` (raw `formatted()` primitive → `~$10.00 USD`) and the withdrawal receipt test (caller keeps its space → `- $0.50`).

## Note

`services/opencode/.../Fiat.kt` is shared-logic parity territory — the change here is display-only (formatting), no math/quark behavior change.
