### PR TITLE
fix(ui/navigation): pop the sheet entry when a drag dismisses it

### DIFF
--- a/ui/navigation/build.gradle.kts
+++ b/ui/navigation/build.gradle.kts
@@ -35,4 +35,5 @@ dependencies {
 
     testImplementation(kotlin("test"))
     testImplementation(libs.bundles.unit.testing)
+    testImplementation(libs.bundles.compose.ui.testing)
 }

--- a/ui/navigation/src/main/kotlin/com/getcode/navigation/scenes/ModalBottomSheetSceneStrategy.kt
+++ b/ui/navigation/src/main/kotlin/com/getcode/navigation/scenes/ModalBottomSheetSceneStrategy.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Modifier
@@ -53,6 +54,7 @@ import com.getcode.theme.CodeTheme
 import com.getcode.ui.core.noRippleClickable
 import com.getcode.ui.utils.LocalSheetExpansionState
 import com.getcode.ui.utils.LocalSheetGesturesState
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 
 data class BottomSheetProperties(
@@ -173,10 +175,41 @@ internal class ModalBottomSheetScene<T : Any> constructor(
                 }
             }
 
+            // One presentation of the sheet must pop its entry exactly once. Every dismissal ends
+            // with the sheet settled at Hidden, and the settle observer below fires for all of
+            // them — including the explicit paths here and in [pendingSheetDismiss] — so the pop is
+            // funnelled through this guard. Reset when the sheet is (re-)opened.
+            var dismissHandled by remember { mutableStateOf(false) }
+            val finishDismiss = {
+                if (!dismissHandled) {
+                    dismissHandled = true
+                    handleBackResult()
+                    onBack()
+                }
+            }
+
             // Animate the sheet in on first composition and after
             // same-route dismiss-replace (sheetGeneration increments).
             LaunchedEffect(navigator.sheetGeneration) {
                 sheetState.animateTo(restingDetent)
+            }
+
+            // [UnstyledBottomSheet] is a plain sheet with no dismissal callback of its own, so
+            // dragging it closed hides it without telling anyone: the entry stays on the backstack
+            // as an invisible sheet that still swallows every touch through its full-size scrim,
+            // and chrome that hides while a sheet is up (the v2 tab bar) stays hidden until the
+            // next tap lands on that scrim and pops it. Watch the sheet's state rather than the
+            // gesture, so a drag-dismiss pops the entry the same way a scrim tap does.
+            LaunchedEffect(navigator.sheetGeneration) {
+                dismissHandled = false
+                // The sheet starts out Hidden, so a return to Hidden only means "dismissed" once
+                // it has actually been presented.
+                snapshotFlow { sheetState.targetDetent }.first { it != SheetDetent.Hidden }
+                // Settled, not merely targeted: mid-drag the target flips to Hidden and back as the
+                // finger crosses the dismiss threshold.
+                snapshotFlow { sheetState.isIdle && sheetState.currentDetent == SheetDetent.Hidden }
+                    .first { it }
+                finishDismiss()
             }
 
             val composeScope = rememberCoroutineScope()
@@ -186,12 +219,10 @@ internal class ModalBottomSheetScene<T : Any> constructor(
                     composeScope.launch {
                         sheetState.animateTo(SheetDetent.Hidden)
                     }.invokeOnCompletion {
-                        handleBackResult()
-                        onBack()
+                        finishDismiss()
                     }
                 } else {
-                    handleBackResult()
-                    onBack()
+                    finishDismiss()
                 }
             }
 
