### PR TITLE
feat(profile): scaffold SetMinDmChatInitFee

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -67,7 +67,7 @@ protovalidate-kt = "0.1.1"
 # protos are independent (flipcash2 does not import ocp), so the packages move on their own
 # cadence and there is nothing to keep aligned.
 ocp-client-protocol = "0.2.0"
-flipcash2-client-protocol = "0.1.0"
+flipcash2-client-protocol = "0.2.0"
 
 # The Android port is the ONLY libphonenumber this app depends on, deliberately. Google's
 # `com.googlecode` artifact used to sit alongside it; the two ship separate copies of the metadata,

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/controllers/ProfileController.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/controllers/ProfileController.kt
@@ -12,6 +12,7 @@ import com.flipcash.services.models.chat.MediaItem
 import com.flipcash.services.repository.ProfileRepository
 import com.flipcash.services.user.UserManager
 import com.getcode.opencode.model.core.ID
+import com.getcode.opencode.model.financial.Fiat
 import com.getcode.utils.TraceType
 import com.getcode.utils.trace
 import javax.inject.Inject
@@ -122,6 +123,17 @@ class ProfileController @Inject constructor(
             ?: return Result.failure(Throwable("No account cluster in UserManager"))
 
         return repository.updateTipCard(owner, hexColor)
+    }
+
+    /**
+     * Sets the minimum fee another user must pay to initialize a DM chat with
+     * the caller, replacing any fee already set.
+     */
+    suspend fun setMinDmChatInitFee(fee: Fiat): Result<Unit> {
+        val owner = userManager.accountCluster?.authority?.keyPair
+            ?: return Result.failure(Throwable("No account cluster in UserManager"))
+
+        return repository.setMinDmChatInitFee(owner, fee)
     }
 
     /**

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/internal/domain/UserProfileMapper.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/internal/domain/UserProfileMapper.kt
@@ -4,6 +4,7 @@ import com.codeinc.flipcash.gen.profile.v1.Model
 import com.codeinc.flipcash.gen.profile.v1.emailAddressOrNull
 import com.codeinc.flipcash.gen.profile.v1.phoneNumberOrNull
 import com.codeinc.flipcash.gen.profile.v1.usernameOrNull
+import com.flipcash.services.internal.network.extensions.toFiat
 import com.flipcash.services.internal.network.extensions.toId
 import com.flipcash.services.internal.network.extensions.toMediaItem
 import com.flipcash.services.models.UserProfile
@@ -30,6 +31,7 @@ class UserProfileMapper @Inject constructor(
             userId = if (from.hasUserId()) from.userId.toId() else null,
             // Public, so it is returned for any user — absent only when unclaimed.
             username = from.usernameOrNull?.value,
+            minDmChatInitFee = if (from.hasMinDmChatInitFee()) from.minDmChatInitFee.toFiat() else null,
         )
     }
 }

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/internal/network/api/ProfileApi.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/internal/network/api/ProfileApi.kt
@@ -4,6 +4,7 @@ import com.codeinc.flipcash.gen.common.v1.Common
 import com.codeinc.flipcash.gen.profile.v1.ProfileGrpcKt
 import com.codeinc.flipcash.gen.profile.v1.ProfileService
 import com.flipcash.services.internal.annotations.FlipcashManagedChannel
+import com.flipcash.services.internal.network.extensions.asFiatPaymentAmount
 import com.flipcash.services.internal.network.extensions.asUserId
 import com.flipcash.services.internal.network.extensions.asUsername
 import com.flipcash.services.internal.network.extensions.authenticate
@@ -14,6 +15,7 @@ import com.flipcash.services.models.SocialAccountUnlinkRequest
 import com.flipcash.services.models.chat.BlobId
 import com.getcode.ed25519.Ed25519
 import com.getcode.opencode.internal.network.core.GrpcApi
+import com.getcode.opencode.model.financial.Fiat
 import com.getcode.utils.toByteString
 import com.codeinc.flipcash.gen.profile.v1.validate
 import dev.bmcreations.protovalidate.orThrow
@@ -155,6 +157,26 @@ internal class ProfileApi @Inject constructor(
 
         return withContext(Dispatchers.IO) {
             api.updateTipCard(request)
+        }
+    }
+
+    /**
+     * Sets the minimum fee another user must pay to initialize a DM chat with
+     * the caller, replacing any fee already set.
+     */
+    suspend fun setMinDmChatInitFee(
+        owner: Ed25519.KeyPair,
+        fee: Fiat,
+    ): ProfileService.SetMinDmChatInitFeeResponse {
+        val request = ProfileService.SetMinDmChatInitFeeRequest.newBuilder()
+            .setMinDmChatInitFee(fee.asFiatPaymentAmount())
+            .apply { setAuth(authenticate(owner)) }
+            .build()
+
+        request.validate().orThrow()
+
+        return withContext(Dispatchers.IO) {
+            api.setMinDmChatInitFee(request)
         }
     }
 

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/internal/network/extensions/LocalToProtobuf.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/internal/network/extensions/LocalToProtobuf.kt
@@ -16,6 +16,7 @@ import com.flipcash.services.models.chat.TypingState
 import com.getcode.ed25519.Ed25519.KeyPair
 import com.getcode.network.jwt.ApiProvider
 import com.getcode.opencode.model.core.ID
