### PR TITLE
build(deps): hold libphonenumber 9.0.37 until the Android port catches up

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,16 @@ updates:
     libphonenumber:
       patterns:
         - "*libphonenumber*"
+  ignore:
+    # Google's libphonenumber can only move when the Android port (io.michaelrocks) has a matching
+    # release — the two ship separate copies of the metadata and must stay on the same version, or
+    # they can disagree on whether a number is valid. See the note in gradle/libs.versions.toml.
+    # The port has no 9.0.37, so this specific version is held. Grouping alone does not prevent it:
+    # a group PR still gets opened with just the one artifact when only that artifact has an update,
+    # and closing such a PR does NOT suppress the version (Dependabot says so explicitly on close).
+    # Remove this entry once the port publishes 9.0.37 or later.
+    - dependency-name: "com.googlecode.libphonenumber:libphonenumber"
+      versions: ["9.0.37"]
   labels:
     - "dependencies"
     - "type: build"


### PR DESCRIPTION
Dependabot re-proposed `com.googlecode.libphonenumber:libphonenumber` 9.0.36 → 9.0.37 in #1259. Merging it would have put the two libphonenumber artifacts back into version skew — the exact thing #1258 fixed — because the Android port `io.michaelrocks:libphonenumber-android` has no 9.0.37 (latest on Maven Central is 9.0.36).

#1259 is closed, but closing is not enough. Dependabot said so on the way out:

> This pull request was built based on a group rule. Closing it will not ignore any of these versions in future pull requests.

The `libphonenumber` group added in #1258 is still doing its job — it makes skew visible in one diff when both artifacts have updates. What it does not do is prevent a group PR containing only one artifact when only that one has an update. So 9.0.37 would come back on the next scheduled run.

This adds an explicit ignore for that single version. Scoped to 9.0.37 deliberately, not to all patches: 9.0.38+ should still be offered, and by then the port may have caught up.

### Follow-up worth doing

This will recur on every upstream release, because the port structurally lags. The durable fix is to stop depending on both artifacts at all — and it is small:

- `io.michaelrocks:libphonenumber-android` (the port) is used throughout `apps/flipcash/shared/phone/.../PhoneUtils.kt` and its tests.
- `com.googlecode.libphonenumber:libphonenumber` (Google's) has **exactly one** consumer: `apps/flipcash/shared/onramp/coinbase/.../PhoneRegion.kt`, using only `parse` and `getRegionCodeForNumber` — both present in the port.

Porting that one file lets the Google artifact be dropped entirely, at which point this ignore rule, the group rule, and the pinning comment in `gradle/libs.versions.toml` all become unnecessary.