@@ -203,8 +234,7 @@ internal class ModalBottomSheetScene<T : Any> constructor(
                         sheetState.animateTo(SheetDetent.Hidden)
                     } finally {
                         Snapshot.withMutableSnapshot {
-                            handleBackResult()
-                            onBack()
+                            finishDismiss()
                             navigator.pendingSheetDismiss = null
                             pendingDismiss()
                         }

--- a/ui/navigation/src/test/kotlin/com/getcode/navigation/scenes/ModalBottomSheetSceneTest.kt
+++ b/ui/navigation/src/test/kotlin/com/getcode/navigation/scenes/ModalBottomSheetSceneTest.kt
@@ -1,0 +1,95 @@
+package com.getcode.navigation.scenes
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.swipeDown
+import androidx.navigation3.runtime.NavEntry
+import androidx.navigation3.runtime.NavKey
+import com.getcode.navigation.AppHome
+import com.getcode.navigation.DemoSheet
+import com.getcode.navigation.core.EmptyCodeNavigator
+import com.getcode.navigation.core.LocalCodeNavigator
+import com.getcode.navigation.scrim.LocalScrimController
+import com.getcode.navigation.scrim.ScrimController
+import com.getcode.navigation.testNavigator
+import com.getcode.theme.DesignSystem
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.assertEquals
+
+private const val SheetContentTag = "sheet-content"
+private const val BaseContentTag = "base-content"
+
+/**
+ * [UnstyledBottomSheet] has no dismissal callback, so the scene has to notice the sheet settling
+ * back at [SheetDetent.Hidden] itself. If it doesn't, a drag-dismiss leaves the (now invisible)
+ * sheet entry on the backstack — swallowing touches through its full-screen scrim and keeping
+ * app chrome that hides for sheets (the v2 tab bar) hidden until the next tap pops it.
+ */
+@RunWith(RobolectricTestRunner::class)
+class ModalBottomSheetSceneTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private var backCount = 0
+
+    private fun showSheet() {
+        backCount = 0
+        val navigator = testNavigator(AppHome, DemoSheet)
+        val baseEntry = NavEntry<NavKey>(key = AppHome) {
+            Box(Modifier.fillMaxSize().testTag(BaseContentTag))
+        }
+        val sheetEntry = NavEntry<NavKey>(key = DemoSheet) {
+            Box(Modifier.fillMaxSize().testTag(SheetContentTag))
+        }
+        val scene = ModalBottomSheetScene(
+            key = DemoSheet,
+            previousEntries = listOf(baseEntry),
+            overlaidEntries = listOf(baseEntry),
+            entry = sheetEntry,
+            sheetProperties = BottomSheetProperties(),
+            onBack = { backCount++ },
+            metadata = emptyMap(),
+            navResultStore = EmptyCodeNavigator.resultStore,
+            lastNavKey = { AppHome },
+        )
+
+        composeTestRule.setContent {
+            DesignSystem {
+                CompositionLocalProvider(
+                    LocalCodeNavigator provides navigator,
+                    LocalScrimController provides ScrimController(),
+                ) {
+                    scene.content()
+                }
+            }
+        }
+        composeTestRule.waitForIdle()
+    }
+
+    @Test
+    fun `an open sheet does not pop its entry`() {
+        showSheet()
+
+        assertEquals(0, backCount, "sheet popped its entry without being dismissed")
+    }
+
+    @Test
+    fun `dragging the sheet closed pops its entry`() {
+        showSheet()
+
+        composeTestRule.onNodeWithTag(SheetContentTag).performTouchInput { swipeDown() }
+        composeTestRule.waitForIdle()
+
+        assertEquals(1, backCount, "drag-to-dismiss did not pop the sheet entry")
+    }
+}


### PR DESCRIPTION
## The bug

Drag a sheet that shows over the v2 tab bar closed (region selection from the wallet tab) and the tab bar doesn't come back — it stays hidden until you tap the screen, and that first tap is swallowed rather than doing what you aimed it at.

## Root cause

`UnstyledBottomSheet` (compose-unstyled) has **no dismissal callback**. That wiring existed when the scene used Material3's `ModalBottomSheet` — its `onDismissRequest` popped the nav entry once a user drag settled the sheet to Hidden — and nothing replaced it when the scene was rebuilt on the unstyled sheet in 6e49a91db.

So a drag-dismiss hides the sheet without telling anyone:

- the `AppRoute.Main.Sheet(...)` entry stays on the backstack, so `navigator.currentRouteKey` still resolves to the sheet → `topTab == null` → `AppNavigationBar` keeps the tab bar hidden;
- the scene's full-size scrim is still composed (just animated to alpha 0), so it eats every touch until one lands on its `noRippleClickable { dismiss(true) }`, which — seeing `currentDetent == Hidden` — pops immediately.

That is exactly the reported "doesn't show until you interact with the screen".

## The fix

Watch the sheet's *state* instead of the gesture, so every dismissal route is covered rather than just the drag:

1. wait until the sheet has actually been presented (`targetDetent != Hidden` — targeted, not settled, so an interrupted open animation still counts);
2. then wait for it to settle back at Hidden (`isIdle && currentDetent == Hidden` — a conjunction, because a partial drag flips the target to Hidden and back as the finger crosses the threshold);
3. pop.

Both explicit dismiss paths (`dismiss()`'s animate-then-pop and the `pendingSheetDismiss` replace) now route through the same idempotent `finishDismiss()`, which the settle observer also calls — so the entry pops exactly once per presentation and can't take a second backstack entry with it. The guard resets on `sheetGeneration`, so a same-route dismiss-then-replace still re-arms.

## Tests

New `ModalBottomSheetSceneTest` (Robolectric + compose test rule) — the drag case fails on the pre-fix code (`expected:<1> but was:<0>`) and passes after:

- `dragging the sheet closed pops its entry`
- `an open sheet does not pop its entry` — control, guards the eager/double-pop direction

Verified:

- `:ui:navigation:testDebugUnitTest` — 31 tests, 0 failures (existing `CodeNavigator*` and `InnerFlowNavigator` suites included)
- `:apps:flipcash:core:testDebugUnitTest` + `:apps:flipcash:app:testDebugUnitTest` — green
