### PR TITLE
feat(menu): add the Finish Your Profile checklist to the You tab

### DIFF
--- a/apps/flipcash/core-ui/src/main/kotlin/com/flipcash/app/core/ui/onboarding/NewUserTutorial.kt
+++ b/apps/flipcash/core-ui/src/main/kotlin/com/flipcash/app/core/ui/onboarding/NewUserTutorial.kt
@@ -25,8 +25,11 @@ import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewWrapper
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.fastForEach
+import com.flipcash.app.theme.FlipcashThemeWrapper
 import com.flipcash.core.R
 import com.getcode.theme.CodeTheme
 import com.getcode.theme.extraSmall
@@ -69,6 +72,30 @@ sealed interface TutorialItem {
             @Composable get() = stringResource(R.string.subtitle_scanTipCard)
         override val icon: Painter
             @Composable get() = painterResource(R.drawable.ic_nav_scan)
+    }
+
+    class ProfilePicture(override val isCompleted: Boolean) : Profile {
+        override val title: String
+            @Composable get() = stringResource(R.string.title_addProfilePicture)
+        override val description: String
+            @Composable get() = stringResource(R.string.subtitle_addProfilePicture)
+        override val icon: Painter
+            @Composable get() = painterResource(R.drawable.ic_people_circle)
+    }
+
+    /**
+     * Drawn but inert. Nothing backs a user-set minimum tip yet: the amount comes from
+     * server-supplied regional presets, no field for it exists on the profile or the tip-card
+     * customization message, and iOS has no implementation either. The row is in the design, so
+     * it is drawn — and it never completes, which is the state node 9641:17019 shows.
+     */
+    class MinimumTip(override val isCompleted: Boolean = false) : Profile {
+        override val title: String
+            @Composable get() = stringResource(R.string.title_setMinimumTip)
+        override val description: String
+            @Composable get() = stringResource(R.string.subtitle_setMinimumTip)
+        override val icon: Painter
+            @Composable get() = painterResource(R.drawable.ic_coins)
     }
 }
 
@@ -165,4 +192,32 @@ private fun OnboardingItemRow(
             contentDescription = null
         )
     }
+}
+
+@Preview(name = "Finish Your Profile — nothing done")
+@PreviewWrapper(FlipcashThemeWrapper::class)
+@Composable
+private fun PreviewFinishProfileEmpty() {
+    NewUserTutorial(
+        title = stringResource(R.string.title_finishYourProfile),
+        items = listOf(
+            TutorialItem.ProfilePicture(isCompleted = false),
+            TutorialItem.MinimumTip(),
+        ),
+        onItemClicked = {},
+    )
+}
+
+@Preview(name = "Finish Your Profile — photo set")
+@PreviewWrapper(FlipcashThemeWrapper::class)
+@Composable
+private fun PreviewFinishProfilePhotoSet() {
+    NewUserTutorial(
+        title = stringResource(R.string.title_finishYourProfile),
+        items = listOf(
+            TutorialItem.ProfilePicture(isCompleted = true),
+            TutorialItem.MinimumTip(),
+        ),
+        onItemClicked = {},
+    )
 }

--- a/apps/flipcash/core-ui/src/main/kotlin/com/flipcash/app/core/ui/onboarding/NewUserTutorial.kt
+++ b/apps/flipcash/core-ui/src/main/kotlin/com/flipcash/app/core/ui/onboarding/NewUserTutorial.kt
@@ -1,4 +1,4 @@
-package com.flipcash.app.balance.internal.components
+package com.flipcash.app.core.ui.onboarding
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -27,9 +27,17 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.fastForEach
-import com.flipcash.features.balance.R
+import com.flipcash.core.R
 import com.getcode.theme.CodeTheme
+import com.getcode.theme.extraSmall
 
