### PR TITLE
feat(wallet): add Withdraw and Create-a-Currency action tiles

### DIFF
--- a/apps/flipcash/core/src/main/res/drawable/ic_coins_add.xml
+++ b/apps/flipcash/core/src/main/res/drawable/ic_coins_add.xml
@@ -1,0 +1,15 @@
+<!-- "Create a Currency" glyph: two overlapping coins with a plus. Vendored from the design
+     (matches the iOS `coinsAdd` asset). -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M15.5148,11.7071V14.3432M15.5148,14.3432V16.9793M15.5148,14.3432H12.8787M15.5148,14.3432H18.151M15.1359,6.5886C13.9753,4.077 11.4338,2.3342 8.4852,2.3342C4.441,2.3342 1.1626,5.6126 1.1626,9.6568C1.1626,13.6357 4.3362,16.8734 8.2902,16.9768M22.8374,14.3432C22.8374,18.3874 19.559,21.6658 15.5148,21.6658C12.3991,21.6658 9.7377,19.7197 8.6801,16.9768C8.365,16.1596 8.1923,15.2716 8.1923,14.3432C8.1923,10.3643 11.3658,7.1265 15.3199,7.0232C15.3847,7.0215 15.4497,7.0207 15.5148,7.0207C19.559,7.0207 22.8374,10.2991 22.8374,14.3432Z"
+      android:strokeWidth="1.5"
+      android:fillColor="#00000000"
+      android:strokeColor="#ffffff"
+      android:strokeLineCap="round"
+      android:strokeLineJoin="round"/>
+</vector>

--- a/apps/flipcash/core/src/main/res/values/strings.xml
+++ b/apps/flipcash/core/src/main/res/values/strings.xml
@@ -628,6 +628,7 @@
     <string name="subtitle_discoverEmptyNew">No currencies have been created in the last week</string>
     <string name="subtitle_discoverEmptyPopular">No popular currencies right now</string>
     <string name="action_createYourOwnCurrency">Create Your Own Currency</string>
+    <string name="action_createCurrency">Create a Currency</string>
     <string name="subtitle_createYourOwnCurrency">Create a currency in minutes and immediately use it as cash</string>
     <string name="prompt_title_notYetAvailable">Not Yet Available</string>
     <string name="prompt_message_currencyCreateNotYetAvailable">Check back soon</string>

--- a/apps/flipcash/features/balance/src/main/kotlin/com/flipcash/app/balance/internal/WalletScreenContent.kt
+++ b/apps/flipcash/features/balance/src/main/kotlin/com/flipcash/app/balance/internal/WalletScreenContent.kt
@@ -3,6 +3,7 @@ package com.flipcash.app.balance.internal
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -18,8 +19,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.Icon
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.AddCircleOutline
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -27,7 +26,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -195,33 +193,67 @@ internal fun WalletScreenContent(
             }
 
             item {
-                // Fixed, width-proportional height (like iOS) so both tiles are equal height and tall
-                // enough for the icon (top) and label (bottom) to sit apart — labels bottom-align even
-                // when one wraps to two lines.
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(CodeTheme.dimens.grid.x2),
+                // 2x2 action grid. Fixed, width-proportional tile height (like iOS) so tiles are
+                // equal height and tall enough for the icon (top) and label (bottom) to sit apart —
+                // labels bottom-align even when one wraps to two lines.
+                Column(
+                    verticalArrangement = Arrangement.spacedBy(CodeTheme.dimens.grid.x2),
                 ) {
-                    TileButton(
-                        modifier = Modifier
-                            .weight(1f)
-                            .aspectRatio(1.45f),
-                        style = TileButtonStyle.Spread,
-                        text = stringResource(R.string.action_addMoney),
-                        icon = rememberVectorPainter(Icons.Outlined.AddCircleOutline),
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(CodeTheme.dimens.grid.x2),
                     ) {
-                        dispatchEvent(WalletViewModel.Event.PresentDepositOptions)
+                        // ic_menu_deposit/ic_menu_withdraw are the app's canonical glyphs for this
+                        // pair (the Settings-sheet money tiles) — matched arrows, not ad-hoc icons.
+                        TileButton(
+                            modifier = Modifier
+                                .weight(1f)
+                                .aspectRatio(1.45f),
+                            style = TileButtonStyle.Spread,
+                            text = stringResource(R.string.action_addMoney),
+                            icon = painterResource(R.drawable.ic_menu_deposit),
+                        ) {
+                            dispatchEvent(WalletViewModel.Event.PresentDepositOptions)
+                        }
+
+                        TileButton(
+                            modifier = Modifier
+                                .weight(1f)
+                                .aspectRatio(1.45f),
+                            style = TileButtonStyle.Spread,
+                            text = stringResource(R.string.action_withdrawMoney),
+                            icon = painterResource(R.drawable.ic_menu_withdraw),
+                        ) {
+                            dispatchEvent(WalletViewModel.Event.OpenScreen(AppRoute.Transfers.Withdrawal()))
+                        }
                     }
 
-                    TileButton(
-                        modifier = Modifier
-                            .weight(1f)
-                            .aspectRatio(1.45f),
-                        style = TileButtonStyle.Spread,
-                        text = stringResource(R.string.action_discoverCurrencies),
-                        icon = painterResource(R.drawable.ic_globe),
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(CodeTheme.dimens.grid.x2),
                     ) {
-                        dispatchEvent(WalletViewModel.Event.OpenScreen(AppRoute.Token.Discovery))
+                        TileButton(
+                            modifier = Modifier
+                                .weight(1f)
+                                .aspectRatio(1.45f),
+                            style = TileButtonStyle.Spread,
+                            text = stringResource(R.string.action_discoverCurrencies),
+                            icon = painterResource(R.drawable.ic_globe),
+                        ) {
+                            dispatchEvent(WalletViewModel.Event.OpenScreen(AppRoute.Token.Discovery))
+                        }
+
+                        // Currency creation now lives here rather than as a Discover promo.
+                        TileButton(
+                            modifier = Modifier
+                                .weight(1f)
+                                .aspectRatio(1.45f),
+                            style = TileButtonStyle.Spread,
+                            text = stringResource(R.string.action_createCurrency),
+                            icon = painterResource(R.drawable.ic_coins_add),
+                        ) {
+                            dispatchEvent(WalletViewModel.Event.OpenScreen(AppRoute.Token.CurrencyCreator))
+                        }
                     }
                 }
             }

