### PR TITLE
style(wallet): tighten the gap under the wallet action tiles

### DIFF
--- a/apps/flipcash/features/balance/src/main/kotlin/com/flipcash/app/balance/internal/WalletScreenContent.kt
+++ b/apps/flipcash/features/balance/src/main/kotlin/com/flipcash/app/balance/internal/WalletScreenContent.kt
@@ -124,7 +124,10 @@ internal fun WalletScreenContent(
             top = CodeTheme.dimens.inset,
             start = CodeTheme.dimens.inset,
             end = CodeTheme.dimens.inset,
-            bottom = LocalTabBarPadding.current.calculateBottomPadding() + CodeTheme.dimens.grid.x12,
+            // Clearance under the last row (the action tiles) once the list is scrolled to the end. The
+            // tab-bar inset already covers the floating bar and its own 15 dp drop, so this is only the
+            // visible gap above the bar: 40 dp, matching iOS (a 96 pt trailing spacer against a 58 pt bar).
+            bottom = LocalTabBarPadding.current.calculateBottomPadding() + CodeTheme.dimens.grid.x8,
         ),
     ) {
         item {


### PR DESCRIPTION
Scrolled to the end of the wallet tab, the 2x2 action tiles left 60 dp of air above the floating tab bar. That 60 dp sits on top of `LocalTabBarPadding`, which already covers the bar, its 15 dp drop and the navigation-bar inset, so it read as a large empty band under the last row.

This drops the extra clearance to 40 dp (`grid.x8`), matching what iOS leaves under the same tiles: a 96 pt trailing spacer against a 58 pt bar.

Only the `LazyColumn`'s bottom `contentPadding` changes; nothing else on the screen moves.