+/**
+ * A row in a "what's left to do" checklist.
+ *
+ * Split by the screen that owns it: [Wallet] and [Profile] are drawn by different tabs and share
+ * nothing but the row layout, so each call site's `when` stays exhaustive over its own family and
+ * cannot be handed an item it has no branch for.
+ */
 sealed interface TutorialItem {
     val title: String
         @Composable get
@@ -39,17 +47,22 @@ sealed interface TutorialItem {
         @Composable get
     val isCompleted: Boolean
 
-    class AddMoney(override val isCompleted: Boolean) : TutorialItem {
+    /** The wallet tab's new-user milestones. */
+    sealed interface Wallet : TutorialItem
+
+    /** The "You" tab's profile-completion steps (node 9544:18140). */
+    sealed interface Profile : TutorialItem
+
+    class AddMoney(override val isCompleted: Boolean) : Wallet {
         override val title: String
             @Composable get() = stringResource(R.string.title_addMoney)
         override val description: String
             @Composable get() = stringResource(R.string.subtitle_addMoney)
         override val icon: Painter
             @Composable get() = rememberVectorPainter(Icons.Outlined.AddCircleOutline)
-
     }
 
-    class ScanTipCard(override val isCompleted: Boolean) : TutorialItem {
+    class ScanTipCard(override val isCompleted: Boolean) : Wallet {
         override val title: String
             @Composable get() = stringResource(R.string.title_scanTipCard)
         override val description: String
@@ -60,11 +73,11 @@ sealed interface TutorialItem {
 }
 
 @Composable
-fun NewUserTutorial(
+fun <T : TutorialItem> NewUserTutorial(
     title: String,
-    items: List<TutorialItem>,
+    items: List<T>,
     modifier: Modifier = Modifier,
-    onItemClicked: (TutorialItem) -> Unit,
+    onItemClicked: (T) -> Unit,
 ) {
     val completedCount = remember(items) { items.count { it.isCompleted } }
 
@@ -93,7 +106,7 @@ fun NewUserTutorial(
 
         Column(
             modifier = Modifier
-                .clip(CodeTheme.shapes.medium)
+                .clip(CodeTheme.shapes.extraSmall)
                 .background(color = Color.White.copy(0.05f)),
         ) {
             items.fastForEach { item ->

--- a/apps/flipcash/core-ui/src/main/kotlin/com/flipcash/app/core/ui/onboarding/NewUserTutorial.kt
+++ b/apps/flipcash/core-ui/src/main/kotlin/com/flipcash/app/core/ui/onboarding/NewUserTutorial.kt
@@ -177,8 +177,7 @@ private fun OnboardingItemRow(
         Column(
             modifier = Modifier
                 .weight(1f)
-                .alpha(if (item.isCompleted) 0.38f else 1f),
-            verticalArrangement = Arrangement.spacedBy(CodeTheme.dimens.grid.x1),
+                .alpha(if (item.isCompleted) 0.38f else 1f)
         ) {
             Text(
                 text = item.title,

--- a/apps/flipcash/core-ui/src/main/kotlin/com/flipcash/app/core/ui/onboarding/NewUserTutorial.kt
+++ b/apps/flipcash/core-ui/src/main/kotlin/com/flipcash/app/core/ui/onboarding/NewUserTutorial.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewWrapper
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.compose.ui.util.fastForEach
 import com.flipcash.app.theme.FlipcashThemeWrapper
 import com.flipcash.core.R
@@ -108,19 +109,20 @@ fun <T : TutorialItem> NewUserTutorial(
 ) {
     val completedCount = remember(items) { items.count { it.isCompleted } }
 
-    Column(
-        modifier = modifier,
-        verticalArrangement = Arrangement.spacedBy(CodeTheme.dimens.inset)
-    ) {
+    Column(modifier = modifier) {
+        // Node 9641:17024 pads the header on all four sides rather than putting a gap under it, so
+        // the space between the title and the box belongs to the header.
         Row(
             modifier = Modifier.fillMaxWidth()
-                .padding(horizontal = CodeTheme.dimens.inset),
+                .padding(CodeTheme.dimens.grid.x3),
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically
         ) {
             Text(
                 text = title,
-                style = CodeTheme.typography.screenTitle,
+                // Not `screenTitle`: FlipcashDesignSystem overrides it to 20sp/W500 app-wide, and
+                // node 9641:17026 asks for Avenir Demi at 18.
+                style = CodeTheme.typography.textMedium.copy(fontSize = 18.sp),
                 color = CodeTheme.colors.textMain,
             )
 
@@ -131,10 +133,14 @@ fun <T : TutorialItem> NewUserTutorial(
             )
         }
 
+        // Node 9641:17028: the box owns the padding and the rows sit flush inside it, spaced by
+        // the same step.
         Column(
             modifier = Modifier
                 .clip(CodeTheme.shapes.extraSmall)
-                .background(color = Color.White.copy(0.05f)),
+                .background(color = Color.White.copy(0.05f))
+                .padding(CodeTheme.dimens.grid.x3),
+            verticalArrangement = Arrangement.spacedBy(CodeTheme.dimens.grid.x3),
         ) {
             items.fastForEach { item ->
                 OnboardingItemRow(
@@ -154,9 +160,8 @@ private fun OnboardingItemRow(
     modifier: Modifier = Modifier,
     onClick: () -> Unit,
 ) {
-    Row(modifier = modifier
-        .clickable(enabled = !item.isCompleted, onClick = onClick)
-        .padding(CodeTheme.dimens.inset),
+    Row(
+        modifier = modifier.clickable(enabled = !item.isCompleted, onClick = onClick),
         horizontalArrangement = Arrangement.spacedBy(CodeTheme.dimens.grid.x2),
     ) {
         Image(
@@ -172,7 +177,8 @@ private fun OnboardingItemRow(
         Column(
             modifier = Modifier
                 .weight(1f)
-                .alpha(if (item.isCompleted) 0.38f else 1f)
+                .alpha(if (item.isCompleted) 0.38f else 1f),
+            verticalArrangement = Arrangement.spacedBy(CodeTheme.dimens.grid.x1),
         ) {
             Text(
                 text = item.title,
@@ -186,7 +192,7 @@ private fun OnboardingItemRow(
             )
         }
         Icon(
-            modifier = Modifier.align(Alignment.CenterVertically),
+            modifier = Modifier.align(Alignment.CenterVertically).size(16.dp),
             painter = painterResource(R.drawable.ic_chevron_right),
             tint = CodeTheme.colors.textSecondary,
             contentDescription = null

--- a/apps/flipcash/core/src/main/res/drawable/ic_people_circle.xml
+++ b/apps/flipcash/core/src/main/res/drawable/ic_people_circle.xml
@@ -1,0 +1,21 @@
+<!-- IconPeopleCircle — "Finish Your Profile" checklist (node 9544:18148). White stroke, tinted
+     at the call site. The export carries a 50% group opacity; it is dropped here so the row's
+     own ColorFilter.tint controls the colour, matching the other tutorial icons. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:pathData="M15.25 10C15.25 11.7949 13.7949 13.25 12 13.25C10.2051 13.25 8.75 11.7949 8.75 10C8.75 8.20507 10.2051 6.75 12 6.75C13.7949 6.75 15.25 8.20507 15.25 10Z"
+        android:fillColor="#00000000"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="1.5"
+        android:strokeLineJoin="round" />
+    <path
+        android:pathData="M18.143 18.9157C16.8294 16.9968 14.668 15.75 12 15.75C9.33203 15.75 7.17056 16.9968 5.85697 18.9157M18.143 18.9157C20.0491 17.2214 21.25 14.7509 21.25 12C21.25 6.89137 17.1086 2.75 12 2.75C6.89137 2.75 2.75 6.89137 2.75 12C2.75 14.7509 3.95086 17.2214 5.85697 18.9157M18.143 18.9157C16.5094 20.3679 14.3577 21.25 12 21.25C9.6423 21.25 7.49061 20.3679 5.85697 18.9157"
+        android:fillColor="#00000000"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="1.5"
+        android:strokeLineJoin="round" />
+</vector>

--- a/apps/flipcash/core/src/main/res/values/strings.xml
+++ b/apps/flipcash/core/src/main/res/values/strings.xml
@@ -488,6 +488,7 @@
     <string name="title_currencyCreatorNameSelection">What do you want to call your currency?</string>
     <string name="hint_currencyName">Currency Name</string>
     <string name="action_next">Next</string>
+    <string name="action_save">Save</string>
     <string name="title_currencyCreatorIconSelection">Upload Currency Icon</string>
     <string name="subtitle_currencyCreatorIconSelection">Choose an image that represents your currency.\nIt will be displayed as a circular icon.</string>
     <string name="subtitle_currencyCreatorIconRecommended">500x500 Recommended</string>
@@ -539,6 +540,14 @@
 
     <string name="title_scanTipCard">Scan a Tip Card</string>
     <string name="subtitle_scanTipCard">Give your first tip</string>
+
+    <string name="title_finishYourProfile">Finish Your Profile</string>
+
+    <string name="title_addProfilePicture">Add a profile picture</string>
+    <string name="subtitle_addProfilePicture">Select a photo from your gallery</string>
+
+    <string name="title_setMinimumTip">Set your minimum tip amount</string>
+    <string name="subtitle_setMinimumTip">Decide what size tip matters to you</string>
 
     <string name="title_amountToBuy">Amount to Buy</string>
     <string name="title_amountToSell">Amount to Sell</string>

--- a/apps/flipcash/core/src/main/res/values/strings.xml
+++ b/apps/flipcash/core/src/main/res/values/strings.xml
@@ -977,8 +977,7 @@
     <string name="error_description_profilePhotoNotAllowedFlaggedImpersonation">AI flagged this photo for impersonation. Please try a different photo. If you think the photo was rejected in error please DM @flipcash on X</string>
     <string name="error_description_profilePhotoNotAllowedFlaggedMisleading">AI flagged this photo as misleading. Please try a different photo. If you think the photo was rejected in error please DM @flipcash on X</string>
     <string name="error_description_profilePhotoNotAllowedFlaggedSpam">AI flagged this photo as spam. Please try a different photo. If you think the photo was rejected in error please DM @flipcash on X</string>
-    <string name="title_profileImageSelection">Upload Your Photo</string>
-    <string name="subtitle_profileImageSelection">This photo will be shown when receiving tips</string>
+    <string name="title_setProfilePicture">Set Profile Picture</string>
     <string name="placeholder_profileDisplayName">Your Name</string>
     <string name="subtitle_profileImageRecommended">500x500 Recommended</string>
     <string name="title_myTipCard">My Tip Card</string>

--- a/apps/flipcash/features/balance/src/main/kotlin/com/flipcash/app/balance/internal/WalletScreenContent.kt
+++ b/apps/flipcash/features/balance/src/main/kotlin/com/flipcash/app/balance/internal/WalletScreenContent.kt
@@ -38,8 +38,8 @@ import kotlinx.coroutines.launch
 import com.flipcash.app.core.ui.AppreciationStyle
 import com.flipcash.app.core.ui.TokenCardStack
 import com.flipcash.app.balance.internal.components.BalanceHeader
-import com.flipcash.app.balance.internal.components.NewUserTutorial
-import com.flipcash.app.balance.internal.components.TutorialItem
+import com.flipcash.app.core.ui.onboarding.NewUserTutorial
+import com.flipcash.app.core.ui.onboarding.TutorialItem
 import com.flipcash.app.core.navigation.LocalTabBarPadding
 import com.flipcash.app.core.ui.TileButton
 import com.flipcash.app.core.ui.TileButtonStyle

--- a/apps/flipcash/features/balance/src/main/kotlin/com/flipcash/app/balance/internal/WalletViewModel.kt
+++ b/apps/flipcash/features/balance/src/main/kotlin/com/flipcash/app/balance/internal/WalletViewModel.kt
@@ -3,7 +3,7 @@ package com.flipcash.app.balance.internal
 import androidx.lifecycle.viewModelScope
 import com.flipcash.app.analytics.Analytics
 import com.flipcash.app.analytics.FlipcashAnalyticsService
-import com.flipcash.app.balance.internal.components.TutorialItem
+import com.flipcash.app.core.ui.onboarding.TutorialItem
 import com.flipcash.app.core.AppRoute
 import com.flipcash.shared.transactionhistory.ActivityFeedCoordinator
 import com.flipcash.shared.transactionhistory.FeedSyncState
@@ -53,7 +53,7 @@ internal class WalletViewModel @Inject constructor(
          * without waiting on the network. The tip milestone inside it is the one that needs a
          * server round-trip; [isTipMilestoneResolved] says whether it can be believed yet.
          */
-        val onboardingItems: List<TutorialItem>? = null,
+        val onboardingItems: List<TutorialItem.Wallet>? = null,
         /**
          * Whether [TutorialItem.ScanTipCard]'s answer is trustworthy.
          *
@@ -111,7 +111,7 @@ internal class WalletViewModel @Inject constructor(
 
     sealed interface Event {
         data class OnOnboardingItemsUpdated(
-            val items: List<TutorialItem>,
+            val items: List<TutorialItem.Wallet>,
             val holdsBalance: Boolean,
             val isTipMilestoneResolved: Boolean,
         ): Event

--- a/apps/flipcash/features/balance/src/test/kotlin/com/flipcash/app/balance/internal/WalletLoadingStateTest.kt
+++ b/apps/flipcash/features/balance/src/test/kotlin/com/flipcash/app/balance/internal/WalletLoadingStateTest.kt
@@ -1,6 +1,6 @@
 package com.flipcash.app.balance.internal
 
-import com.flipcash.app.balance.internal.components.TutorialItem
+import com.flipcash.app.core.ui.onboarding.TutorialItem
 import com.flipcash.shared.transactionhistory.FeedSyncState
 import com.flipcash.shared.transactionhistory.TransactionAvatar
 import com.flipcash.shared.transactionhistory.TransactionListItem

--- a/apps/flipcash/features/balance/src/test/kotlin/com/flipcash/app/balance/internal/WalletMilestoneGatingTest.kt
+++ b/apps/flipcash/features/balance/src/test/kotlin/com/flipcash/app/balance/internal/WalletMilestoneGatingTest.kt
@@ -2,7 +2,7 @@ package com.flipcash.app.balance.internal
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.flipcash.app.analytics.StubFlipcashAnalytics
-import com.flipcash.app.balance.internal.components.TutorialItem
+import com.flipcash.app.core.ui.onboarding.TutorialItem
 import com.flipcash.app.core.MainCoroutineRule
 import com.flipcash.app.core.dispatchers.TestDispatchers
 import com.flipcash.app.funding.PurchaseMethodController

--- a/apps/flipcash/features/menu/src/main/kotlin/com/flipcash/app/menu/internal/MenuScreenContent.kt
+++ b/apps/flipcash/features/menu/src/main/kotlin/com/flipcash/app/menu/internal/MenuScreenContent.kt
@@ -34,6 +34,7 @@ import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -544,7 +545,7 @@ private fun ClaimedTipCard(
             modifier = slideAway.fillMaxWidth(),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            Spacer(Modifier.height(CodeTheme.dimens.grid.x13))
+            Spacer(Modifier.height(CodeTheme.dimens.grid.x6))
 
             Column(
                 modifier = Modifier
@@ -567,6 +568,16 @@ private fun ClaimedTipCard(
                             is TutorialItem.MinimumTip -> Unit
                         }
                     }
+
+
+                    // Node 9641:17048 separates the checklist from the link row. The column
+                    // already spaces siblings by 10dp; the rest of the 20dp gap on each side is
+                    // the divider's own padding.
+                    HorizontalDivider(
+                        modifier = Modifier.padding(vertical = CodeTheme.dimens.grid.x2),
+                        color = CodeTheme.colors.divider,
+                        thickness = CodeTheme.dimens.border,
+                    )
                 }
 
                 if (link != null) {

--- a/apps/flipcash/features/menu/src/main/kotlin/com/flipcash/app/menu/internal/MenuScreenContent.kt
+++ b/apps/flipcash/features/menu/src/main/kotlin/com/flipcash/app/menu/internal/MenuScreenContent.kt
@@ -77,6 +77,8 @@ import com.flipcash.app.core.navigation.LocalTabBarPadding
 import com.flipcash.app.menu.MenuList
 import com.flipcash.app.menu.internal.MenuScreenViewModel.Event
 import com.flipcash.app.menu.internal.MenuScreenViewModel.TipCardState
+import com.flipcash.app.core.ui.onboarding.NewUserTutorial
+import com.flipcash.app.core.ui.onboarding.TutorialItem
 import com.flipcash.app.menu.internal.components.UsernameProgress
 import com.flipcash.app.menu.internal.components.UsernameProgressCard
 import com.flipcash.app.theme.FlipcashThemeWrapper
@@ -280,6 +282,10 @@ internal fun MenuScreenContent(viewModel: MenuScreenViewModel) {
                         usernameProgress = state.usernameProgress,
                         usernameMinimumBalance = state.usernameMinimumBalance,
                         onClaimUsername = { viewModel.dispatchEvent(Event.ClaimUsername) },
+                        profileTutorial = state.profileTutorial,
+                        onSetProfilePicture = {
+                            viewModel.dispatchEvent(Event.SetProfilePicture)
+                        },
                     )
                 },
                 footer = {
@@ -407,6 +413,8 @@ private fun YouHeader(
     usernameProgress: UsernameProgress?,
     usernameMinimumBalance: String,
     onClaimUsername: () -> Unit,
+    profileTutorial: List<TutorialItem.Profile>?,
+    onSetProfilePicture: () -> Unit,
 ) {
     when (tipCardState) {
         TipCardState.Unknown -> Unit
@@ -433,6 +441,8 @@ private fun YouHeader(
             usernameProgress = usernameProgress,
             usernameMinimumBalance = usernameMinimumBalance,
             onClaimUsername = onClaimUsername,
+            profileTutorial = profileTutorial,
+            onSetProfilePicture = onSetProfilePicture,
         )
     }
 }
@@ -466,6 +476,8 @@ private fun ClaimedTipCard(
     usernameProgress: UsernameProgress?,
     usernameMinimumBalance: String,
     onClaimUsername: () -> Unit,
+    profileTutorial: List<TutorialItem.Profile>?,
+    onSetProfilePicture: () -> Unit,
 ) {
     Column(
         modifier = Modifier.fillMaxWidth(),
@@ -540,6 +552,23 @@ private fun ClaimedTipCard(
                     .padding(horizontal = CodeTheme.dimens.grid.x5),
                 verticalArrangement = Arrangement.spacedBy(CodeTheme.dimens.grid.x2),
             ) {
+                // Node 9641:17031 puts the checklist directly under the caption, above the
+                // link row. Null while the profile is unresolved so it never draws against a
+                // guess.
+                if (profileTutorial != null) {
+                    NewUserTutorial(
+                        modifier = Modifier.fillMaxWidth(),
+                        title = stringResource(R.string.title_finishYourProfile),
+                        items = profileTutorial,
+                    ) { item ->
+                        when (item) {
+                            is TutorialItem.ProfilePicture -> onSetProfilePicture()
+                            // Inert: nothing backs a user-set minimum tip yet.
+                            is TutorialItem.MinimumTip -> Unit
+                        }
+                    }
+                }
+
                 if (link != null) {
                     TipLinkRow(link = link, enabled = enabled, onCopy = onCopyLink)
                 }

--- a/apps/flipcash/features/menu/src/main/kotlin/com/flipcash/app/menu/internal/MenuScreenViewModel.kt
+++ b/apps/flipcash/features/menu/src/main/kotlin/com/flipcash/app/menu/internal/MenuScreenViewModel.kt
@@ -12,6 +12,7 @@ import com.flipcash.app.core.bill.Scannable
 import com.flipcash.app.core.extensions.setText
 import com.flipcash.app.core.share.TipCodeExportFormat
 import com.flipcash.app.core.share.TipCodeExporter
+import com.flipcash.app.core.ui.onboarding.TutorialItem
 import com.flipcash.app.core.util.Linkify
 import com.flipcash.app.featureflags.BetaFeature
 import com.flipcash.app.core.toast.SystemToastController
@@ -106,6 +107,9 @@ internal class MenuScreenViewModel @Inject constructor(
         // The gate, formatted (e.g. `$100 USD`). Carried next to [usernameProgress] because both the
         // card's locked subtitle and the sheet behind its tap quote it.
         val usernameMinimumBalance: String = "",
+        // The "Finish Your Profile" checklist, or null while the profile is unresolved. Only ever
+        // drawn under a claimed card — see [ClaimedTipCard].
+        val profileTutorial: List<TutorialItem.Profile>? = null,
     ) {
         /** The card to share, export or expand — only a claimed one qualifies. */
         val tipCard: Scannable.TipCard?
@@ -159,6 +163,10 @@ internal class MenuScreenViewModel @Inject constructor(
             val progress: UsernameProgress?,
             val minimumBalance: String,
         ) : Event
+        data class OnProfileTutorialChanged(val items: List<TutorialItem.Profile>?) : Event
+
+        /** The checklist's photo row — opens the photo step of the profile flow on its own. */
+        data object SetProfilePicture : Event
 
         /** The progress card's tap — claim a handle, or explain why it can't be claimed yet. */
         data object ClaimUsername : Event
@@ -272,6 +280,17 @@ internal class MenuScreenViewModel @Inject constructor(
             }
             .launchIn(viewModelScope)
 
+        // Gated on Ready for the same reason as the tip card: a named account restores its cached
+        // profile before auth completes, so the checklist would otherwise flash an outstanding
+        // photo step at someone who already has one.
+        userManager.state
+            .filter { it.authState is AuthState.Ready }
+            .map { it.userProfile }
+            .distinctUntilChanged()
+            .map { profileTutorialItems(it) }
+            .onEach { dispatchEvent(Event.OnProfileTutorialChanged(it)) }
+            .launchIn(viewModelScope)
+
         // The username nudge. Gated on Ready for the same reason as the tip card: a named account
         // restores its cached profile before auth completes, so the card would otherwise flash for
         // someone who already holds a handle.
@@ -359,6 +378,25 @@ internal class MenuScreenViewModel @Inject constructor(
                             includeName = true,
                             // Explicitly false: a name is all a tip card needs.
                             includePhoto = false,
+                        )
+                    )
+                )
+            }
+            .launchIn(viewModelScope)
+
+        eventFlow
+            .filterIsInstance<Event.SetProfilePicture>()
+            .onEach {
+                dispatchEvent(
+                    Event.OpenScreen(
+                        AppRoute.UpdateUserProfile(
+                            origin = AppRoute.Sheets.Menu,
+                            nameSource = DisplayNameSource.MyAccount,
+                            // Photo only: the account already has a name and a card by the time
+                            // this checklist is drawn, so the flow reduces to the one step.
+                            includeName = false,
+                            includePhoto = true,
+                            includeUsername = false,
                         )
                     )
                 )
@@ -520,10 +558,15 @@ internal class MenuScreenViewModel @Inject constructor(
                     )
                 }
 
+                is Event.OnProfileTutorialChanged -> { state ->
+                    state.copy(profileTutorial = event.items)
+                }
+
                 is Event.PresentDepositOptions,
                 Event.CheckForUpdate,
                 Event.ClaimTipCard,
                 Event.ClaimUsername,
+                Event.SetProfilePicture,
                 Event.ShareTipCard,
                 Event.CopyTipLink,
                 Event.DownloadTipCard,

--- a/apps/flipcash/features/menu/src/main/kotlin/com/flipcash/app/menu/internal/ProfileTutorial.kt
+++ b/apps/flipcash/features/menu/src/main/kotlin/com/flipcash/app/menu/internal/ProfileTutorial.kt
@@ -1,0 +1,20 @@
+package com.flipcash.app.menu.internal
+
+import com.flipcash.app.core.ui.onboarding.TutorialItem
+import com.flipcash.services.models.UserProfile
+
+/**
+ * The "Finish Your Profile" checklist for the "You" tab (node 9544:18140).
+ *
+ * Null while the profile is unresolved, so the card is never drawn against a guess — an account
+ * that already has a photo would otherwise flash an outstanding step on the way in.
+ *
+ * The minimum-tip step is always outstanding; see [TutorialItem.MinimumTip].
+ */
+internal fun profileTutorialItems(profile: UserProfile?): List<TutorialItem.Profile>? {
+    profile ?: return null
+    return listOf(
+        TutorialItem.ProfilePicture(isCompleted = profile.profilePicture != null),
+        TutorialItem.MinimumTip(),
+    )
+}

--- a/apps/flipcash/features/menu/src/test/kotlin/com/flipcash/app/menu/internal/ProfileTutorialTest.kt
+++ b/apps/flipcash/features/menu/src/test/kotlin/com/flipcash/app/menu/internal/ProfileTutorialTest.kt
@@ -1,0 +1,49 @@
+package com.flipcash.app.menu.internal
+
+import com.flipcash.app.core.ui.onboarding.TutorialItem
+import com.flipcash.services.models.UserProfile
+import com.flipcash.services.models.chat.MediaItem
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class ProfileTutorialTest {
+
+    // MediaItem is a plain data class over a rendition list, so an empty one stands in for
+    // "a picture is set" without needing a mocking library in this module.
+    private val anyPicture = MediaItem(renditions = emptyList())
+
+    private fun profile(picture: MediaItem?) = UserProfile(
+        displayName = "Brandon",
+        socialAccounts = emptyList(),
+        phoneNumber = null,
+        email = null,
+        profilePicture = picture,
+    )
+
+    @Test
+    fun `an unresolved profile has no checklist`() {
+        assertNull(profileTutorialItems(profile = null))
+    }
+
+    @Test
+    fun `a profile without a picture leaves both steps outstanding`() {
+        val items = profileTutorialItems(profile(picture = null))
+        assertEquals(2, items?.size)
+        assertTrue(items!!.none { it.isCompleted })
+    }
+
+    @Test
+    fun `a profile with a picture completes only the picture step`() {
+        val items = profileTutorialItems(profile(picture = anyPicture))
+        assertEquals(1, items?.count { it.isCompleted })
+        assertTrue(items!!.first { it is TutorialItem.ProfilePicture }.isCompleted)
+    }
+
+    @Test
+    fun `the minimum tip step never completes`() {
+        val items = profileTutorialItems(profile(picture = anyPicture))
+        assertTrue(items!!.none { it is TutorialItem.MinimumTip && it.isCompleted })
+    }
+}

--- a/apps/flipcash/features/user-profile/src/main/kotlin/com/flipcash/app/userprofile/internal/photo/PhotoSelectionScreen.kt
+++ b/apps/flipcash/features/user-profile/src/main/kotlin/com/flipcash/app/userprofile/internal/photo/PhotoSelectionScreen.kt
@@ -28,7 +28,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -67,6 +66,8 @@ internal fun PhotoSelectionScreen() {
 
     Column {
         AppBarWithTitle(
+            title = stringResource(R.string.title_setProfilePicture),
+            titleAlignment = Alignment.CenterHorizontally,
             onBackIconClicked = {
                 keyboard.hideIfVisible {
                     flowNavigator.back()
@@ -101,29 +102,8 @@ private fun PhotoSelectionScreenContent(
     CodeScaffold(
         modifier = Modifier
             .padding(horizontal = CodeTheme.dimens.inset),
-        topBar = {
-            Column(
-                modifier = Modifier.fillMaxWidth()
-                    .padding(top = CodeTheme.dimens.grid.x8),
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.spacedBy(CodeTheme.dimens.grid.x3),
-            ) {
-                Text(
-                    text = stringResource(R.string.title_profileImageSelection),
-                    style = CodeTheme.typography.textLarge,
-                    color = CodeTheme.colors.textMain,
-                )
-
-                Text(
-                    modifier = Modifier
-                        .padding(horizontal = CodeTheme.dimens.inset),
-                    text = stringResource(R.string.subtitle_profileImageSelection),
-                    style = CodeTheme.typography.textSmall,
-                    textAlign = TextAlign.Center,
-                    color = CodeTheme.colors.textSecondary,
-                )
-            }
-        },
+        // The app bar carries the title now; the body is just the photo and the name.
+        topBar = {},
         bottomBar = {
             Column(
                 modifier = Modifier.fillMaxWidth(),
@@ -135,7 +115,7 @@ private fun PhotoSelectionScreenContent(
                         .fillMaxWidth()
                         .navigationBarsPadding()
                         .padding(bottom = CodeTheme.dimens.grid.x3),
-                    text = stringResource(R.string.action_next),
+                    text = stringResource(R.string.action_save),
                     enabled = state.image.isLoaded() && state.processingState.isIdle,
                     isLoading = state.processingState.loading,
                     isSuccess = state.processingState.success,


### PR DESCRIPTION
The You tab had no prompt to finish setting up a profile. This adds the "Finish Your Profile" checklist from node 9641:16758, between the tip card's "Full Screen" caption and the tip-link row.

It reuses the wallet tab's `NewUserTutorial` rather than adding a second checklist component. To make that work the component moved from `:apps:flipcash:features:balance` to `:apps:flipcash:core-ui`, and `TutorialItem` split into two nested sealed families — `TutorialItem.Wallet` for the wallet milestones, `TutorialItem.Profile` for these two steps — so each call site's `when` stays exhaustive. `NewUserTutorial` is now generic over `T : TutorialItem`. The convention plugin already puts `core-ui` on every feature module, so no build files changed.

The photo row is live: it pushes `AppRoute.UpdateUserProfile` with `includeName = false, includePhoto = true`, landing straight on the picker. Completion comes from `profile.profilePicture != null`, so the row shows a green check and stops responding once a photo is set.

The minimum-tip row is drawn but inert. Nothing backs a user-set minimum tip on either platform yet; it's rendered because node 9641:17019 shows the counter as `1/2` with both rows present. That's separate scope.

The photo step is retitled everywhere it appears, including onboarding: the title moves into the app bar as "Set Profile Picture", the body title and subtitle are gone, and the primary button reads "Save" instead of "Next".
