### PR TITLE
refactor(bills): move bill decorators + modals into :shared:bills

### DIFF
--- a/apps/flipcash/features/scanner/src/main/kotlin/com/flipcash/app/scanner/internal/bills/ScannableContainer.kt
+++ b/apps/flipcash/features/scanner/src/main/kotlin/com/flipcash/app/scanner/internal/bills/ScannableContainer.kt
@@ -58,8 +58,8 @@ import com.flipcash.app.session.PutInWallet
 import com.flipcash.app.updates.LocalAppUpdater
 import com.getcode.ui.components.OnLifecycleEvent
 import androidx.lifecycle.Lifecycle
-import com.flipcash.app.scanner.internal.bills.decor.ScannableDecoratorContext
-import com.flipcash.app.scanner.internal.bills.decor.ScannableDecorator
+import com.flipcash.app.bills.decor.ScannableDecoratorContext
+import com.flipcash.app.bills.decor.ScannableDecorator
 import com.flipcash.features.scanner.R
 import com.getcode.manager.BottomBarAction
 import com.getcode.manager.BottomBarManager

--- a/apps/flipcash/shared/bills/build.gradle.kts
+++ b/apps/flipcash/shared/bills/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
 
     implementation(project(":libs:messaging"))
     implementation(project(":apps:flipcash:shared:common-ui"))
+    implementation(project(":apps:flipcash:shared:session"))
 
     implementation(libs.androidx.datastore)
     implementation(libs.bundles.haze)

--- a/apps/flipcash/shared/bills/src/main/kotlin/com/flipcash/app/bills/BillManagementOptions.kt
+++ b/apps/flipcash/shared/bills/src/main/kotlin/com/flipcash/app/bills/BillManagementOptions.kt
@@ -1,4 +1,4 @@
-package com.flipcash.app.scanner.internal.bills
+package com.flipcash.app.bills
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement

--- a/apps/flipcash/shared/bills/src/main/kotlin/com/flipcash/app/bills/decor/PayableDecorator.kt
+++ b/apps/flipcash/shared/bills/src/main/kotlin/com/flipcash/app/bills/decor/PayableDecorator.kt
@@ -1,4 +1,4 @@
-package com.flipcash.app.scanner.internal.bills.decor
+package com.flipcash.app.bills.decor
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.EnterExitState
@@ -19,8 +19,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment.Companion.BottomCenter
 import androidx.compose.ui.Modifier
 import com.flipcash.app.core.bill.Scannable
-import com.flipcash.app.scanner.internal.bills.BillManagementOptions
-import com.flipcash.app.scanner.internal.ui.modals.ReceivedFundsConfirmation
+import com.flipcash.app.bills.BillManagementOptions
+import com.flipcash.app.bills.modals.ReceivedFundsConfirmation
 import com.getcode.ui.core.measured
 import com.getcode.ui.utils.AnimationUtils
 import kotlinx.coroutines.delay

--- a/apps/flipcash/shared/bills/src/main/kotlin/com/flipcash/app/bills/decor/ScannableDecorator.kt
+++ b/apps/flipcash/shared/bills/src/main/kotlin/com/flipcash/app/bills/decor/ScannableDecorator.kt
@@ -1,4 +1,4 @@
-package com.flipcash.app.scanner.internal.bills.decor
+package com.flipcash.app.bills.decor
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.AnimatedVisibilityScope
@@ -24,7 +24,7 @@ import com.flipcash.app.core.bill.Scannable
  * content (so it survives the exit animation) and gates its `visible` on
  * [ScannableDecoratorContext.liveBill].
  */
