### PR TITLE
fix(deps): keep both libphonenumber artifacts on the same version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,13 @@ updates:
   schedule:
     interval: weekly
   open-pull-requests-limit: 10
+  groups:
+    # Both libphonenumber artifacts must move together — see the note in gradle/libs.versions.toml.
+    # Grouping them into one PR makes any version skew visible in a single diff rather than in two
+    # PRs that can land independently.
+    libphonenumber:
+      patterns:
+        - "*libphonenumber*"
   labels:
     - "dependencies"
     - "type: build"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -64,8 +64,13 @@ protobuf = "4.35.1"
 protobuf-plugin = "0.10.0"
 protovalidate-kt = "0.1.1"
 
+# These two must stay on the SAME version. `:shared:phone` parses and formats with the Android port
+# while the services modules validate with Google's artifact, and each ships its own copy of the
+# libphonenumber metadata — so a version skew means the two can disagree on whether a number is
+# valid. The port lags upstream, so it sets the ceiling: only bump `-google` once the port has
+# published a matching release.
 lib-phone-number-port = "9.0.36"
-lib-phone-number-google = "9.0.37"
+lib-phone-number-google = "9.0.36"
 zxing = "3.5.4"
 
 androidx-benchmark-macro = "1.5.0-beta01"


### PR DESCRIPTION
Follow-up to #1241 / #1242.

Those two were reviewed and merged as a pair precisely so the two libphonenumber artifacts would agree at `9.0.36`. Between the review and the merge, #1242 hit a conflict and Dependabot rebased it onto a newer upstream release — so `code/cash` now has:

| Catalog key | Artifact | Version |
|---|---|---|
| `lib-phone-number-port` | `io.michaelrocks:libphonenumber-android` | 9.0.36 |
| `lib-phone-number-google` | `com.googlecode.libphonenumber:libphonenumber` | **9.0.37** |

### Why the skew is worth fixing rather than ignoring

Both artifacts are on the runtime classpath and each bundles **its own copy of the libphonenumber metadata**. The class names don't collide (`io.michaelrocks.libphonenumber.android.*` vs `com.google.i18n.phonenumbers.*`), so nothing breaks at build time — but the two are consulted at different points in the same flow:

- `:shared:phone` parses and formats with the **port**
- `:services:flipcash`, `:services:flipcash-compose`, `:services:opencode` and `:shared:onramp:coinbase` validate with **Google's**

A metadata patch typically adjusts number ranges for a handful of countries. One patch of drift is enough for the client to format a number as valid and the services layer to reject it (or the reverse) — for some countries only, intermittently, with nothing in the stack trace pointing at a version mismatch.

`9.0.36` is the **latest** published version of the port (checked against Maven Central), so it sets the ceiling. This pins `-google` back to match and documents the coupling in the catalog so the next bump doesn't silently re-skew.

### Dependabot grouping

Also groups both artifacts into one Dependabot PR. To be clear about what this does and doesn't buy: it does **not** force matching versions — the port will keep lagging, and a grouped PR will still propose 9.0.37/9.0.36. What it does is put the skew in a single diff you can see and correct, instead of two PRs that can each be merged on their own and look fine in isolation. That's exactly how this one got through.

### Verification

- `./gradlew :apps:flipcash:app:assembleDebug` — green (also confirms the other seven dependency bumps that just landed build together)
- `:apps:flipcash:shared:phone:testDebugUnitTest` — green
- `:libs:encryption:hmac:testAndroidHostTest` — green (KMP module; `test` is ambiguous here, `testAndroidHostTest` is the real task)
