### PR TITLE
build(base58): declare the base58 lint tasks' dependency on generated fixtures

### DIFF
--- a/libs/encryption/base58/build.gradle.kts
+++ b/libs/encryption/base58/build.gradle.kts
@@ -68,6 +68,12 @@ val generateTestFixtures = tasks.register<GenerateTestFixtures>("generateTestFix
     outputDirectory.set(layout.buildDirectory.dir("generated/testFixtures"))
 }
 
+// `srcDir(taskProvider)` below carries the task dependency to the Kotlin compile tasks only; AGP's
+// lint tasks read the same source directories straight off disk, so Gradle fails the build over an
+// undeclared dependency on the generated fixtures. Wire it up by hand.
+tasks.matching { it.name.startsWith("lint") || it.name.endsWith("LintModel") }
+    .configureEach { dependsOn(generateTestFixtures) }
+
 kotlin {
     android {
         namespace = "com.getcode.encryption.base58"


### PR DESCRIPTION
`code/cash` is red at HEAD, so every open PR is currently failing on a build-config error unrelated to its own changes.

#1289 introduced a `GenerateTestFixtures` task in `:libs:encryption:base58`, wired into the build via `commonTest { kotlin.srcDir(generateTestFixtures) }`. That form carries the task dependency to the Kotlin compile tasks only — AGP's `generateAndroidHostTestLintModel` and `lintAnalyzeAndroidHostTest` read the same source directories straight off disk, so Gradle fails on an undeclared dependency on `build/generated/testFixtures` once both land in one task graph. That is exactly what CI's `flipcashTestDebug :apps:flipcash:app:lintDebug` does:

```
A problem was found with the configuration of task
':libs:encryption:base58:generateAndroidHostTestLintModel' (type 'LintModelWriterTask').
Property has implicit dependency
  Task ':libs:encryption:base58:generateAndroidHostTestLintModel' uses this output of task
  ':libs:encryption:base58:generateTestFixtures' without declaring an explicit or implicit dependency.
```

This is the same wiring #1288 added to `:libs:codes:kikcode` a minute earlier. #1289's own CI was already failing on this when it merged.

## Follow-up

The `GenerateTestFixtures` task classes in `base58` and `kikcode` are now byte-identical apart from the generated package name. That copy-paste is why this broke twice — extracting it into a `build-logic` convention plugin that wires the lint dependency automatically would stop a third recurrence.