-internal sealed interface ScannableDecorator {
+sealed interface ScannableDecorator {
     @Composable
     fun BoxScope.Content(context: ScannableDecoratorContext)
 
@@ -76,7 +76,7 @@ internal sealed interface ScannableDecorator {
  *   container so the card floats above it.
  * @param onDismiss dismisses the current bill (equivalent to `session.dismissBill(PutInWallet)`).
  */
-internal data class ScannableDecoratorContext(
+data class ScannableDecoratorContext(
     val liveBill: Scannable?,
     val billState: BillState,
     val isRemoteSendLoading: Boolean,

--- a/apps/flipcash/shared/bills/src/main/kotlin/com/flipcash/app/bills/decor/TipCardDecorator.kt
+++ b/apps/flipcash/shared/bills/src/main/kotlin/com/flipcash/app/bills/decor/TipCardDecorator.kt
@@ -1,4 +1,4 @@
-package com.flipcash.app.scanner.internal.bills.decor
+package com.flipcash.app.bills.decor
 
 import androidx.compose.animation.EnterExitState
 import androidx.compose.foundation.layout.Box
@@ -19,7 +19,7 @@ import com.flipcash.app.core.extensions.navigateAll
 import com.flipcash.app.core.extensions.openAsSheet
 import com.flipcash.app.core.tipping.LocalTipCoordinator
 import com.flipcash.app.core.tipping.TipEvent
-import com.flipcash.app.scanner.internal.ui.modals.TipUserModal
+import com.flipcash.app.bills.modals.TipUserModal
 import com.flipcash.app.session.LocalSessionController
 import com.getcode.navigation.core.LocalCodeNavigator
 import com.getcode.ui.core.measured

--- a/apps/flipcash/shared/bills/src/main/kotlin/com/flipcash/app/bills/modals/ReceivedFundsConfirmation.kt
+++ b/apps/flipcash/shared/bills/src/main/kotlin/com/flipcash/app/bills/modals/ReceivedFundsConfirmation.kt
@@ -1,4 +1,4 @@
-package com.flipcash.app.scanner.internal.ui.modals
+package com.flipcash.app.bills.modals
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
@@ -13,7 +13,7 @@ import androidx.compose.ui.unit.dp
 import com.flipcash.app.core.bill.Scannable
 import com.flipcash.app.core.money.formatted
 import com.flipcash.app.core.ui.TokenIconWithName
-import com.flipcash.features.scanner.R
+import com.flipcash.shared.bills.R
 import com.getcode.opencode.compose.LocalExchange
 import com.getcode.theme.CodeTheme
 import com.getcode.theme.White

--- a/apps/flipcash/shared/bills/src/main/kotlin/com/flipcash/app/bills/modals/TipUserModal.kt
+++ b/apps/flipcash/shared/bills/src/main/kotlin/com/flipcash/app/bills/modals/TipUserModal.kt
@@ -1,4 +1,4 @@
-package com.flipcash.app.scanner.internal.ui.modals
+package com.flipcash.app.bills.modals
 
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateFloatAsState
@@ -38,7 +38,7 @@ import com.flipcash.app.core.tipping.LocalTipCoordinator
 import com.flipcash.app.core.tipping.TipAmount
 import com.flipcash.app.core.tokens.TokenPurpose
 import com.flipcash.app.core.ui.TokenSelectionPill
-import com.flipcash.features.scanner.R
+import com.flipcash.shared.bills.R
 import com.getcode.navigation.core.LocalCodeNavigator
 import com.getcode.opencode.model.financial.Fiat
 import com.getcode.opencode.model.financial.Token


### PR DESCRIPTION
## Summary
**Phase A** of moving bill rendering to the app root: relocate the below-bill **decorators** and their **modals** out of `:features:scanner` into `:shared:bills`. Pure move — **no behavior change** — so the eventual root-level bill overlay can host them.

Moved (6 files):
- `decor/` → `ScannableDecorator`, `PayableDecorator`, `TipCardDecorator`
- `BillManagementOptions`, `modals/ReceivedFundsConfirmation`, `modals/TipUserModal`

Details:
- `ScannableDecorator` (sealed interface) + `ScannableDecoratorContext` become **public** — the scanner still consumes them, now cross-module. Concrete decorators/modals stay `internal` to `:shared:bills`.
- `:shared:bills` gains a `:shared:session` dep (`LocalSessionController`). No dependency cycle (`:shared:session` doesn't depend on `:shared:bills`).
- The 7 string resources resolve transitively (`:core` + `:ui:resources`); none moved. `R` import repointed to `com.flipcash.shared.bills.R`.
- `ScannableContainer` repointed to the new package.

Follow-up (Phase B): a root-level `BillOverlay` in `App.kt`, scanner slim-down, frosting removal.

## Test Plan
- [ ] `:shared:bills`, `:features:scanner`, `:app` compile (verified: BUILD SUCCESSFUL)
- [ ] Scanner still shows/dismisses bills, tip modal, received-funds confirmation exactly as before
