### PR TITLE
feat(tokens): replace Get with Buy In, swap Withdraw for Buy More

### DIFF
--- a/apps/flipcash/core/src/main/kotlin/com/flipcash/app/core/tokens/SwapStep.kt
+++ b/apps/flipcash/core/src/main/kotlin/com/flipcash/app/core/tokens/SwapStep.kt
@@ -40,7 +40,7 @@ sealed interface SwapStep : FlowStep, Parcelable {
     data object ConvertDestinationSelection : SwapStep, Sheet, WrapContentSheet, HalfSheet
 
     /**
-     * v2 Get only: the payment-source picker, opened from the inline "Get with" row on amount
+     * v2 Get only: the payment-source picker, opened from the inline "Buy with" row on amount
      * entry. Distinct from [TokenSelection] because picking here pops back to the amount screen
      * rather than advancing to the receipt.
      */

--- a/apps/flipcash/core/src/main/res/drawable/ic_arrow_down.xml
+++ b/apps/flipcash/core/src/main/res/drawable/ic_arrow_down.xml
@@ -1,0 +1,13 @@
+<!-- Figma "IconArrowDown" (node 9536:8434) — single down arrow for the Buy In / Buy More tiles. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="28dp"
+    android:height="28dp"
+    android:viewportWidth="28"
+    android:viewportHeight="28">
+    <path
+        android:pathData="M21.2917 16.3333L14 23.625L6.70833 16.3333M14 22.75V4.375"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="1.75"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round" />
+</vector>

--- a/apps/flipcash/core/src/main/res/drawable/ic_arrow_up_large.xml
+++ b/apps/flipcash/core/src/main/res/drawable/ic_arrow_up_large.xml
@@ -1,0 +1,16 @@
+<!-- Vertical mirror of ic_arrow_down, for the Withdraw tile on Dollars. The design has no
+     28px up arrow of its own — Figma's IconArrowUp is the 15.8px square-cap market-cap
+     indicator, and the tile row it draws (node 9631:2168) has no Withdraw tile at all.
+     Named _large because ui/components already owns a 20dp ic_arrow_up for chat send. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="28dp"
+    android:height="28dp"
+    android:viewportWidth="28"
+    android:viewportHeight="28">
+    <path
+        android:pathData="M21.2917 11.6667L14 4.375L6.70833 11.6667M14 5.25V23.625"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="1.75"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round" />
+</vector>

--- a/apps/flipcash/core/src/main/res/values/strings.xml
+++ b/apps/flipcash/core/src/main/res/values/strings.xml
@@ -549,7 +549,7 @@
     <string name="action_buy">Buy</string>
     <string name="action_sell">Sell</string>
     <string name="action_convert">Convert</string>
-    <string name="action_get">Get</string>
+    <string name="action_buyIn">Buy In</string>
     <string name="label_createdAt">Created %1$s</string>
     <string name="subtitle_about">About</string>
     <string name="title_amountToWithdraw">Amount to Withdraw</string>

--- a/apps/flipcash/core/src/main/res/values/strings.xml
+++ b/apps/flipcash/core/src/main/res/values/strings.xml
@@ -575,9 +575,8 @@
     <string name="subtitle_amountAvailable">%1$s available</string>
     <string name="action_confirmConversion">Confirm</string>
 
-    <!-- Currency purchase (v2 Get flow) -->
-    <string name="title_get">Get</string>
-    <string name="label_getWith">Get with</string>
+    <!-- Currency purchase (v2 buy flow) -->
+    <string name="label_buyWith">Buy with</string>
     <string name="subtitle_youGet">You Get</string>
     <string name="action_confirm">Confirm</string>
     <string name="label_buyWarning">Review the above before confirming.\nOnce made, your transaction is irreversible.</string>

--- a/apps/flipcash/features/tokens/src/main/kotlin/com/flipcash/app/tokens/SwapEntryScreen.kt
+++ b/apps/flipcash/features/tokens/src/main/kotlin/com/flipcash/app/tokens/SwapEntryScreen.kt
@@ -55,9 +55,11 @@ internal fun SwapEntryScreen(
                 is SwapPurpose.Buy if purpose.fundingSource != FundingSource.Flexible ->
                     stringResource(R.string.title_amountToAdd)
                 is SwapPurpose.Convert -> stringResource(R.string.title_amountToConvert)
-                // v2 renames the direct buy to "Get" and states the amount in the header instead
-                // of the title, matching Convert.
-                is SwapPurpose.BalanceIncrease if state.isGet -> stringResource(R.string.title_get)
+                // v2 titles the direct buy after the currency-info tile that opened it and
+                // states the amount in the header instead of the title, matching Convert.
+                is SwapPurpose.BalanceIncrease if state.isGet -> stringResource(
+                    if (state.isBuyingMore) R.string.action_buyMore else R.string.action_buyIn
+                )
                 is SwapPurpose.BalanceIncrease -> stringResource(R.string.title_amountToBuy)
                 is SwapPurpose.BalanceDecrease -> stringResource(R.string.title_amountToSell)
             },

--- a/apps/flipcash/features/tokens/src/main/kotlin/com/flipcash/app/tokens/TokenBuyReceiptScreen.kt
+++ b/apps/flipcash/features/tokens/src/main/kotlin/com/flipcash/app/tokens/TokenBuyReceiptScreen.kt
@@ -33,7 +33,11 @@ internal fun BuyReceiptScreen() {
     ) {
         AppBarWithTitle(
             title = stringResource(
-                if (state.isGet) R.string.title_get else R.string.title_confirmPurchase
+                when {
+                    !state.isGet -> R.string.title_confirmPurchase
+                    state.isBuyingMore -> R.string.action_buyMore
+                    else -> R.string.action_buyIn
+                }
             ),
             titleAlignment = Alignment.CenterHorizontally,
             onBackIconClicked = { flowNavigator.back() }

--- a/apps/flipcash/features/tokens/src/main/kotlin/com/flipcash/app/tokens/internal/TokenSelectorRow.kt
+++ b/apps/flipcash/features/tokens/src/main/kotlin/com/flipcash/app/tokens/internal/TokenSelectorRow.kt
@@ -104,14 +104,14 @@ internal fun ConvertDestinationSelector(
     modifier = modifier,
 )
 
-/** "Get with [🪙 Currency ⌄]" — what a v2 Get is paid from. */
+/** "Buy with [🪙 Currency ⌄]" — what a v2 buy is paid from. */
 @Composable
 internal fun BuyFundingSelector(
     funding: TokenWithBalance?,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) = TokenSelectorRow(
-    label = stringResource(R.string.label_getWith),
+    label = stringResource(R.string.label_buyWith),
     selected = funding,
     onClick = onClick,
     modifier = modifier,

--- a/apps/flipcash/features/tokens/src/main/kotlin/com/flipcash/app/tokens/internal/components/info/CurrencyInfoContentV2.kt
+++ b/apps/flipcash/features/tokens/src/main/kotlin/com/flipcash/app/tokens/internal/components/info/CurrencyInfoContentV2.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
@@ -27,9 +28,6 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.Icon
 import androidx.compose.material.Text
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.ArrowDownward
-import androidx.compose.material.icons.outlined.ArrowUpward
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -332,19 +330,57 @@ private fun CurrencyActionTiles(
     dispatch: (TokenInfoViewModel.Event) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val giveTile: @Composable RowScope.() -> Unit = {
+        ActionTile(
+            modifier = Modifier.weight(1f),
+            label = stringResource(R.string.action_give),
+            icon = {
+                Icon(
+                    painter = painterResource(R.drawable.ic_banknote),
+                    contentDescription = null,
+                    tint = CodeTheme.colors.textMain,
+                    modifier = Modifier.size(CodeTheme.dimens.staticGrid.x6),
+                )
+            },
+            onClick = {
+                dispatch(
+                    TokenInfoViewModel.Event.OpenScreen(
+                        AppRoute.Sheets.Give(mint = tokenMint, fromTokenInfo = true)
+                    )
+                )
+            },
+        )
+    }
+
+    val convertTile: @Composable RowScope.() -> Unit = {
+        ActionTile(
+            modifier = Modifier.weight(1f),
+            label = stringResource(R.string.action_convert),
+            icon = {
+                Icon(
+                    painter = painterResource(R.drawable.ic_convert),
+                    contentDescription = null,
+                    tint = CodeTheme.colors.textMain,
+                    modifier = Modifier.size(CodeTheme.dimens.staticGrid.x6),
+                )
+            },
+            onClick = { dispatch(TokenInfoViewModel.Event.OnConvert) },
+        )
+    }
+
     Row(
         modifier = modifier,
         horizontalArrangement = Arrangement.spacedBy(CodeTheme.dimens.grid.x2),
     ) {
         when {
             !isHeld -> {
-                // Single full-width "Get" tile
+                // Single full-width "Buy In" tile
                 ActionTile(
                     modifier = Modifier.weight(1f),
-                    label = stringResource(R.string.action_get),
+                    label = stringResource(R.string.action_buyIn),
                     icon = {
                         Icon(
-                            imageVector = Icons.Outlined.ArrowDownward,
+                            painter = painterResource(R.drawable.ic_arrow_down),
                             contentDescription = null,
                             tint = CodeTheme.colors.textMain,
                             modifier = Modifier.size(CodeTheme.dimens.staticGrid.x6),
@@ -354,46 +390,17 @@ private fun CurrencyActionTiles(
                 )
             }
 
-            else -> {
-                // Held (incl. USDF/Dollars in v2): Give + Convert + Withdraw
-                ActionTile(
-                    modifier = Modifier.weight(1f),
-                    label = stringResource(R.string.action_give),
-                    icon = {
-                        Icon(
-                            painter = painterResource(R.drawable.ic_banknote),
-                            contentDescription = null,
-                            tint = CodeTheme.colors.textMain,
-                            modifier = Modifier.size(CodeTheme.dimens.staticGrid.x6),
-                        )
-                    },
-                    onClick = {
-                        dispatch(
-                            TokenInfoViewModel.Event.OpenScreen(
-                                AppRoute.Sheets.Give(mint = tokenMint, fromTokenInfo = true)
-                            )
-                        )
-                    },
-                )
-                ActionTile(
-                    modifier = Modifier.weight(1f),
-                    label = stringResource(R.string.action_convert),
-                    icon = {
-                        Icon(
-                            painter = painterResource(R.drawable.ic_convert),
-                            contentDescription = null,
-                            tint = CodeTheme.colors.textMain,
-                            modifier = Modifier.size(CodeTheme.dimens.staticGrid.x6),
-                        )
-                    },
-                    onClick = { dispatch(TokenInfoViewModel.Event.OnConvert) },
-                )
+            // Dollars keeps Withdraw: there is no "buy more" of the cash reserve, and cashing
+            // out is the action people come to this screen for.
+            tokenMint == Mint.usdf -> {
+                giveTile()
+                convertTile()
                 ActionTile(
                     modifier = Modifier.weight(1f),
                     label = stringResource(R.string.action_withdraw),
                     icon = {
                         Icon(
-                            imageVector = Icons.Outlined.ArrowUpward,
+                            painter = painterResource(R.drawable.ic_arrow_up_large),
                             contentDescription = null,
                             tint = CodeTheme.colors.textMain,
                             modifier = Modifier.size(CodeTheme.dimens.staticGrid.x6),
@@ -409,6 +416,25 @@ private fun CurrencyActionTiles(
                         )
                     },
                 )
+            }
+
+            // Held non-USDF token: Give + Buy More + Convert
+            else -> {
+                giveTile()
+                ActionTile(
+                    modifier = Modifier.weight(1f),
+                    label = stringResource(R.string.action_buyMore),
+                    icon = {
+                        Icon(
+                            painter = painterResource(R.drawable.ic_arrow_down),
+                            contentDescription = null,
+                            tint = CodeTheme.colors.textMain,
+                            modifier = Modifier.size(CodeTheme.dimens.staticGrid.x6),
+                        )
+                    },
+                    onClick = { dispatch(TokenInfoViewModel.Event.OnBuy(shortfall)) },
+                )
+                convertTile()
             }
         }
     }

--- a/apps/flipcash/shared/tokens/src/main/kotlin/com/flipcash/app/tokens/ui/SwapViewModel.kt
+++ b/apps/flipcash/shared/tokens/src/main/kotlin/com/flipcash/app/tokens/ui/SwapViewModel.kt
@@ -39,6 +39,7 @@ import com.flipcash.shared.amountentry.AmountEntryStyle
 import com.flipcash.shared.tokens.R
 import com.getcode.manager.BottomBarAction
 import com.getcode.manager.BottomBarManager
+import com.getcode.opencode.controllers.AccountController
 import com.getcode.opencode.controllers.TransactionOperations
 import com.getcode.opencode.exchange.Exchange
 import com.getcode.opencode.exchange.VerifiedFiat
@@ -106,6 +107,7 @@ data class AmountEntryState(
 @HiltViewModel
 class SwapViewModel @Inject constructor(
     private val userManager: UserManager,
+    private val accountController: AccountController,
     private val exchange: Exchange,
     private val verifiedFiatCalculator: VerifiedFiatCalculator,
     transactionController: TransactionOperations,
@@ -268,6 +270,8 @@ class SwapViewModel @Inject constructor(
         val fundingTokenWithBalance: TokenWithBalance? = null,
         // Convert only: the currency the conversion lands in. `tokenWithBalance` is the source.
         val destinationTokenWithBalance: TokenWithBalance? = null,
+        /** Whether the account already holds a token account for the target mint. See [isBuyingMore]. */
+        val hasTokenAccount: Boolean = false,
     ) {
         val sellFee: Double?
             get() {
@@ -324,6 +328,16 @@ class SwapViewModel @Inject constructor(
         val isGet: Boolean
             get() = purpose is SwapPurpose.Buy && !isAddingMoney
 
+        /**
+         * Whether a Get is adding to a position the account already has, which titles its screens
+         * "Buy More" rather than "Buy In".
+         *
+         * Held is the same test the currency-info tile row uses — an existing token account, or a
+         * positive balance — so the tile the user tapped and the screen it opens always agree.
+         */
+        val isBuyingMore: Boolean
+            get() = isGet && (hasTokenAccount || tokenBalance.isPositive)
+
         /** The currency a Get is paid from. Null until the default is seeded or one is picked. */
         val fundingMint: Mint?
             get() = fundingTokenWithBalance?.token?.address
@@ -346,6 +360,7 @@ class SwapViewModel @Inject constructor(
     sealed interface Event {
         data class OnPurposeChanged(val purpose: SwapPurpose) : Event
         data class OnSelectedTokenChanged(val token: TokenWithBalance) : Event
+        data class OnTokenAccountKnown(val exists: Boolean) : Event
         data class OnReservesUpdated(val reserves: TokenWithBalance) : Event
 
         data class OnLimitsChanged(val limits: Limits?) : Event
@@ -404,7 +419,7 @@ class SwapViewModel @Inject constructor(
         data object ShowSellReceipt : Event
 
         // region v2 Get — the payment source is chosen inline, before the amount is confirmed.
-        /** Opens the "Get with" picker. */
+        /** Opens the "Buy with" picker. */
         data object SelectBuyFundingSource : Event
         /** A payment source was picked (or defaulted); the token still needs resolving. */
         data class OnFundingSourceSelected(val mint: Mint) : Event
@@ -699,6 +714,15 @@ class SwapViewModel @Inject constructor(
             }
             .filterNotNull()
             .onEach { dispatchEvent(Event.OnFundingSourceResolved(it)) }
+            .launchIn(viewModelScope)
+
+        // A token account outlives a balance that has gone to zero, so it — not the balance
+        // alone — is what tells a Get whether it is a first buy or a top-up.
+        eventFlow.filterIsInstance<Event.OnPurposeChanged>()
+            .map { it.purpose.mint }
+            .distinctUntilChanged()
+            .flatMapLatest { accountController.observeHasAccountFor(it) }
+            .onEach { dispatchEvent(Event.OnTokenAccountKnown(it)) }
             .launchIn(viewModelScope)
 
         eventFlow.filterIsInstance<Event.OnPurposeChanged>()
@@ -1907,6 +1931,7 @@ class SwapViewModel @Inject constructor(
                     state.copy(purpose = resolved)
                 }
                 is Event.OnSelectedTokenChanged -> { state -> state.copy(tokenWithBalance = event.token) }
+                is Event.OnTokenAccountKnown -> { state -> state.copy(hasTokenAccount = event.exists) }
                 is Event.OnReservesUpdated -> { state -> state.copy(reservesWithBalance = event.reserves) }
 
                 is Event.OnAmountAccepted -> { state ->


### PR DESCRIPTION
Token info led with "Get" for a token you don't hold and offered Give/Convert/Withdraw for one you do. Withdrawal isn't the action someone reaches for from a token's page, and there was no way to add to a position you already hold without backing out to the buy flow.

- **Unowned:** the single tile reads "Buy In", same `OnBuy(shortfall)` dispatch as before.
- **Held:** Give · Buy More · Convert. Withdraw drops, Convert takes its slot, and "Buy More" takes the middle with the same dispatch as the unowned tile.
- **Dollars:** unchanged at Give · Convert · Withdraw. There is no buying more of the cash reserve, and cashing out is what people come to that screen for. `CurrencyActionTiles` branches on `tokenMint == Mint.usdf`.

`action_get` had a single call site and is replaced by `action_buyIn`; `action_buyMore` already existed.

**Icons.** The Buy In / Buy More tiles use `ic_arrow_down`, exported from Figma's `IconArrowDown` (node 9536:8434). The Withdraw tile has no design asset to pull: the file's only `IconArrowUp` is the 15.8px square-cap market-cap indicator, a different family from the 28px round-cap tile glyphs, and the tile row the design draws (node 9631:2168) has no Withdraw tile at all — it puts Withdraw in a full-width text button instead. So `ic_arrow_up_large` is `ic_arrow_down` reflected about y=14, which matches the family exactly. The `_large` suffix is there because `ui/components` already owns a 20dp `ic_arrow_up` for the chat send button; a second drawable by that name in a module on the same classpath would silently win the resource merge.

Worth a second opinion on two things: the mirrored asset, if a designer would rather add a real 28px `IconArrowUp` to the file; and the fact that withdrawal is no longer reachable from a non-Dollars token's page. `AppRoute.Transfers.Withdrawal` still exists and is reachable elsewhere, but I didn't audit every entry point — if this tile was the primary way in, that path is gone for tokens.

## Buy flow titles

`SwapEntryScreen` and `BuyReceiptScreen` were both titled "Get", so tapping a tile opened a screen that named the action something else. Both now derive the title from `state.isBuyingMore`, and the payment-source row reads "Buy with". Held is the same test the tile row uses — an existing token account or a positive balance — so the tile and the screen it opens always agree; `SwapViewModel` picks the account up from `AccountController.observeHasAccountFor`, which outlives a balance that has gone to zero.

`title_get` and `label_getWith` are dropped. "You Get" on the receipt breakdown is left alone; it names a leg of the trade, not the flow.

Matches code-payments/code-ios-app#671, which makes the same change on iOS.
