### PR TITLE
fix(wallet): match iOS token order and card-stack spacing

### DIFF
--- a/apps/flipcash/features/balance/src/main/kotlin/com/flipcash/app/balance/internal/WalletScreenContent.kt
+++ b/apps/flipcash/features/balance/src/main/kotlin/com/flipcash/app/balance/internal/WalletScreenContent.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.flipcash.app.core.AppRoute
 import com.flipcash.app.core.ui.TokenCardStack
@@ -73,13 +74,14 @@ internal fun WalletScreenContent(
         state = listState,
         modifier = Modifier.fillMaxSize(),
         contentPadding = PaddingValues(
+            top = CodeTheme.dimens.inset,
             start = CodeTheme.dimens.inset,
             end = CodeTheme.dimens.inset,
-            bottom = LocalTabBarPadding.current.calculateBottomPadding(),
+            bottom = LocalTabBarPadding.current.calculateBottomPadding() + CodeTheme.dimens.grid.x12,
         )
     ) {
         item {
-            Spacer(Modifier.height(CodeTheme.dimens.grid.x20))
+            Spacer(Modifier.height(CodeTheme.dimens.grid.x15))
         }
 
         item {

--- a/apps/flipcash/shared/tokens/src/main/kotlin/com/flipcash/app/tokens/ui/SelectTokenViewModel.kt
+++ b/apps/flipcash/shared/tokens/src/main/kotlin/com/flipcash/app/tokens/ui/SelectTokenViewModel.kt
@@ -163,8 +163,11 @@ class SelectTokenViewModel @Inject constructor(
                             )
                         }
                         .sortedWith(
-                            compareByDescending<TokenWithLocalizedBalance> { it.balance.nativeAmount.rounded() }
-                                .thenBy { it.token.address.base58() }
+                            // Match iOS (Session.balances): descending by exact value, then
+                            // alphabetical by name (not by mint address, which reordered equal-value
+                            // tokens like LaunchIt/Teddies differently than iOS).
+                            compareByDescending<TokenWithLocalizedBalance> { it.balance.nativeAmount }
+                                .thenBy { it.token.name }
                         )
                         .filter {
                             val hasBalance = it.balance.nativeAmount.hasDisplayableValue


### PR DESCRIPTION
## Summary
- **Token order:** sort balances descending by exact native value, tiebreaking on **token name** instead of mint address. Equal-value tokens (e.g. LaunchIt / Teddies) now order the same as iOS `Session.balances`.
- **Card-stack spacing:** add a top inset + extra bottom content padding to the wallet list and trim the header spacer so the token-card stack fully collapses by the time the recent-activity rows are on screen — with the space above the stack and below the last recent row matching iOS.

## Test Plan
- [x] `:apps:flipcash:features:balance` and `:apps:flipcash:shared:tokens` compile.
- [ ] On device: compare wallet against iOS — token order matches; cards fully collapse when scrolled to Recent; top/bottom spacing matches.