### PR TITLE
docs: correct debug applicationId and google-services.json path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Code/Flipcash is a mobile wallet app for instant, global, private payments using
 bundle exec fastlane android flipcash_tests
 ```
 
-**Requirements**: Java 21 (Corretto), `google-services.json` in `apps/flipcash/app/src/`, API keys in `local.properties` (BUGSNAG_API_KEY, MIXPANEL_API_KEY, COINBASE_ONRAMP_API_KEY, GOOGLE_CLOUD_PROJECT_NUMBER). Keys resolve via `tryReadProperty` (local.properties → env var → empty), so a missing key won't fail the build but disables the dependent feature. See `docs/architecture/10-build-and-run.md`.
+**Requirements**: Java 21 (Corretto), `google-services.json` in `apps/flipcash/app/` (CI provisions it at `apps/flipcash/app/src/`; the Google Services plugin accepts either), API keys in `local.properties` (BUGSNAG_API_KEY, MIXPANEL_API_KEY, COINBASE_ONRAMP_API_KEY, GOOGLE_CLOUD_PROJECT_NUMBER). Keys resolve via `tryReadProperty` (local.properties → env var → empty), so a missing key won't fail the build but disables the dependent feature. See `docs/architecture/10-build-and-run.md`.
 
 ## Module Structure
 
@@ -91,7 +91,7 @@ The feature plugin automatically includes `:libs:logging`, `:ui:core`, `:ui:comp
 
 ## Namespaces
 
-- App: `com.flipcash.app.android` (debug: `com.flipcash.app.android.dev`)
+- App: `com.flipcash.app.android` (no `applicationIdSuffix` — debug and release share the ID, so installing one replaces the other)
 - Legacy/shared: `com.getcode`
 - Features: `com.flipcash.features.*`
 - Shared modules: `com.flipcash.shared.*`

--- a/docs/architecture/08-cross-cutting-concerns.md
+++ b/docs/architecture/08-cross-cutting-concerns.md
@@ -96,7 +96,7 @@ Flow-exposure pattern, and lifecycle-aware streaming — are in
 `compileSdk 36`, `minSdk 29`, **Java/Kotlin 21**, all set by the convention plugins
 (see [01](01-modules-and-boundaries.md)). API keys (Bugsnag, Mixpanel, Coinbase
 on-ramp, Google Cloud project number) are read from `local.properties` and surfaced
-through `BuildConfig`; `google-services.json` lives under `apps/flipcash/app/src/`.
+through `BuildConfig`; `google-services.json` lives at `apps/flipcash/app/` (or `apps/flipcash/app/src/`).
 See [10 — Build & run](10-build-and-run.md) for the full list.
 
 ## Why this matters

--- a/docs/architecture/10-build-and-run.md
+++ b/docs/architecture/10-build-and-run.md
@@ -9,7 +9,7 @@ build actually needs from you. This is the day-one setup doc.
 |-------------|-------|
 | **JDK 21** | Amazon Corretto 21 is what CI uses. The convention plugins pin the Java/Kotlin toolchain to 21 ([01](01-modules-and-boundaries.md)). |
 | **Android SDK** | `compileSdk 36`, `minSdk 29`, `targetSdk` per the version catalog. |
-| **`google-services.json`** | Required at `apps/flipcash/app/src/google-services.json` (Firebase). The build fails without it. |
+| **`google-services.json`** | Required (Firebase). Goes at `apps/flipcash/app/google-services.json`; the Google Services plugin also accepts `apps/flipcash/app/src/`, which is where CI provisions it. The build fails without it. |
 | **`local.properties`** | API keys (below) plus the standard `sdk.dir`. |
 
 ## API keys in `local.properties`
@@ -71,7 +71,7 @@ See [12 — Testing](12-testing.md) for the testing approach.
 | | Application ID |
 |---|----------------|
 | Release | `com.flipcash.app.android` |
-| Debug | `com.flipcash.app.android.dev` (suffix lets debug + release coexist on one device) |
+| Debug | `com.flipcash.app.android` — there is no `applicationIdSuffix`, so debug and release share the ID and installing one replaces the other |
 
 The app forces **dark mode** (`MODE_NIGHT_YES`, see [07](07-design-system.md)).
 `versionCode` comes from `Packaging.Flipcash.versionCode` or `gitVersionCode()`.
@@ -93,7 +93,7 @@ and the upload pipeline.
 
 ## Troubleshooting
 
-- **`google-services.json` missing** → place it at `apps/flipcash/app/src/`.
+- **`google-services.json` missing** → place it at `apps/flipcash/app/` (or `apps/flipcash/app/src/`).
 - **A feature behaves as if unconfigured** (no analytics, on-ramp fails) → the
   corresponding key is absent from `local.properties` (the build won't warn loudly,
   because the fallback is an empty string).


### PR DESCRIPTION
Two build-setup claims in the docs no longer match the build.

**Debug `applicationId`** — the docs say debug installs as `com.flipcash.app.android.dev`. There is no `applicationIdSuffix` anywhere in the Gradle files; `apps/flipcash/app/build.gradle.kts` sets `applicationId = appNamespace` with no per-buildType override, so debug and release share `com.flipcash.app.android` and installing one replaces the other. Found this the hard way — `adb shell monkey -p com.flipcash.app.android.dev` returns "No activities found to run".

**`google-services.json` location** — the docs point only at `apps/flipcash/app/src/`. The checked-out copy actually lives at the module root, `apps/flipcash/app/`, and builds fine from there (`processDebugGoogleServices --rerun-tasks` passes). CI writes it to `src/` (`.github/workflows/ci.yml:65`) and also passes, so the Google Services plugin accepts either — the docs now say so rather than naming one path.

Same two claims were repeated across `CLAUDE.md`, `docs/architecture/10-build-and-run.md`, and `docs/architecture/08-cross-cutting-concerns.md`.
