### PR TITLE
feat(profile): add helper sublabel below display name input field

### DIFF
--- a/apps/flipcash/core/src/main/kotlin/com/flipcash/app/core/ui/DisplayTextInput.kt
+++ b/apps/flipcash/core/src/main/kotlin/com/flipcash/app/core/ui/DisplayTextInput.kt
@@ -1,9 +1,12 @@
 package com.flipcash.app.core.ui
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.text.input.InputTransformation
 import androidx.compose.foundation.text.input.KeyboardActionHandler
 import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -30,11 +33,15 @@ fun DisplayTextInput(
     placeholder: String,
     modifier: Modifier = Modifier,
     textModifier: Modifier = Modifier,
+    sublabel: String? = null,
     style: TextStyle = CodeTheme.typography.displayMedium.copy(
         color = CodeTheme.colors.textMain,
         fontWeight = FontWeight.SemiBold,
     ),
     placeholderStyle: TextStyle = style.copy(color = CodeTheme.colors.textTertiary),
+    sublabelStyle: TextStyle = CodeTheme.typography.textSmall.copy(
+        color = CodeTheme.colors.textSecondary,
+    ),
     minLines: Int = 1,
     maxLines: Int = 1,
     enabled: Boolean = true,
@@ -42,27 +49,36 @@ fun DisplayTextInput(
     onKeyboardAction: KeyboardActionHandler? = null,
     inputTransformation: InputTransformation? = null,
 ) {
-    TextInput(
-        state = state,
-        modifier = modifier,
-        textModifier = textModifier,
-        placeholder = placeholder,
-        style = style,
-        placeholderStyle = placeholderStyle,
-        textFieldAlignment = Alignment.TopStart,
-        maxLines = maxLines,
-        minLines = minLines,
-        minHeight = 0.dp,
-        shape = RectangleShape,
-        enabled = enabled,
-        colors = inputColors(
-            backgroundColor = Color.Transparent,
-            borderColor = Color.Transparent,
-            unfocusedBorderColor = Color.Transparent,
-            placeholderColor = placeholderStyle.color,
-        ),
-        keyboardOptions = keyboardOptions,
-        onKeyboardAction = onKeyboardAction,
-        inputTransformation = inputTransformation,
-    )
+    Column(verticalArrangement = Arrangement.spacedBy(CodeTheme.dimens.grid.x2)) {
+        TextInput(
+            state = state,
+            modifier = modifier,
+            textModifier = textModifier,
+            placeholder = placeholder,
+            style = style,
+            placeholderStyle = placeholderStyle,
+            textFieldAlignment = Alignment.TopStart,
+            maxLines = maxLines,
+            minLines = minLines,
+            minHeight = 0.dp,
+            shape = RectangleShape,
+            enabled = enabled,
+            colors = inputColors(
+                backgroundColor = Color.Transparent,
+                borderColor = Color.Transparent,
+                unfocusedBorderColor = Color.Transparent,
+                placeholderColor = placeholderStyle.color,
+            ),
+            keyboardOptions = keyboardOptions,
+            onKeyboardAction = onKeyboardAction,
+            inputTransformation = inputTransformation,
+        )
+
+        if (sublabel != null) {
+            Text(
+                text = sublabel,
+                style = sublabelStyle,
+            )
+        }
+    }
 }

--- a/apps/flipcash/core/src/main/res/values/strings.xml
+++ b/apps/flipcash/core/src/main/res/values/strings.xml
@@ -887,6 +887,7 @@
     <string name="action_startReceivingTips">Start Receiving Tips</string>
 
     <string name="title_profileNameSelection">What is your name?</string>
+    <string name="subtitle_profileNameSelection">This is how you\'ll appear to others</string>
     <string name="hint_profileName">Your Name</string>
     <string name="error_title_profileNameNotAllowed">This Name is Not Allowed</string>
     <string name="error_description_profileNameNotAllowed">Try a different name</string>

--- a/apps/flipcash/features/user-profile/src/main/kotlin/com/flipcash/app/userprofile/internal/name/NameEntryScreen.kt
+++ b/apps/flipcash/features/user-profile/src/main/kotlin/com/flipcash/app/userprofile/internal/name/NameEntryScreen.kt
@@ -122,27 +122,32 @@ private fun NameEntryScreenContent(
         }
     ) { padding ->
         val focusRequester = remember { FocusRequester() }
-        DisplayTextInput(
-            state = state.nameFieldState,
-            placeholder = stringResource(R.string.hint_profileName),
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(padding)
-                .focusRequester(focusRequester),
-            textModifier = Modifier.sharedElementTransition(
-                transition = SharedTransition.CurrencyName,
-            ),
-            keyboardOptions = KeyboardOptions(
-                capitalization = KeyboardCapitalization.Words,
-                keyboardType = KeyboardType.Text,
-                imeAction = ImeAction.Done,
-            ),
-            onKeyboardAction = {
-                keyboard.hideIfVisible {
-                    dispatchEvent(NameEntryViewModel.Event.CheckName)
-                }
-            },
-        )
+        // Apply the scaffold's content padding to the wrapper, not the field —
+        // padding on the field itself inflates its box and pushes the sublabel
+        // far below the entered text instead of letting it sit just underneath.
+        Column(modifier = Modifier.padding(padding)) {
+            DisplayTextInput(
+                state = state.nameFieldState,
+                placeholder = stringResource(R.string.hint_profileName),
+                sublabel = stringResource(R.string.subtitle_profileNameSelection),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .focusRequester(focusRequester),
+                textModifier = Modifier.sharedElementTransition(
+                    transition = SharedTransition.CurrencyName,
+                ),
+                keyboardOptions = KeyboardOptions(
+                    capitalization = KeyboardCapitalization.Words,
+                    keyboardType = KeyboardType.Text,
+                    imeAction = ImeAction.Done,
+                ),
+                onKeyboardAction = {
+                    keyboard.hideIfVisible {
+                        dispatchEvent(NameEntryViewModel.Event.CheckName)
+                    }
+                },
+            )
+        }
 
         LaunchedEffect(Unit) {
             focusRequester.requestFocus()


### PR DESCRIPTION
## What

Adds a helper sublabel **"This is how you'll appear to others"** directly below the name input on the display-name entry screen (`NameEntryScreen`), per the new Figma design ([node 8966-1323](https://www.figma.com/design/Jxf2wD9QyfKaONbhHSdU0K/Flipcash?node-id=8966-1323&m=dev)).

## How

- **`DisplayTextInput`** gains an optional `sublabel: String? = null` param (plus `sublabelStyle`, defaulting to `textSmall` / `textSecondary`). The component now lays out the field and sublabel in a `Column`, so the helper text is rendered *inside* the component, directly beneath the field. This avoids the overlap that occurs when a sublabel is added as a sibling in `CodeScaffold`'s content slot (which stacks its children).
- **`NameEntryScreen`** passes `sublabel = stringResource(R.string.subtitle_profileNameSelection)` and applies the scaffold's content padding to a wrapper `Column` rather than the field itself — otherwise the padding inflates the field's box and pushes the sublabel far below the entered text instead of hugging it.
- **`strings.xml`** adds `subtitle_profileNameSelection`.

## Testing

- `:apps:flipcash:app:installDebug` builds clean and runs on a Pixel_10 emulator (Android 17).
- Verified on-device: the sublabel renders directly below the entered name with no overlap and tight spacing.

The iOS counterpart is code-payments/code-ios-app#571.
