### PR TITLE
feat(featureflags): launch the New UI flag

### DIFF
--- a/apps/flipcash/core/src/main/res/values/strings.xml
+++ b/apps/flipcash/core/src/main/res/values/strings.xml
@@ -142,8 +142,8 @@
 
     <string name="subtitle_appVersionInfoFooter">Version %1$s • Build %2$s%3$s</string>
 
-    <string name="title_labsAreEmpty">Nothing Cooking in the Lab Right Now</string>
-    <string name="subtitle_labsAreEmpty">Check back in the next app update.</string>
+    <string name="title_labsAreEmpty">No Beta Features</string>
+    <string name="subtitle_labsAreEmpty">There are no beta features available right now.</string>
 
     <string name="title_betaOverride">Beta Overrides</string>
     <string name="subtitle_betaOverride">All flags are visible. Toggle off to reset flags to defaults.</string>

--- a/apps/flipcash/features/lab/src/main/kotlin/com/flipcash/app/lab/internal/LabsScreenContent.kt
+++ b/apps/flipcash/features/lab/src/main/kotlin/com/flipcash/app/lab/internal/LabsScreenContent.kt
@@ -164,10 +164,6 @@ internal fun LabsScreenContent(viewModel: LabsScreenViewModel, onboarding: Boole
                         horizontalAlignment = Alignment.CenterHorizontally
                     ) {
                         Text(
-                            text = "\uD83D\uDE2D",
-                            style = CodeTheme.typography.displayMedium
-                        )
-                        Text(
                             text = stringResource(R.string.title_labsAreEmpty),
                             style = CodeTheme.typography.textLarge,
                             color = CodeTheme.colors.textMain
@@ -175,7 +171,7 @@ internal fun LabsScreenContent(viewModel: LabsScreenViewModel, onboarding: Boole
 
                         Text(
                             text = stringResource(R.string.subtitle_labsAreEmpty),
-                            style = CodeTheme.typography.textSmall,
+                            style = CodeTheme.typography.textMedium,
                             color = CodeTheme.colors.textSecondary,
                         )
                     }

--- a/apps/flipcash/shared/featureflags/src/main/kotlin/com/flipcash/app/featureflags/FeatureFlag.kt
+++ b/apps/flipcash/shared/featureflags/src/main/kotlin/com/flipcash/app/featureflags/FeatureFlag.kt
@@ -132,7 +132,12 @@ sealed interface FeatureFlag<T: Any> {
     data object NewUi: FeatureFlag<Boolean> {
         override val key: String = "new_ui_enabled"
         override val default: Boolean = true
-        override val launched: Boolean = false
+        // Launched: the new UI is now the only shell. `launched` makes the controller short-circuit
+        // to `default` — so a user who had toggled this OFF during the beta is moved onto it (their
+        // stored `false` is ignored and cleared on next launch) — and drops it from
+        // `availableEntries`, removing the toggle from Labs. The v1 code it gated is torn out
+        // separately.
+        override val launched: Boolean = true
         override val visible: Boolean = true
         override val persistLogOut: Boolean = true
     }


### PR DESCRIPTION
Marks `FeatureFlag.NewUi` as **launched**, turning the new UI on for everyone and removing the toggle from Labs. This is the first of two changes — the v1 code teardown follows separately.

## Why `launched` rather than just leaving `default = true`

`default` was already `true`, but that only covered users who never touched the toggle. `InternalFeatureFlagController` short-circuits `launched` flags in `get()` and `observe()`:

```kotlin
if (flag.launched) return@map flag.defaultEnabled
```

so a persisted `false` from a beta tester who opted out is now ignored, and the controller's `init` block clears the stored preference on next launch. `launched` also drops the flag from `availableEntries`, which is what removes the row from the Labs list.

`minTrack` was checked and only filters the Labs list — it never gates the value.

## Labs empty state

With `NewUi` out of the list, the empty state is now reachable on tracks where no other flag is visible, so it's aligned with iOS's `SettingsAdvancedBetaFeaturesScreen`: emoji dropped, copy and typography matched.

| | Before | After |
|---|---|---|
| Emoji | 😭 `displayMedium` | — |
| Title | "Nothing Cooking in the Lab Right Now" | "No Beta Features" |
| Subtitle | "Check back in the next app update." `textSmall` | "There are no beta features available right now." `textMedium` |

## Not in this PR

The v1 code the flag gated is still in the tree and now unreachable — the v1 `AppContent`, the v1 `NavigationBar` body, `ScannerNavigationBar`, `BalanceScreen`, and the `isNewUi` plumbing through `CodeNavigator`/`MainRoot`/`AppScreenContent`. That teardown is a separate change, along with the `NavBarConfig` / `FeatureFlag.NavBar` / Labs "Navigation Bar" screen cluster that `NavBarConfig`'s own docs mark for removal with v1.