+import com.getcode.opencode.model.financial.Fiat
 import com.getcode.solana.keys.Checksum
 import com.getcode.solana.keys.PublicKey
 import com.getcode.utils.toByteString
@@ -91,6 +92,13 @@ internal fun ChatId.asChatId(): Common.ChatId {
 
 internal fun String.asCountryCode(): Common.CountryCode {
     return Common.CountryCode.newBuilder().setValue(this).build()
+}
+
+internal fun Fiat.asFiatPaymentAmount(): Common.FiatPaymentAmount {
+    return Common.FiatPaymentAmount.newBuilder()
+        .setCurrency(currencyCode.name.lowercase())
+        .setNativeAmount(decimalValue)
+        .build()
 }
 
 internal fun SocialAccountLinkRequest.linkingToken(): ProfileService.LinkSocialAccountRequest.LinkingToken {

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/internal/network/extensions/ProtobufToLocal.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/internal/network/extensions/ProtobufToLocal.kt
@@ -70,6 +70,10 @@ internal fun Common.UserId.toId(): ID = value.toByteArray().toList()
 internal fun Common.Hash.toChecksum(): Checksum = value.toByteArray().toChecksum()
 internal fun Common.PublicKey.toPublicKey(): PublicKey = value.toByteArray().toPublicKey()
 internal fun Common.PublicKey.toMint(): Mint = value.toByteArray().toMint()
+internal fun Common.FiatPaymentAmount.toFiat(): Fiat = Fiat(
+    fiat = nativeAmount,
+    currencyCode = CurrencyCode.tryValueOf(currency) ?: CurrencyCode.USD,
+)
 
 internal fun PushModels.Payload.asPayload(): NotificationPayload {
     val navigationTrigger = navigationOrNull?.typeCase?.let { type ->

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/internal/network/services/ProfileService.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/internal/network/services/ProfileService.kt
@@ -9,6 +9,7 @@ import com.flipcash.services.models.GetUserProfileError
 import com.flipcash.services.models.LinkSocialAccountError
 import com.flipcash.services.models.ProfileIdentifier
 import com.flipcash.services.models.SetDisplayNameError
+import com.flipcash.services.models.SetMinDmChatInitFeeError
 import com.flipcash.services.models.SetProfilePictureError
 import com.flipcash.services.models.SetUsernameError
 import com.flipcash.services.models.SocialAccountLinkRequest
@@ -20,6 +21,7 @@ import com.flipcash.services.models.chat.MediaItem
 import com.flipcash.services.internal.network.extensions.toMediaItem
 import com.getcode.ed25519.Ed25519
 import com.getcode.opencode.internal.network.extensions.foldWithSuppression
+import com.getcode.opencode.model.financial.Fiat
 import javax.inject.Inject
 
 internal class ProfileService @Inject constructor(
@@ -128,6 +130,26 @@ internal class ProfileService @Inject constructor(
                 }
             },
             onFailure = { Result.failure(it.toValidationOrElse { cause -> UpdateTipCardError.Other(cause) }) }
+        )
+    }
+
+    suspend fun setMinDmChatInitFee(
+        owner: Ed25519.KeyPair,
+        fee: Fiat,
+    ): Result<Unit> {
+        return runCatching {
+            api.setMinDmChatInitFee(owner, fee)
+        }.foldWithSuppression(
+            onSuccess = { response ->
+                when (response.result) {
+                    ProfileService.SetMinDmChatInitFeeResponse.Result.OK -> Result.success(Unit)
+                    ProfileService.SetMinDmChatInitFeeResponse.Result.DENIED -> Result.failure(SetMinDmChatInitFeeError.Denied())
+                    ProfileService.SetMinDmChatInitFeeResponse.Result.INVALID_AMOUNT -> Result.failure(SetMinDmChatInitFeeError.InvalidAmount())
+                    ProfileService.SetMinDmChatInitFeeResponse.Result.UNRECOGNIZED -> Result.failure(SetMinDmChatInitFeeError.Unrecognized())
+                    null -> Result.failure(SetMinDmChatInitFeeError.Unrecognized())
+                }
+            },
+            onFailure = { Result.failure(it.toValidationOrElse { cause -> SetMinDmChatInitFeeError.Other(cause) }) }
         )
     }
 

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/internal/repositories/InternalProfileRepository.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/internal/repositories/InternalProfileRepository.kt
@@ -15,6 +15,7 @@ import com.flipcash.services.models.chat.BlobId
 import com.flipcash.services.models.chat.MediaItem
 import com.flipcash.services.repository.ProfileRepository
 import com.getcode.ed25519.Ed25519
+import com.getcode.opencode.model.financial.Fiat
 import com.getcode.utils.ErrorUtils
 
 internal class InternalProfileRepository(
@@ -83,6 +84,14 @@ internal class InternalProfileRepository(
         hexColor: String,
     ): Result<Unit> {
         return service.updateTipCard(owner, hexColor)
+            .onFailure { ErrorUtils.handleError(it) }
+    }
+
+    override suspend fun setMinDmChatInitFee(
+        owner: Ed25519.KeyPair,
+        fee: Fiat,
+    ): Result<Unit> {
+        return service.setMinDmChatInitFee(owner, fee)
             .onFailure { ErrorUtils.handleError(it) }
     }
 

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/models/Errors.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/models/Errors.kt
@@ -601,6 +601,16 @@ sealed class UpdateTipCardError(
     data class Other(override val cause: Throwable? = null) : UpdateTipCardError(message = cause?.message, cause = cause), NotifiableError
 }
 
+sealed class SetMinDmChatInitFeeError(
+    override val message: String? = null,
+    override val cause: Throwable? = null
+): CodeServerError(message, cause) {
+    class Denied: SetMinDmChatInitFeeError("Denied")
+    class InvalidAmount: SetMinDmChatInitFeeError("Invalid amount")
+    class Unrecognized : SetMinDmChatInitFeeError("Unrecognized"), NotifiableError
+    data class Other(override val cause: Throwable? = null) : SetMinDmChatInitFeeError(message = cause?.message, cause = cause), NotifiableError
+}
+
 // Thrown when a reserved blob failed server-side finalization (moderation / decode / size).
 // Terminal: the client must reserve a fresh upload to retry.
 class BlobRejectedException(val rejection: BlobRejection) :

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/models/UserProfile.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/models/UserProfile.kt
@@ -3,6 +3,7 @@ package com.flipcash.services.models
 import android.os.Parcelable
 import com.flipcash.services.models.chat.MediaItem
 import com.getcode.opencode.model.core.ID
+import com.getcode.opencode.model.financial.Fiat
 import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.Serializable
 import kotlin.time.Instant
@@ -27,6 +28,11 @@ data class UserProfile(
     // The user's public Flipcash handle. Public, so it is present for any user —
     // null when they haven't claimed one yet.
     val username: String? = null,
+    // The minimum fee another user must pay to initialize a DM chat with this
+    // user. Public, so it is present for any user, not just the caller. Null
+    // when the user hasn't set one, in which case the server default applies.
+    // Update it with ProfileController.setMinDmChatInitFee.
+    val minDmChatInitFee: Fiat? = null,
 ): Parcelable {
     /** The phone number only when it has been verified — backwards-compatible accessor. */
     val verifiedPhoneNumber: String? get() = phoneNumber?.takeIf { it.verified }?.value
@@ -43,6 +49,7 @@ data class UserProfile(
             tipCardColor = null,
             userId = null,
             username = null,
+            minDmChatInitFee = null,
         )
     }
 }

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/repository/ProfileRepository.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/repository/ProfileRepository.kt
@@ -8,6 +8,7 @@ import com.flipcash.services.models.UserProfile
 import com.flipcash.services.models.chat.BlobId
 import com.flipcash.services.models.chat.MediaItem
 import com.getcode.ed25519.Ed25519
+import com.getcode.opencode.model.financial.Fiat
 
 interface ProfileRepository {
     suspend fun getProfile(identifier: ProfileIdentifier, owner: Ed25519.KeyPair): Result<UserProfile>
@@ -15,6 +16,7 @@ interface ProfileRepository {
     suspend fun setUsername(username: String, owner: Ed25519.KeyPair): Result<Unit>
     suspend fun setProfilePicture(blobId: BlobId, owner: Ed25519.KeyPair): Result<MediaItem>
     suspend fun updateTipCard(owner: Ed25519.KeyPair, hexColor: String): Result<Unit>
+    suspend fun setMinDmChatInitFee(owner: Ed25519.KeyPair, fee: Fiat): Result<Unit>
     suspend fun linkSocialAccount(request: SocialAccountLinkRequest, owner: Ed25519.KeyPair): Result<SocialAccount>
     suspend fun unlinkSocialAccount(request: SocialAccountUnlinkRequest, owner: Ed25519.KeyPair): Result<Unit>
 }

--- a/services/flipcash/src/test/kotlin/com/flipcash/services/controllers/ProfileControllerTest.kt
+++ b/services/flipcash/src/test/kotlin/com/flipcash/services/controllers/ProfileControllerTest.kt
@@ -14,6 +14,7 @@ import com.flipcash.services.user.UserManager
 import com.getcode.ed25519.Ed25519
 import com.getcode.opencode.model.accounts.AccountCluster
 import com.getcode.opencode.model.core.ID
+import com.getcode.opencode.model.financial.Fiat
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -305,6 +306,7 @@ private class FakeProfileRepository : ProfileRepository {
     var setUsernameResult: Result<Unit> = Result.success(Unit)
     var setProfilePictureResult: Result<MediaItem> = Result.failure(RuntimeException("not configured"))
     var updateTipCardResult: Result<Unit> = Result.success(Unit)
+    var setMinDmChatInitFeeResult: Result<Unit> = Result.success(Unit)
     var linkSocialAccountResult: Result<SocialAccount> = Result.failure(RuntimeException("not configured"))
     var unlinkSocialAccountResult: Result<Unit> = Result.success(Unit)
 
@@ -313,6 +315,7 @@ private class FakeProfileRepository : ProfileRepository {
     override suspend fun setUsername(username: String, owner: Ed25519.KeyPair) = setUsernameResult
     override suspend fun setProfilePicture(blobId: BlobId, owner: Ed25519.KeyPair) = setProfilePictureResult
     override suspend fun updateTipCard(owner: Ed25519.KeyPair, hexColor: String) = updateTipCardResult
+    override suspend fun setMinDmChatInitFee(owner: Ed25519.KeyPair, fee: Fiat) = setMinDmChatInitFeeResult
     override suspend fun linkSocialAccount(request: SocialAccountLinkRequest, owner: Ed25519.KeyPair) =
         linkSocialAccountResult
     override suspend fun unlinkSocialAccount(request: SocialAccountUnlinkRequest, owner: Ed25519.KeyPair) =


### PR DESCRIPTION
Scaffolds `SetMinDmChatInitFee` and `UserProfile.min_dm_chat_init_fee`, which arrive in `flipcash2-client-protocol` `0.2.0`.

## Blocked on the contract release

Draft until [code-payments/flipcash2-client-protocol#5](https://github.com/code-payments/flipcash2-client-protocol/pull/5) merges and `0.2.0` publishes to Maven Central. The pin bump here names a version that does not exist yet, so dependency resolution reports `com.flipcash:flipcash2-client-protocol:0.2.0 FAILED` until then. CI never sees the local `protoLocalRoot` override, so it resolves the pin and nothing else.

Built green against the client checkout locally: `:services:flipcash:assembleDebug` and `:services:flipcash:testDebugUnitTest`.

## What the contract added

`SetMinDmChatInitFee` sets the minimum fee another user must pay to initialize a DM chat with the caller, replacing any fee already set. `SetMinDmChatInitFeeResponse.Result` is a new enum of `OK`, `DENIED`, and `INVALID_AMOUNT`. `UserProfile.min_dm_chat_init_fee` is a new optional `FiatPaymentAmount`, unset when the user has not chosen one.

## Scaffolding

Follows `updateTipCard`, the closest existing sibling, through the same layers:

- `ProfileApi.setMinDmChatInitFee` builds and validates the request, dispatching on IO.
- `ProfileService` folds the response `Result` into a new `SetMinDmChatInitFeeError` sealed class.
- `InternalProfileRepository` reports every failure through `ErrorUtils.handleError`, matching `updateTipCard` rather than `setUsername`'s selective suppression.
- `ProfileController.setMinDmChatInitFee(fee: Fiat)` exposes it, with no local-profile-cache merge, again matching `updateTipCard`.
- `UserProfile` gains `minDmChatInitFee: Fiat?`, mapped in `UserProfileMapper`, with new `FiatPaymentAmount` conversions in both directions.

No UI or feature-layer wiring: `updateTipCard` has no feature-layer callers either, so a surface here would be inventing a feature rather than scaffolding the contract. That wiring belongs in whichever PR builds the screen.