--- a/apps/flipcash/features/discovery/src/main/kotlin/com/flipcash/app/discovery/internal/components/TokenLeaderboard.kt
+++ b/apps/flipcash/features/discovery/src/main/kotlin/com/flipcash/app/discovery/internal/components/TokenLeaderboard.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
@@ -64,8 +63,9 @@ internal fun TokenLeaderboard(
     val features = LocalFeatureFlags.current
     val isNewUi by features.observe(FeatureFlag.NewUi).collectAsStateWithLifecycle()
 
-    // The v2 upsell card sits over the list as the bottom bar; frost it against the leaderboard
-    // scrolling beneath. The inline (non-v2) card is part of the list itself, so it gets no hazeState.
+    // v2 surfaces currency creation as a Wallet action tile, so Discover drops its promo entirely;
+    // v1 keeps it as the first row above the leaderboard. The haze source stays wired for the
+    // scroll gradient's benefit.
     val hazeState = rememberHazeState()
 
     val currencyCreatorCard = @Composable { modifier: Modifier, haze: HazeState? ->
@@ -73,20 +73,7 @@ internal fun TokenLeaderboard(
             dispatch(TokenDiscoveryViewModel.Event.CreateCurrency)
         }
     }
-    CodeScaffold(
-        bottomBar = {
-            if (isNewUi) {
-                currencyCreatorCard(
-                    Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = CodeTheme.dimens.inset)
-                        .navigationBarsPadding()
-                        .padding(bottom = CodeTheme.dimens.grid.x3),
-                    hazeState,
-                )
-            }
-        },
-    ) { padding ->
+    CodeScaffold { padding ->
         LazyColumn(
             modifier = Modifier
                 .fillMaxSize()


### PR DESCRIPTION
Ports [code-payments/code-ios-app#598](https://github.com/code-payments/code-ios-app/pull/598).

The v2 Wallet's action row becomes a 2x2 grid:

| | |
|---|---|
| Add Money | Withdraw Money |
| Discover Currencies | Create a Currency |

### Changes
- Add/Withdraw use the app's canonical matched glyph pair (`ic_menu_deposit` / `ic_menu_withdraw`, as on the Settings money tiles) instead of an ad-hoc Material icon. Create a Currency gets a new `ic_coins_add` vendored from the design.
- Withdraw pushes `AppRoute.Transfers.Withdrawal` onto the wallet's own stack so it pops back to the Wallet (iOS needed `.withdrawCurrency` for the same reason).
- Discover drops its floating currency-creator promo now that creation lives on the Wallet.

Tile corner radius already matched the design token (`shapes.extraSmall`, 6dp) on both the wallet tiles and the currency-info action tiles — no change needed there.

### Flag gating
v2-only: `WalletScreenContent` is the NewUi wallet, and the legacy inline currency-creator promo on Discover is untouched.
