### PR TITLE
fix(wallet): bottom-align labels on Spread TileButtons

### DIFF
--- a/apps/flipcash/core-ui/src/main/kotlin/com/flipcash/app/core/ui/TileButton.kt
+++ b/apps/flipcash/core-ui/src/main/kotlin/com/flipcash/app/core/ui/TileButton.kt
@@ -81,6 +81,8 @@ fun TileButton(
                     modifier = Modifier
                         .fillMaxWidth()
                         .fillMaxHeight(),
+                    // Icon pinned to the top, label pinned to the bottom — the tile's height (set by the
+                    // caller) becomes the gap, so single- and multi-line labels bottom-align across tiles.
                     verticalArrangement = Arrangement.SpaceBetween,
                     horizontalAlignment = Alignment.Start,
                 ) {

--- a/apps/flipcash/features/balance/src/main/kotlin/com/flipcash/app/balance/internal/WalletScreenContent.kt
+++ b/apps/flipcash/features/balance/src/main/kotlin/com/flipcash/app/balance/internal/WalletScreenContent.kt
@@ -3,13 +3,12 @@ package com.flipcash.app.balance.internal
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
-import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -149,6 +148,7 @@ internal fun WalletScreenContent(
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
+                        .padding(top = CodeTheme.dimens.grid.x2)
                         .clickable {
                             dispatchEvent(
                                 WalletViewModel.Event.OpenScreen(AppRoute.Sheets.ActivityHistory)
@@ -189,18 +189,17 @@ internal fun WalletScreenContent(
             }
 
             item {
-                // Equal-height tiles: the taller (wrapping) label drives the row height and the
-                // shorter tile stretches to match, so each tile can spread its icon/label vertically.
+                // Fixed, width-proportional height (like iOS) so both tiles are equal height and tall
+                // enough for the icon (top) and label (bottom) to sit apart — labels bottom-align even
+                // when one wraps to two lines.
                 Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(IntrinsicSize.Min),
+                    modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.spacedBy(CodeTheme.dimens.grid.x2),
                 ) {
                     TileButton(
                         modifier = Modifier
                             .weight(1f)
-                            .fillMaxHeight(),
+                            .aspectRatio(1.45f),
                         style = TileButtonStyle.Spread,
                         text = stringResource(R.string.action_addMoney),
                         icon = rememberVectorPainter(Icons.Outlined.AddCircleOutline),
@@ -211,7 +210,7 @@ internal fun WalletScreenContent(
                     TileButton(
                         modifier = Modifier
                             .weight(1f)
-                            .fillMaxHeight(),
+                            .aspectRatio(1.45f),
                         style = TileButtonStyle.Spread,
                         text = stringResource(R.string.action_discoverCurrencies),
                         icon = painterResource(R.drawable.ic_globe),


### PR DESCRIPTION
## Summary
Make the wallet's Spread action tiles match iOS: icon top-left, label **bottom**-left, labels bottom-aligned across tiles even when one wraps to two lines.

- `TileButton` Spread uses `Arrangement.SpaceBetween` — icon pins top, label pins bottom; the tile height is the gap.
- Wallet **Add Money / Discover Currencies** switch from an `IntrinsicSize.Min` row (tiles were only as tall as content → no gap on the 2-line card, and the 1-line label sat top-aligned) to `Modifier.weight(1f).aspectRatio(1.45f)`. Equal height, width-proportional like iOS, tall enough for the labels to bottom-align.

## Test plan
- `./gradlew :apps:flipcash:app:compileDebugKotlin` passes.
- On device: "Add Money" and "Discover Currencies" tiles are equal height; the plus/globe icons sit top-left and both labels bottom-align.
