### PR TITLE
fix(tipping): show the below-minimum tip prompt as info, not an alert

### DIFF
--- a/apps/flipcash/features/menu/src/main/kotlin/com/flipcash/app/menu/internal/ProfileTutorial.kt
+++ b/apps/flipcash/features/menu/src/main/kotlin/com/flipcash/app/menu/internal/ProfileTutorial.kt
@@ -4,7 +4,7 @@ import com.flipcash.app.core.ui.onboarding.TutorialItem
 import com.flipcash.services.models.UserProfile
 
 /**
- * The "Finish Your Profile" checklist for the "You" tab (node 9544:18140).
+ * The "Finish Your Profile" checklist for the "You" tab.
  *
  * Null while the profile is unresolved, so the card is never drawn against a guess — an account
  * that already has a photo would otherwise flash an outstanding step on the way in. Null again once

--- a/apps/flipcash/features/user-profile/src/main/kotlin/com/flipcash/app/userprofile/internal/mintip/MinimumTipEntryScreen.kt
+++ b/apps/flipcash/features/user-profile/src/main/kotlin/com/flipcash/app/userprofile/internal/mintip/MinimumTipEntryScreen.kt
@@ -16,8 +16,8 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 
 /**
- * Minimum-tip entry (nodes 9541:10951, 9553:113170). Leaving without saving discards the entry —
- * there is no draft to keep, so a changed-but-abandoned amount just doesn't reach the profile.
+ * Minimum-tip entry. Leaving without saving discards the entry — there is no draft to keep, so a
+ * changed-but-abandoned amount just doesn't reach the profile.
  *
  * @param isLastStep whether the flow ends here, which is the only thing that decides between
  * "Save" and "Next".

--- a/apps/flipcash/features/user-profile/src/main/kotlin/com/flipcash/app/userprofile/internal/mintip/MinimumTipEntryViewModel.kt
+++ b/apps/flipcash/features/user-profile/src/main/kotlin/com/flipcash/app/userprofile/internal/mintip/MinimumTipEntryViewModel.kt
@@ -33,8 +33,8 @@ import javax.inject.Inject
 import kotlin.math.abs
 
 /**
- * Backs the minimum-tip entry screen (nodes 9541:10951, 9553:113170) — the fee another user has to
- * pay to open a DM, which the profile carries as `minDmChatInitFee`.
+ * Backs the minimum-tip entry screen — the fee another user has to pay to open a DM, which the
+ * profile carries as `minDmChatInitFee`.
  *
  * Two things separate it from the send-side tip entry: there is no ceiling, since a user can ask
  * for any amount regardless of what anyone can afford, so the preset minimum is the only bound and
@@ -151,7 +151,9 @@ internal class MinimumTipEntryViewModel @Inject constructor(
 
                 val min = minimumAmount.value
                 if (min != null && amount.valueLessThan(min)) {
-                    BottomBarManager.showAlert(
+                    // Info, not alert: nothing has gone wrong and nothing is being destroyed —
+                    // the entry is just under the floor and needs raising.
+                    BottomBarManager.showInfo(
                         title = resources.getString(R.string.error_title_minimumTip, min.formatted()),
                         message = resources.getString(R.string.error_description_minimumTip),
                     )


### PR DESCRIPTION
Follow-up to #1360.

Entering a minimum tip under the floor put up a destructive red banner. The design calls for the info style — nothing has failed and nothing is being destroyed, the entry is just too low and needs raising. Saving still fails loudly, since that one is a real failure.

Also drops the Figma node ids from these files' KDoc. They don't survive file edits, so they go stale without anyone noticing.