### PR TITLE
refactor(ui): AppBarWithTitle custom title + append close after end actions

### DIFF
--- a/apps/flipcash/features/tokens/src/main/kotlin/com/flipcash/app/tokens/TokenInfoScreen.kt
+++ b/apps/flipcash/features/tokens/src/main/kotlin/com/flipcash/app/tokens/TokenInfoScreen.kt
@@ -52,7 +52,7 @@ fun TokenInfoScreen(
         val viewModel = hiltViewModel<TokenInfoViewModel>()
         val state by viewModel.stateFlow.collectAsStateWithLifecycle()
         AppBarWithTitle(
-            title = {
+            titleContent = {
                 state.token.dataOrNull?.let { token ->
                     TokenIconWithName(
                         token = token,
@@ -62,7 +62,8 @@ fun TokenInfoScreen(
                 }
             },
             titleAlignment = Alignment.CenterHorizontally,
-            rightContents = {
+            onBackIconClicked = { navigator.pop() },
+            endContent = {
                 state.token.dataOrNull?.let {
                     if (!state.isCashReserve) {
                         AppBarDefaults.Share {
@@ -71,7 +72,6 @@ fun TokenInfoScreen(
                         }
                     }
                 }
-                AppBarDefaults.Close { navigator.pop() }
             },
         )
 

--- a/ui/components/src/main/kotlin/com/getcode/ui/components/TitleBar.kt
+++ b/ui/components/src/main/kotlin/com/getcode/ui/components/TitleBar.kt
@@ -185,10 +185,11 @@ object AppBarDefaults {
 fun AppBarWithTitle(
     modifier: Modifier = Modifier,
     title: String = "",
+    titleContent: (@Composable () -> Unit)? = null,
     titleAlignment: Alignment.Horizontal = Alignment.Start,
     contentPadding: PaddingValues = AppBarDefaults.ContentPadding,
     onBackIconClicked: (() -> Unit)? = null,
-    endContent: @Composable () -> Unit = { },
+    endContent: @Composable RowScope.() -> Unit = { },
 ) {
     val navigator = LocalCodeNavigator.current
     val flowDismissStyle = LocalFlowDismissStyle.current
@@ -217,16 +218,17 @@ fun AppBarWithTitle(
             }
         },
         titleRegion = {
-            AppBarDefaults.Title(text = title)
+            if (titleContent != null) titleContent() else AppBarDefaults.Title(text = title)
         },
         titleAlignment = titleAlignment,
+        // The caller's end actions always render; a Close (when the leading control resolves to
+        // one) is appended after them so it sits furthest toward the screen edge — the
+        // conventional dismiss position. [TopAppBarBase] already lays these out in an
+        // [EndActionSlotHolder], so a back arrow never has to share the leading slot with a close.
         rightContents = {
-            EndActionSlotHolder {
-                if (showClose) {
-                    AppBarDefaults.Close { onBackIconClicked() }
-                } else {
-                    endContent()
-                }
+            endContent()
+            if (showClose) {
+                AppBarDefaults.Close { onBackIconClicked() }
             }
         },
     )


### PR DESCRIPTION
## Summary
- Add an optional `titleContent` slot to `AppBarWithTitle` so callers can render a **composable** title (e.g. a token icon + name) instead of only a plain string, and widen `endContent` to a `RowScope` receiver.
- When the leading control resolves to a **Close**, append it *after* the caller's end actions (furthest toward the screen edge — the conventional dismiss position) instead of replacing them. `TopAppBarBase` already lays these out in an `EndActionSlotHolder`, so a back arrow never shares the leading slot with a close.
- `TokenInfoScreen` adopts the new slots: `titleContent` for the token icon/name + an explicit `onBackIconClicked`, dropping its manual trailing Close.

## Test Plan
- [x] Full `:apps:flipcash:app:assembleDebug` compiles (50+ `AppBarWithTitle` callers — signature change is source-compatible).
- [x] On device: token info screen shows the icon/name title, share action, and a close in the conventional edge position; spot-check a couple of other AppBar screens for correct close/end-action placement.