### PR TITLE
fix(splash): stop launch logo bleeding through transparent screens

### DIFF
--- a/apps/flipcash/app/src/main/kotlin/com/flipcash/app/internal/ui/App.kt
+++ b/apps/flipcash/app/src/main/kotlin/com/flipcash/app/internal/ui/App.kt
@@ -9,7 +9,9 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
@@ -170,7 +172,7 @@ internal fun App(
 
                     val scrimController = remember { ScrimController() }
 
-                    Box(modifier = semanticsModifier) {
+                    Box(modifier = semanticsModifier.fillMaxSize().background(CodeTheme.colors.background)) {
                         SharedTransitionLayout {
                             CompositionLocalProvider(
                                 LocalCodeNavigator provides codeNavigator,


### PR DESCRIPTION
## Problem

Users see the Flipcash \"F\" launch logo (white rounded-pill mark, no wordmark) stuck on screen over fully-interactive content — My Account settings, the Wallet tab, and chat threads — across the entire session. The logo appears centered on those screens but is absent on the You tab and Chat tab home.

## Root cause

`android:windowBackground` in `Theme.Code` is set to `@drawable/splash` (a layer-list: `splash_background` color + `ic_launcher_foreground` centered). This drawable is **never cleared** after `MainActivity.setContent {}`. Once Compose renders its first frame the window background sits in the `DecorView` behind the Compose surface for the Activity's entire lifetime.

The outermost Compose root `Box` in `App.kt` had no background modifier, so whether the window drawable bled through depended on whether each screen's own root happened to paint a full-size opaque background:

- **You tab (`MenuScreenContent`)** — uses `CodeScaffold` → Material `Scaffold(backgroundColor = CodeTheme.colors.background)` → opaque; "F" hidden.
- **My Account (`MyAccountScreen`)** — bare `Column(fillMaxSize)` with no background modifier → transparent; "F" bleeds through.
- **Wallet (`WalletScreen`)** — bare `Column` / `LazyColumn` with no background → transparent center; "F" bleeds through.
- **Chat tab (`MessengerScreen`)** — paints its own opaque background; "F" hidden.

The logo is the window drawable (behind Compose), not a Compose element — `navigator.replaceAll` and all nav transitions have no effect on it.

## Fix

Paint `CodeTheme.colors.background` (`#19191A`, identical to `splash_background`) on the single outermost root `Box` in `App.kt` that wraps both `NewAppContent` and `AppContent`. One change covers all screens on both nav paths.

```diff
-Box(modifier = semanticsModifier) {
+Box(modifier = semanticsModifier.fillMaxSize().background(CodeTheme.colors.background)) {
```

The cold-start splash (window background visible before the first Compose frame) is unchanged — the fix only prevents bleed-through after Compose takes the surface.

## Safety

- **Haze/blur** (`hazeSource` on the inner `Box` in `NewAppContent`): unaffected. Haze only samples Compose-layer pixels; its source node is a child of this root Box, not behind it. The backdrop color used by the nav bar blur (`CodeTheme.colors.background`) is unchanged.
- **Nav3 `OverlayScene` / bottom-sheets**: unaffected. Their transparency is inter-Compose-layer (showing the screen behind them in the Compose hierarchy), which this change does not touch. The opaque root Box is below the entire `NavDisplay`.
- **No screen intentionally relies on seeing the window drawable**: confirmed by searching all Kotlin source for `R.drawable.splash`, `ic_launcher_foreground`, `windowIsTranslucent`, and translucent-theme patterns — zero hits in non-build-artifact files.