### PR TITLE
chore(services): consume the client-protocol artifacts from Maven Central

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -64,6 +64,12 @@ protobuf = "4.35.1"
 protobuf-plugin = "0.10.0"
 protovalidate-kt = "0.1.1"
 
+# Generated client SDKs for the two backend contracts. Separate versions on purpose: the
+# protos are independent (flipcash2 does not import ocp), so the packages move on their own
+# cadence and there is nothing to keep aligned.
+ocp-client-protocol = "0.1.0"
+flipcash2-client-protocol = "0.1.0"
+
 # The Android port is the ONLY libphonenumber this app depends on, deliberately. Google's
 # `com.googlecode` artifact used to sit alongside it; the two ship separate copies of the metadata,
 # so any version skew between them meant they could disagree on whether a number is valid — and the
@@ -215,6 +221,8 @@ grpc-protobuf-lite = { module = "io.grpc:grpc-protobuf-lite", version.ref = "grp
 grpc-stub = { module = "io.grpc:grpc-stub", version.ref = "grpc" }
 protobuf-kotlin-lite = { module = "com.google.protobuf:protobuf-kotlin-lite", version.ref = "protobuf" }
 protobuf-validate-runtime = { module = "dev.bmcreations:protovalidate-runtime", version.ref = "protovalidate-kt" }
+ocp-client-protocol = { module = "com.flipcash:ocp-client-protocol", version.ref = "ocp-client-protocol" }
+flipcash2-client-protocol = { module = "com.flipcash:flipcash2-client-protocol", version.ref = "flipcash2-client-protocol" }
 
 # Retrofit
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }

--- a/services/flipcash/build.gradle.kts
+++ b/services/flipcash/build.gradle.kts
@@ -24,7 +24,7 @@ android {
 }
 
 dependencies {
-    implementation("com.flipcash:flipcash2-client-protocol:0.1.0")
+    implementation(libs.flipcash2.client.protocol)
     api(project(":libs:network:jwt"))
     api(project(":services:opencode"))
     implementation(project(":ui:resources"))

--- a/services/flipcash/build.gradle.kts
+++ b/services/flipcash/build.gradle.kts
@@ -24,7 +24,7 @@ android {
 }
 
 dependencies {
-    implementation("com.flipcash:flipcash2-client-protocol:0.1.0-SNAPSHOT")
+    implementation("com.flipcash:flipcash2-client-protocol:0.1.0")
     api(project(":libs:network:jwt"))
     api(project(":services:opencode"))
     implementation(project(":ui:resources"))

--- a/services/flipcash/build.gradle.kts
+++ b/services/flipcash/build.gradle.kts
@@ -24,7 +24,7 @@ android {
 }
 
 dependencies {
-    implementation(project(":definitions:flipcash:models"))
+    implementation("com.flipcash:flipcash2-client-protocol:0.1.0-SNAPSHOT")
     api(project(":libs:network:jwt"))
     api(project(":services:opencode"))
     implementation(project(":ui:resources"))

--- a/services/opencode/build.gradle.kts
+++ b/services/opencode/build.gradle.kts
@@ -27,7 +27,7 @@ android {
 }
 
 dependencies {
-    implementation("com.flipcash:ocp-client-protocol:0.1.0")
+    implementation(libs.ocp.client.protocol)
     api(project(":libs:currency-math"))
     api(project(":libs:datetime"))
     api(project(":libs:encryption:base58"))

--- a/services/opencode/build.gradle.kts
+++ b/services/opencode/build.gradle.kts
@@ -27,7 +27,7 @@ android {
 }
 
 dependencies {
-    implementation("com.flipcash:ocp-client-protocol:0.1.0-SNAPSHOT")
+    implementation("com.flipcash:ocp-client-protocol:0.1.0")
     api(project(":libs:currency-math"))
     api(project(":libs:datetime"))
     api(project(":libs:encryption:base58"))

--- a/services/opencode/build.gradle.kts
+++ b/services/opencode/build.gradle.kts
@@ -27,7 +27,7 @@ android {
 }
 
 dependencies {
-    implementation(project(":definitions:opencode:models"))
+    implementation("com.codeinc.opencode:ocp-client-protocol:0.1.0-SNAPSHOT")
     api(project(":libs:currency-math"))
     api(project(":libs:datetime"))
     api(project(":libs:encryption:base58"))

--- a/services/opencode/build.gradle.kts
+++ b/services/opencode/build.gradle.kts
@@ -27,7 +27,7 @@ android {
 }
 
 dependencies {
-    implementation("com.codeinc.opencode:ocp-client-protocol:0.1.0-SNAPSHOT")
+    implementation("com.flipcash:ocp-client-protocol:0.1.0-SNAPSHOT")
     api(project(":libs:currency-math"))
     api(project(":libs:datetime"))
     api(project(":libs:encryption:base58"))


### PR DESCRIPTION
`:services:opencode` and `:services:flipcash` now depend on published packages instead of the
in-repo generated proto modules:

```diff
-implementation(project(":definitions:opencode:models"))
+implementation("com.flipcash:ocp-client-protocol:0.1.0")

-implementation(project(":definitions:flipcash:models"))
+implementation("com.flipcash:flipcash2-client-protocol:0.1.0")
```

Both artifacts are on Maven Central, generated by
[ocp-client-protocol](https://github.com/code-payments/ocp-client-protocol) and
[flipcash2-client-protocol](https://github.com/code-payments/flipcash2-client-protocol) from the
same upstream contracts this repo vendors today. Their generated Kotlin is byte-identical to what
`:definitions:*:models` produces — 263 files for OCP, 526 for Flipcash, checked per generator and
gated in each repo's CI. That equivalence is why this is a two-line change and not a migration.

Artifact coordinates and generated namespace are deliberately different. The packages publish
under `com.flipcash`; the code inside stays in `com.codeinc.opencode.gen.*` and
`com.codeinc.flipcash.gen.*`, which is set by `java_package` in the protos. No imports move.

Two dependencies that the app's graph used to supply incidentally are now declared by the
artifacts themselves: `protovalidate-runtime` and `kotlinx-coroutines`. The generated grpckt stubs
reference `kotlinx.coroutines.flow.Flow`, and a standalone artifact cannot rely on picking that up
from a consumer.

`:definitions:opencode:models` and `:definitions:flipcash:models` now have no consumers. They stay
in place here — removing them, along with the `fetch-protos.sh` machinery behind them, belongs in
its own change once iOS also consumes the packages.
