### PR TITLE
fix(userflags): add the new flag to the ResolvedUserFlags fixture

### DIFF
--- a/apps/flipcash/shared/userflags/src/test/kotlin/com/flipcash/app/userflags/ResolvedUserFlagsTest.kt
+++ b/apps/flipcash/shared/userflags/src/test/kotlin/com/flipcash/app/userflags/ResolvedUserFlagsTest.kt
@@ -35,6 +35,7 @@ class ResolvedUserFlagsTest {
         assertEquals(Fiat(quarks = 4_000_000L), resolved.minimumHolderAmountForLeaderboard.effectiveValue)
         assertEquals(true, resolved.requireCoinbaseEmailVerification.effectiveValue)
         assertEquals(ServerFlags.tipPresets, resolved.tipPresets.effectiveValue)
+        assertEquals(Fiat(quarks = 5_000_000L), resolved.usernameMinBalance.effectiveValue)
     }
 
     @Test
@@ -140,6 +141,7 @@ private val ServerFlags = UserFlags(
     tipPresets = listOf(
         TipPresets(region = "US", minimum = 1.0, low = 2.0, medium = 3.0, high = 4.0),
     ),
+    usernameMinBalance = Fiat(quarks = 5_000_000L),
 )
 
 // Every value here differs from the matching server value above, so a flag that reads the


### PR DESCRIPTION
`usernameMinBalance` landed on `UserFlags` in #1322 without a default, so `ResolvedUserFlagsTest`'s fixture no longer compiles. `code/cash` is red, and with it every open PR:

```
ResolvedUserFlagsTest.kt:140:5 No value passed for parameter 'usernameMinBalance'
```

The flag resolves with `FieldOverride.None`, so it isn't overridable and needs no `OverrideCase` — the completeness guard covers `Overrides` fields, not `UserFlags` fields. That leaves the fixture value and the assertion that `resolve without overrides exposes the server value for every flag` already promises by name.