### PR TITLE
test(tokens): supply accountController to SwapViewModel

### DIFF
--- a/apps/flipcash/shared/tokens/src/test/kotlin/com/flipcash/app/tokens/ui/SwapViewModelErrorTest.kt
+++ b/apps/flipcash/shared/tokens/src/test/kotlin/com/flipcash/app/tokens/ui/SwapViewModelErrorTest.kt
@@ -9,6 +9,7 @@ import com.flipcash.app.tokens.TokenCoordinator
 import com.flipcash.app.tokens.UsdcDepositSweep
 import com.flipcash.services.user.UserManager
 import com.getcode.manager.BottomBarManager
+import com.getcode.opencode.controllers.AccountController
 import com.getcode.opencode.controllers.TransactionOperations
 import com.getcode.opencode.exchange.Exchange
 import com.getcode.opencode.exchange.VerifiedFiat
@@ -58,6 +59,7 @@ class SwapViewModelErrorTest {
     var mainCoroutineRule = MainCoroutineRule(UnconfinedTestDispatcher())
 
     private val userManager = mockk<UserManager>(relaxed = true)
+    private val accountController = mockk<AccountController>(relaxed = true)
     private val exchange = mockk<Exchange>(relaxed = true)
     private val verifiedFiatCalculator = mockk<VerifiedFiatCalculator>(relaxed = true)
     // Mockito for Result-returning methods (MockK double-boxes Result inline class)
@@ -87,6 +89,11 @@ class SwapViewModelErrorTest {
 
         every { userManager.accountCluster } returns accountCluster
 
+        // A Get asks whether the mint already has a token account to decide first-buy vs top-up.
+        // Nothing here exercises that branch, so answer "no" rather than leaving it on a relaxed
+        // mock's empty flow.
+        every { accountController.observeHasAccountFor(any()) } returns MutableStateFlow(false)
+
         // Stub limits StateFlow so init block doesn't NPE on null flow
         whenever(transactionController.limits).thenReturn(MutableStateFlow(null))
 
@@ -107,6 +114,7 @@ class SwapViewModelErrorTest {
     private fun createViewModel(): SwapViewModel {
         return SwapViewModel(
             userManager = userManager,
+            accountController = accountController,
             exchange = exchange,
             verifiedFiatCalculator = verifiedFiatCalculator,
             transactionController = transactionController,


### PR DESCRIPTION
`code/cash` does not compile its `:apps:flipcash:shared:tokens` unit tests. #1341 added a required `accountController` parameter to `SwapViewModel` and changed only `SwapViewModel.kt`, leaving `SwapViewModelErrorTest.createViewModel()` on the old constructor:

```
SwapViewModelErrorTest.kt:122:13 No value passed for parameter 'accountController'.
```

Every branch cut from `code/cash` inherits the break, because PR CI builds the merge commit rather than the branch head. #1344 is where I hit it.

The fix is the mock and the argument. `observeHasAccountFor` is stubbed to return false: nothing in this file exercises the first-buy/top-up branch it feeds, and an explicit answer is steadier than a relaxed mock's empty flow.

`SwapViewModelStateTest` only uses the companion object, so it compiles either way and is untouched.

`:apps:flipcash:shared:tokens:testDebugUnitTest` runs 35 tests across both classes with no failures.
