### PR TITLE
chore(discovery): say "members" instead of "people"

### DIFF
--- a/apps/flipcash/core/src/main/res/values/strings.xml
+++ b/apps/flipcash/core/src/main/res/values/strings.xml
@@ -244,10 +244,10 @@
     <string name="error_title_paymentFailedDueToInsufficientFunds">Insufficient Balance</string>
     <string name="error_description_paymentFailedDueToInsufficientFunds">You don\'t have enough funds to complete this payment</string>
 
-    <plurals name="subtitle_personCount">
-        <item quantity="zero">0 people</item>
-        <item quantity="one">1 person</item>
-        <item quantity="other">%1$s people</item>
+    <plurals name="subtitle_memberCount">
+        <item quantity="zero">0 members</item>
+        <item quantity="one">1 member</item>
+        <item quantity="other">%1$s members</item>
     </plurals>
 
     <string name="action_addCash">Add Cash</string>
@@ -826,7 +826,7 @@
 
     <string name="content_description_leaderboard">Learn more</string>
     <string name="prompt_title_learnAboutLeaderboard">Leaderboard Ranking</string>
-    <string name="prompt_description_learnAboutLeaderboard">People must have a minimum balance of %1$s to be counted</string>
+    <string name="prompt_description_learnAboutLeaderboard">Members must have a minimum balance of %1$s to be counted</string>
 
     <string name="action_invite">Invite</string>
     <string name="action_remove">Remove</string>

--- a/apps/flipcash/features/discovery/src/main/kotlin/com/flipcash/app/discovery/internal/components/TokenMetricsRow.kt
+++ b/apps/flipcash/features/discovery/src/main/kotlin/com/flipcash/app/discovery/internal/components/TokenMetricsRow.kt
@@ -97,7 +97,7 @@ internal fun TokenMetricsRow(
             val subtitle = token.marketCap()?.formatted().orEmpty()
 
             val value = pluralStringResource(
-                R.plurals.subtitle_personCount,
+                R.plurals.subtitle_memberCount,
                 token.holderMetrics.currentHolders.toInt(),
                 token.holderMetrics.currentHolders.abbreviated()
             )
@@ -146,7 +146,7 @@ internal fun TokenMetricsRow(
             val value = currentCap?.let { "$currencySymbol${it.abbreviated()}" }.orEmpty()
 
             val subtitle = pluralStringResource(
-                R.plurals.subtitle_personCount,
+                R.plurals.subtitle_memberCount,
                 token.holderMetrics.currentHolders.toInt(),
                 token.holderMetrics.currentHolders.abbreviated()
             )


### PR DESCRIPTION
The leaderboard subtitle and the leaderboard info prompt both described token holders as people. Both now say "members".

- `subtitle_personCount` → `subtitle_memberCount` ("0 members" / "1 member" / "%1$s members"). The plural is only referenced from the Discovery leaderboard rows, so the key is renamed rather than left stale.
- `prompt_description_learnAboutLeaderboard` → "Members must have a minimum balance of %1$s to be counted".

Internal `holder` naming (`HolderMetrics`, `currentHolders`, `RankingSystem.Holders`, `minimumHolderAmount`) is unchanged — none of it is user-facing, and it mirrors the backend model. The remaining "people" strings in the app (contacts permission rationale, blocklist empty state, tip chat header) are outside Discovery and untouched.