### PR TITLE
chore(tokens): drop the unreachable sell branch from the swap success title

### DIFF
--- a/apps/flipcash/core/src/main/res/values/strings.xml
+++ b/apps/flipcash/core/src/main/res/values/strings.xml
@@ -536,7 +536,6 @@
     <string name="label_blendModeColorDodge">Color Dodge</string>
     <string name="label_blendModePlusLighter">Plus Lighter</string>
 
-    <string name="title_cashReserves">USDF</string>
     <string name="action_buyMore">Buy More</string>
 
     <string name="title_addMoney">Add Money</string>

--- a/apps/flipcash/features/tokens/src/main/kotlin/com/flipcash/app/tokens/internal/TokenTxProcessingScreen.kt
+++ b/apps/flipcash/features/tokens/src/main/kotlin/com/flipcash/app/tokens/internal/TokenTxProcessingScreen.kt
@@ -130,9 +130,13 @@ private fun TokenTxProcessingScreen(
                         val name = when (state.purpose) {
                             is SwapPurpose.Convert -> state.destinationTokenName
                             is SwapPurpose.BalanceIncrease -> state.tokenName
-                            else -> stringResource(R.string.title_cashReserves)
+                            // Selling is unreachable now that the v1 token screen is gone, and a
+                            // purpose is always set by the time a swap reaches this screen.
+                            else -> null
                         }
-                        state.netTransferAmount.formatted(suffix = stringResource(R.string.label_ofToken, name))
+                        state.netTransferAmount.formatted(
+                            suffix = name?.let { stringResource(R.string.label_ofToken, it) },
+                        )
                     }
                 },
                 style = CodeTheme.typography.textLarge,


### PR DESCRIPTION
Stacked on #1290 — base it there, not `code/cash`. Merge that first.

#1290 guts `TokenInfoScreen.kt` (-404 lines), taking the v1 `ButtonOptions` Sell button with it. That was the only place a `SwapPurpose.Sell` was ever constructed; the v2 action row offers Give, Convert, and Withdraw. So the swap-processing success title can no longer be reached as a sell.

That title's `else` arm existed to name the reserve for exactly that case:

```kotlin
is SwapPurpose.Convert -> state.destinationTokenName
is SwapPurpose.BalanceIncrease -> state.tokenName
else -> stringResource(R.string.title_cashReserves)
```

Now it catches only a sell that can't happen and a null purpose. This makes the two reachable purposes explicit and lets the fallback go unnamed rather than claim a destination it can't have — `Fiat.formatted` already takes a nullable `suffix`, so no signature change. `title_cashReserves` had no other reference and goes with it.

### Deliberately left alone

- **`SwapPurpose.Sell`** and **`BalanceDecrease`** stay. `Sell` is unreachable but still referenced by `SwapViewModel` (5 sites), `AppRoute.kt:226`, and the still-routed `TokenSellReceiptScreen`, plus two tests. Deleting the type is a much wider change than this one — worth its own PR. `BalanceDecrease` is also implemented by `Convert`.
- **`canSell`** stays — it's a computed property the **Convert** flow reads at `TokenInfoViewModel.kt:336` to gate the "no balance yet" bottom bar.
- **`action_sell`** stays — still used by `TokenSellReceiptScreen.kt:74`.

### Conflict note

`feat/usdc-to-dollars-conversion-graphic` (commit `602ac8960`) touches this same `when` to suppress the "of <currency>" suffix for non-Flexible Buy and reserve-bound Convert. Both changes converge on a nullable suffix, so resolution is mechanical — keep that branch's `Buy`/`Convert` arms and this branch's dropped sell fallback.