### PR TITLE
build(codes): declare the kikcode lint tasks' dependency on generated fixtures

### DIFF
--- a/libs/codes/kikcode/build.gradle.kts
+++ b/libs/codes/kikcode/build.gradle.kts
@@ -68,6 +68,12 @@ val generateTestFixtures = tasks.register<GenerateTestFixtures>("generateTestFix
     outputDirectory.set(layout.buildDirectory.dir("generated/testFixtures"))
 }
 
+// `srcDir(taskProvider)` below carries the task dependency to the Kotlin compile tasks only; AGP's
+// lint tasks read the same source directories straight off disk, so Gradle fails the build over an
+// undeclared dependency on the generated fixtures. Wire it up by hand.
+tasks.matching { it.name.startsWith("lint") || it.name.endsWith("LintModel") }
+    .configureEach { dependsOn(generateTestFixtures) }
+
 kotlin {
     android {
         namespace = "com.getcode.codes.kikcode"


### PR DESCRIPTION
CI on `code/cash` is red since #1287: the `Run Flipcash Tests` job fails with two Gradle validation errors in `:libs:codes:kikcode`.

```
A problem was found with the configuration of task ':libs:codes:kikcode:lintAnalyzeAndroidHostTest'.
Property has implicit dependency
  Task ':libs:codes:kikcode:lintAnalyzeAndroidHostTest' uses this output of task
  ':libs:codes:kikcode:generateTestFixtures' without declaring an explicit or implicit dependency.
```

`commonTest`'s `kotlin.srcDir(generateTestFixtures)` carries the task dependency to the Kotlin compile tasks only. AGP's `lintAnalyzeAndroidHostTest` and `generateAndroidHostTestLintModel` read the same source directories straight off disk, so Gradle rejects the build whenever `generateTestFixtures` and those lint tasks land in one task graph — exactly what CI's `flipcashTestDebug :apps:flipcash:app:lintDebug` invocation does.

This declares the dependency explicitly for the module's lint tasks. The name filter only matches `lintAnalyze*` / `*LintModel` tasks, so the lint-jar/`compileLint` tasks are untouched.