### PR TITLE
fix(tests): repair unit tests broken by the new-ui v2 merge

### DIFF
--- a/apps/flipcash/app/src/test/kotlin/com/flipcash/app/internal/ui/navigation/BuildNavGraphForLaunchTest.kt
+++ b/apps/flipcash/app/src/test/kotlin/com/flipcash/app/internal/ui/navigation/BuildNavGraphForLaunchTest.kt
@@ -31,6 +31,7 @@ class BuildNavGraphForLaunchTest {
     ): LaunchNavGraph? = buildNavGraphForLaunch(
         state = state,
         router = FakeRouter(action),
+        isNewUi = false,
         deepLink = { deepLink },
     )
 
@@ -122,9 +123,11 @@ class BuildNavGraphForLaunchTest {
     }
 
     @Test
-    fun `unknown auth state without deeplink navigates to OnboardingFlow`() {
-        val result = build(AuthState.Unknown)!!
-        assertIs<AppRoute.OnboardingFlow>(result.baseRoutes.single())
+    fun `unknown auth state waits on Loading`() {
+        // Unknown is a transient pre-resolution state, grouped with Authenticating: it returns
+        // null so the Loading screen stays put until auth resolves. A genuine no-account
+        // resolves to LoggedOut (which routes to OnboardingFlow), covered separately.
+        assertNull(build(AuthState.Unknown))
     }
 
     // -- Onboarding --

--- a/apps/flipcash/features/balance/src/test/kotlin/com/flipcash/app/balance/internal/BalanceViewModelTest.kt
+++ b/apps/flipcash/features/balance/src/test/kotlin/com/flipcash/app/balance/internal/BalanceViewModelTest.kt
@@ -5,8 +5,10 @@ import com.flipcash.app.analytics.StubFlipcashAnalytics
 import com.flipcash.app.core.AppRoute
 import com.flipcash.app.core.MainCoroutineRule
 import com.flipcash.app.core.dispatchers.TestDispatchers
+import com.flipcash.app.activityfeed.ActivityFeedCoordinator
 import com.flipcash.app.funding.PurchaseMethodController
 import com.flipcash.app.userflags.UserFlagsCoordinator
+import com.flipcash.shared.chat.ChatCoordinator
 import com.flipcash.services.internal.model.thirdparty.OnRampProvider
 import com.flipcash.services.user.UserManager
 import io.mockk.coEvery
@@ -38,6 +40,8 @@ class BalanceViewModelTest {
     private val userManager: UserManager = mockk(relaxed = true)
     private val userFlags: UserFlagsCoordinator = mockk(relaxed = true)
     private val purchaseMethodController: PurchaseMethodController = mockk(relaxed = true)
+    private val chatCoordinator: ChatCoordinator = mockk(relaxed = true)
+    private val feedCoordinator: ActivityFeedCoordinator = mockk(relaxed = true)
 
     private lateinit var dispatchers: TestDispatchers
 
@@ -47,6 +51,8 @@ class BalanceViewModelTest {
         dispatchers = dispatchers,
         purchaseMethodController = purchaseMethodController,
         analytics = StubFlipcashAnalytics(),
+        chatCoordinator = chatCoordinator,
+        feedCoordinator = feedCoordinator,
     )
 
     @Test


### PR DESCRIPTION
## Problem

`./gradlew test` (the CI `Run Flipcash Tests` job) is **red on `code/cash`** — the v2 tab-bar UI merge (#1209) changed three production signatures/behaviors but left the unit tests asserting the old ones. Because the compile of those test sources fails, CI goes red for **every** open PR based on `code/cash`, not just the change that happens to be under review.

## Fixes

- **`BalanceViewModelTest`** — `BalanceViewModel` gained `chatCoordinator` + `feedCoordinator` constructor params; the test now passes relaxed mocks for them.
- **`BuildNavGraphForLaunchTest`** — `buildNavGraphForLaunch` gained an `isNewUi` param; the test helper passes `isNewUi = false` (its assertions cover v1 routing).
- **`BuildNavGraphForLaunchTest`** — `AuthState.Unknown` is now intentionally grouped with `Authenticating` and returns `null` (stay on the Loading screen until auth resolves), per the explanatory comment in `MainRoot`. The stale test asserted `Unknown → OnboardingFlow`; it now asserts the documented wait-on-Loading behavior, mirroring the existing `Authenticating` test.

## Verification

`./gradlew testDebugUnitTest --continue` is fully green (`:apps:flipcash:app` and `:apps:flipcash:features:balance` test tasks force-reran and pass). No production code changed — tests only.

Merging this unblocks CI on the other open PRs based on `code/cash`.
