### PR TITLE
feat(userflags): surface the username minimum balance flag

### DIFF
--- a/apps/flipcash/features/userflags/src/main/kotlin/com/flipcash/app/userflags/internal/UserFlagsViewModel.kt
+++ b/apps/flipcash/features/userflags/src/main/kotlin/com/flipcash/app/userflags/internal/UserFlagsViewModel.kt
@@ -77,6 +77,11 @@ internal class UserFlagsViewModel @Inject constructor(
                                 "High ${format(presets.high)}",
                             ).joinToString(separator = "\n")
                         ),
+                        ReadOnlyTextEntry(
+                            R.string.label_flag_usernameMinBalance,
+                            flags.data.usernameMinBalance.effectiveValue
+                                .formatted(rule = Fiat.FormattingRule.Truncated)
+                        ),
                     )
                 }
 

--- a/apps/flipcash/shared/userflags/src/main/kotlin/com/flipcash/app/userflags/ResolvedUserFlags.kt
+++ b/apps/flipcash/shared/userflags/src/main/kotlin/com/flipcash/app/userflags/ResolvedUserFlags.kt
@@ -36,6 +36,7 @@ data class ResolvedUserFlags(
     val minimumHolderAmountForLeaderboard: ResolvedFlag<Fiat>,
     val requireCoinbaseEmailVerification: ResolvedFlag<Boolean>,
     val tipPresets: ResolvedFlag<List<TipPresets>>,
+    val usernameMinBalance: ResolvedFlag<Fiat>,
 )
 
 internal fun UserFlags.resolve(overrides: Overrides): ResolvedUserFlags = ResolvedUserFlags(
@@ -54,4 +55,5 @@ internal fun UserFlags.resolve(overrides: Overrides): ResolvedUserFlags = Resolv
     minimumHolderAmountForLeaderboard = ResolvedFlag(minimumHolderValue, overrides.minimumHolderAmountForLeaderboard),
     requireCoinbaseEmailVerification = ResolvedFlag(requireCoinbaseEmailVerification, overrides.requireCoinbaseEmailVerification),
     tipPresets = ResolvedFlag(tipPresets, FieldOverride.None),
+    usernameMinBalance = ResolvedFlag(usernameMinBalance, FieldOverride.None),
 )

