### PR TITLE
feat(nav): slide in-tab pushes, keep crossfade on tab switches

### DIFF
--- a/apps/flipcash/app/src/main/kotlin/com/flipcash/app/internal/ui/navigation/AppContent.kt
+++ b/apps/flipcash/app/src/main/kotlin/com/flipcash/app/internal/ui/navigation/AppContent.kt
@@ -10,10 +10,13 @@ import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.togetherWith
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.scene.OverlayScene
+import androidx.navigation3.scene.Scene
 import androidx.navigation3.scene.SinglePaneSceneStrategy
 import com.flipcash.app.core.AppRoute
 import com.flipcash.app.core.navigation.DeeplinkAction
+import com.flipcash.app.core.navigation.asNavBarTab
 import com.flipcash.app.core.navigation.LocalTabBarPadding
 import com.flipcash.app.internal.ui.AppNavigationBar
 import com.flipcash.app.internal.ui.navigation.decorators.rememberNavBlockingOverlayEntryDecorator
@@ -153,27 +156,38 @@ internal fun NewAppContent(
                     },
                     SinglePaneSceneStrategy(),
                 ),
-                // v2 is tab-centric: switching tabs (replaceAll) crossfades. Sheets/overlays keep
-                // their own (no) transition; everything else fades too.
+                // v2 is tab-centric: a forward move that LANDS on a tab home is a tab switch
+                // (replaceAll between tab homes) and crossfades; any other forward move is a push
+                // into a detail screen and slides in. Pops always slide back out (a pop is always
+                // leaving a detail). Sheets/overlays keep their own (no) transition.
                 transitionSpec = {
-                    if (targetState is OverlayScene<*> || initialState is OverlayScene<*>) {
-                        EnterTransition.None togetherWith ExitTransition.None
-                    } else {
-                        fadeIn(tween(300)) togetherWith fadeOut(tween(300))
+                    val landsOnTab = (codeNavigator.currentRouteKey as? AppRoute)?.asNavBarTab() != null
+                    when {
+                        targetState is OverlayScene<*> || initialState is OverlayScene<*> ->
+                            EnterTransition.None togetherWith ExitTransition.None
+                        landsOnTab ->
+                            fadeIn(tween(300)) togetherWith fadeOut(tween(300))
+                        else ->
+                            slideInHorizontally(initialOffsetX = { it }) togetherWith
+                                    slideOutHorizontally(targetOffsetX = { -it })
                     }
                 },
                 popTransitionSpec = {
-                    if (targetState is OverlayScene<*> || initialState is OverlayScene<*>) {
-                        EnterTransition.None togetherWith ExitTransition.None
-                    } else {
-                        fadeIn(tween(300)) togetherWith fadeOut(tween(300))
+                    when {
+                        targetState is OverlayScene<*> || initialState is OverlayScene<*> ->
+                            EnterTransition.None togetherWith ExitTransition.None
+                        else ->
+                            slideInHorizontally(initialOffsetX = { -it }) togetherWith
+                                    slideOutHorizontally(targetOffsetX = { it })
                     }
                 },
                 predictivePopTransitionSpec = {
-                    if (targetState is OverlayScene<*> || initialState is OverlayScene<*>) {
-                        EnterTransition.None togetherWith ExitTransition.None
-                    } else {
-                        fadeIn(tween(300)) togetherWith fadeOut(tween(300))
+                    when {
+                        targetState is OverlayScene<*> || initialState is OverlayScene<*> ->
+                            EnterTransition.None togetherWith ExitTransition.None
+                        else ->
+                            slideInHorizontally(initialOffsetX = { -it }) togetherWith
+                                    slideOutHorizontally(targetOffsetX = { it })
                     }
                 },
                 onBack = { codeNavigator.navigateBack() },

--- a/apps/flipcash/features/balance/src/main/kotlin/com/flipcash/app/balance/WalletScreen.kt
+++ b/apps/flipcash/features/balance/src/main/kotlin/com/flipcash/app/balance/WalletScreen.kt
@@ -50,7 +50,7 @@ fun WalletScreen() {
             viewModel.eventFlow
                 .filterIsInstance<WalletViewModel.Event.OpenScreen>()
                 .map { it.screen }
-                .onEach { navigator.openAsSheet(it) }
+                .onEach { navigator.push(it) }
                 .launchIn(this)
         }
     }


### PR DESCRIPTION
## Summary
Differentiate navigation transitions in the v2 tab host: **tab switches crossfade, in-tab pushes slide**.

- The nested tab nav host (`NewAppContent`) crossfaded every transition.
- Now a forward move that lands on a **tab home** (Scanner/Wallet, via `asNavBarTab`) crossfades — a tab switch (`replaceAll`) — while any other forward move **slides in** (a push into a detail screen) and pops **slide back out**. Overlays/sheets keep their no-transition path.
- Route is read via `codeNavigator.currentRouteKey` (the `Scene.key` is not the `AppRoute` at runtime).
- Also switches the wallet's `OpenScreen` navigation from `openAsSheet` to `push`, so detail screens (e.g. Token Info) get the slide.

## Test Plan
- [ ] Switch tabs (Scanner ↔ Wallet) → crossfade
- [ ] Wallet → tap a token card → Token Info slides in; back slides out
- [ ] Sheets/overlays unaffected
