### PR TITLE
ci(shared-core): write a placeholder local.properties before publishing

### DIFF
--- a/.github/workflows/publish-shared-core.yml
+++ b/.github/workflows/publish-shared-core.yml
@@ -52,6 +52,21 @@ jobs:
           path: spm-repo
           token: ${{ secrets.SHARED_CORE_PUBLISH_TOKEN }}
 
+      # Gradle configures every project in the build, and the Android app applies the
+      # secrets plugin, which fails configuration outright when `local.properties` is
+      # absent. This lane only builds the KMP module — nothing here compiles the app or
+      # talks to any of these services — so obviously-fake values are enough to get
+      # through configuration without handing this workflow the real secrets.
+      - name: Write placeholder local.properties
+        run: |
+          set -euo pipefail
+          {
+            echo 'BUGSNAG_API_KEY="00000000000000000000000000000000"'
+            echo 'GOOGLE_CLOUD_PROJECT_NUMBER=000000000000'
+            echo 'MIXPANEL_API_KEY="00000000000000000000000000000000"'
+            echo 'COINBASE_ONRAMP_API_KEY=00000000-0000-0000-0000-000000000000'
+          } > ./local.properties
+
       - name: Build the XCFramework, upload it, and update Package.swift
         env:
           # Gradle reads ORG_GRADLE_PROJECT_-prefixed vars as project properties,


### PR DESCRIPTION
The first `Publish SharedCore` run failed before it reached the KMP module: Gradle
configures every project in the build, and the Android app applies the secrets plugin,
which fails configuration outright when `local.properties` is missing.

This lane only builds `:kmp:shared-core` — nothing in it compiles the app or talks to
Bugsnag, Mixpanel, or Coinbase — so it writes obviously-fake values rather than taking
on the real secrets, mirroring the placeholder handling already in `ci.yml`.

With this step in place the workflow published `0.1.0` end to end: the `SharedCore.xcframework.zip`
release asset, the generated `Package.swift`, and the `0.1.0` tag on the commit that references it,
all in `code-payments/flipcash-shared-core-spm`.