--- a/apps/flipcash/shared/userflags/src/main/kotlin/com/flipcash/app/userflags/UserFlagsCoordinator.kt
+++ b/apps/flipcash/shared/userflags/src/main/kotlin/com/flipcash/app/userflags/UserFlagsCoordinator.kt
@@ -181,6 +181,7 @@ private data class CachedFlags(
     val minimumHolderValue: CachedFiat,
     val requireCoinbaseEmailVerification: Boolean,
     val tipPresets: List<CachedTipPresets> = emptyList(),
+    val usernameMinBalance: CachedFiat = CachedFiat(quarks = 0),
 ) {
     fun toDomain(): UserFlags = UserFlags(
         isStaff = isStaff,
@@ -200,6 +201,7 @@ private data class CachedFlags(
         minimumHolderValue = minimumHolderValue.toDomain(),
         requireCoinbaseEmailVerification = requireCoinbaseEmailVerification,
         tipPresets = tipPresets.map { it.toDomain() },
+        usernameMinBalance = usernameMinBalance.toDomain(),
     )
 
     companion object {
@@ -223,6 +225,7 @@ private data class CachedFlags(
             minimumHolderValue = CachedFiat.fromDomain(flags.minimumHolderValue),
             requireCoinbaseEmailVerification = flags.requireCoinbaseEmailVerification,
             tipPresets = flags.tipPresets.map { CachedTipPresets.fromDomain(it) },
+            usernameMinBalance = CachedFiat.fromDomain(flags.usernameMinBalance),
         )
     }
 }

--- a/apps/flipcash/shared/userflags/src/main/res/values/strings.xml
+++ b/apps/flipcash/shared/userflags/src/main/res/values/strings.xml
@@ -22,4 +22,5 @@
     <string name="label_flag_minHolderAmount">Minimum Holder Amount for Leaderboard</string>
     <string name="hint_flag_minHolderAmount">Enter amount</string>
     <string name="label_flag_tipPresets">Tip Presets</string>
+    <string name="label_flag_usernameMinBalance">Username Minimum Balance</string>
 </resources>

--- a/definitions/flipcash/protos/src/main/proto/account/v1/flipcash_account_service.proto
+++ b/definitions/flipcash/protos/src/main/proto/account/v1/flipcash_account_service.proto
@@ -169,6 +169,9 @@ message UserFlags {
 
 	// Tip presets for all currencies
 	repeated TipPresets tip_presets = 15;
+
+	// USDF amount, in quarks, that must be held across all currencies in order to set a username
+	uint64 username_min_balance = 16;
 }
 
 message TipPresets {

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/internal/domain/UserFlagsMapper.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/internal/domain/UserFlagsMapper.kt
@@ -31,6 +31,7 @@ internal class UserFlagsMapper @Inject constructor():
             minimumHolderValue = Fiat(quarks = from.minimumHolderValue),
             requireCoinbaseEmailVerification = from.requireCoinbaseEmailVerification,
             tipPresets = from.tipPresetsList.map { it.toDomain() },
+            usernameMinBalance = Fiat(quarks = from.usernameMinBalance),
         )
     }
 }

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/models/UserFlags.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/models/UserFlags.kt
@@ -21,6 +21,8 @@ data class UserFlags(
     val minimumHolderValue: Fiat,
     val requireCoinbaseEmailVerification: Boolean,
     val tipPresets: List<TipPresets>,
+    // USDF that must be held across all currencies before a username can be set.
+    val usernameMinBalance: Fiat,
 ) {
     companion object {
         val Default = UserFlags(
@@ -39,6 +41,7 @@ data class UserFlags(
             minimumHolderValue = Fiat.Zero,
             requireCoinbaseEmailVerification = false,
             tipPresets = emptyList(),
+            usernameMinBalance = Fiat.Zero,
         )
     }
 }


### PR DESCRIPTION
`UserFlags` gained `username_min_balance` upstream — the USDF amount, in quarks, a user must hold across all currencies before setting a username. This vendors the proto change and maps the field through to the domain model and the debug flag editor.

It gates the username claim flow whose service layer landed in #1320. That flow has no UI yet, so nothing reads this value so far.

## Read-only, not overridable

Every other `Fiat` flag is overridable in the debug editor; this one isn't. The practical cost: exercising the claim gate locally means having the server send a non-zero value, since you can't force one from the editor.

`ReadOnlyEntry` holds a `Boolean`, so the amount goes in `readOnlyTextEntries` next to `tipPresets`, formatted with `Fiat.FormattingRule.Truncated` to match how `WithdrawalFeeAmount` renders.

## Default is `Fiat.Zero`

The fee and price flags (`newCurrencyPurchaseAmount`, `newCurrencyFeeAmount`) default to `Fiat.MAX_VALUE` — for an amount the user pays, an unknown value should fail closed. This one is a minimum balance to *hold*, the same shape as `minimumHolderValue`, so it takes that flag's `Fiat.Zero` default instead.

Zero means an absent flag leaves the gate open and the server's `INSUFFICIENT_BALANCE` result stays the real enforcement, rather than hard-blocking a claim the server would have allowed. The tradeoff to be aware of: a silent mapping failure would look identical to "no gate configured."

The resemblance to `minimumHolderValue` stops at the default. `minimumHolderValue` is a per-mint threshold — `TokenDiscoveryViewModel` checks it against one token's balance — whereas `username_min_balance` is cumulative across every mint. Whoever writes the claim gate should compare it against the summed balance (`LocalFiat.underlyingTokenAmount`), not a single token's. The domain property carries that note in a comment.

## `CachedFlags` needed the field too

`UserFlagsCoordinator` holds a `@Serializable` cache model whose `toDomain()` reconstructs the whole `UserFlags`, so it doesn't compile without the new field. It defaults to zero quarks so payloads cached before this change still decode — the read path does `runCatching { json.decodeFromString<CachedFlags>(raw) }.getOrNull() ?: return`, which discards the entire cached flag set on a decode failure. An undefaulted field would blank the flags on the first launch after upgrade.
