### PR TITLE
feat(gradle): build the contract packages from local checkouts

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,6 +21,36 @@ plugins {
     id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 
+// The contract packages are consumed at the versions pinned in gradle/libs.versions.toml,
+// which means trying a proto change would mean publishing one. Point protoLocalRoot at the
+// directory holding ocp-client-protocol/ and flipcash2-client-protocol/ to build against
+// those checkouts instead:
+//
+//     # local.properties
+//     protoLocalRoot=/Users/you/dev/bmcreations/code
+//
+// Gradle substitutes com.flipcash:ocp-client-protocol and com.flipcash:flipcash2-client-protocol
+// for the included builds on its own, because the coordinates match. The version in
+// libs.versions.toml is ignored while this is on.
+//
+// local.properties is untracked and CI never writes it, so release builds always resolve the
+// pinned versions from Maven Central.
+val protoLocalRoot = java.util.Properties().apply {
+    val f = File(settingsDir, "local.properties")
+    if (f.exists()) f.inputStream().use { load(it) }
+}.getProperty("protoLocalRoot")?.trim()?.takeIf { it.isNotEmpty() }
+
+if (protoLocalRoot != null) {
+    listOf("ocp-client-protocol", "flipcash2-client-protocol").forEach { repo ->
+        val dir = File(protoLocalRoot, repo)
+        require(dir.isDirectory) {
+            "protoLocalRoot=$protoLocalRoot has no $repo checkout in it"
+        }
+        includeBuild(dir)
+    }
+    logger.lifecycle("Contract packages: building from $protoLocalRoot, not the pinned versions")
+}
+
 dependencyResolutionManagement {
     repositoriesMode = RepositoriesMode.PREFER_SETTINGS
     repositories {


### PR DESCRIPTION
Changing a `.proto` and seeing it in the app required a real release of the client packages, because
`gradle/libs.versions.toml` is the only way in. Maven Central will not take a version number twice,
so iterating burned versions.

`settings.gradle.kts` now reads an optional `protoLocalRoot` from `local.properties`. When it is
set, the build includes `ocp-client-protocol` and `flipcash2-client-protocol` from that directory as
composite builds. Gradle substitutes them for `com.flipcash:ocp-client-protocol` and
`com.flipcash:flipcash2-client-protocol` on its own because the coordinates match, so no module
declares anything different and the pinned versions are ignored while the override is on. A missing
checkout fails configuration with the path it looked for rather than silently falling back.

The opt-in lives in `local.properties`, which is untracked and never written by CI, so a release
build resolves the version pins exactly as it does today.

Substitution is confirmed rather than assumed: with both versions temporarily pinned to a
nonexistent `99.99.99`, resolution succeeds with `protoLocalRoot` set and reports
`com.flipcash:ocp-client-protocol:99.99.99 FAILED` without it. A message appended to an uncommitted
`.proto` reached `com.codeinc.opencode.gen.common.v1.LocalDevProbe`, and
`:services:opencode:compileDebugKotlin` built against it.

Pairs with the client-repo change that lets the contract itself be synced from a local checkout:
code-payments/ocp-client-protocol#3 and code-payments/flipcash2-client-protocol#3.
