### PR TITLE
feat(profile): confirm a profile change before it is written

### DIFF
--- a/apps/flipcash/core/src/main/res/values/strings.xml
+++ b/apps/flipcash/core/src/main/res/values/strings.xml
@@ -964,6 +964,23 @@
     <string name="error_title_usernameCheckFailed">Something Went Wrong</string>
     <string name="error_description_usernameCheckFailed">Please try again</string>
 
+    <!-- Confirmation before a profile edit is committed. Only shown on a change: a first display
+         name, username, picture, or minimum tip overwrites nothing, so there is nothing to warn
+         about. Username carries the extra sentence because the old handle is released on change
+         and someone else can claim it. -->
+    <string name="prompt_title_changeDisplayName">Change Display Name?</string>
+    <string name="prompt_description_changeDisplayName">Are you sure you want to permanently change your display name?</string>
+    <string name="action_changeDisplayName">Change Display Name</string>
+    <string name="prompt_title_changeUsername">Change Username?</string>
+    <string name="prompt_description_changeUsername">Are you sure you want to permanently change your username? You might not be able to get your old username back</string>
+    <string name="action_changeUsername">Change Username</string>
+    <string name="prompt_title_changeProfilePicture">Change Profile Picture?</string>
+    <string name="prompt_description_changeProfilePicture">Are you sure you want to permanently change your profile picture?</string>
+    <string name="action_changeProfilePicture">Change Profile Picture</string>
+    <string name="prompt_title_changeMinimumTip">Change Minimum Tip?</string>
+    <string name="prompt_description_changeMinimumTip">Are you sure you want to permanently change your minimum tip?</string>
+    <string name="action_changeMinimumTip">Change Minimum Tip</string>
+
     <!-- A tapped `flipcash.com/{username}` link that resolves to nothing. -->
     <string name="error_title_usernameNotFound">No Such Account</string>
     <string name="error_description_usernameNotFound">Nobody has claimed \@%1$s</string>

--- a/apps/flipcash/features/user-profile/src/main/kotlin/com/flipcash/app/userprofile/internal/mintip/MinimumTipEntryViewModel.kt
+++ b/apps/flipcash/features/user-profile/src/main/kotlin/com/flipcash/app/userprofile/internal/mintip/MinimumTipEntryViewModel.kt
@@ -9,6 +9,7 @@ import com.flipcash.shared.amountentry.AmountEntryDelegate
 import com.flipcash.shared.amountentry.AmountEntryLabel
 import com.flipcash.shared.amountentry.AmountEntryStyle
 import com.flipcash.shared.payments.TipPaymentDelegate
+import com.getcode.manager.BottomBarAction
 import com.getcode.manager.BottomBarManager
 import com.getcode.opencode.exchange.Exchange
 import com.getcode.opencode.model.financial.CurrencyCode
@@ -70,6 +71,12 @@ internal class MinimumTipEntryViewModel @Inject constructor(
 
         /** User asked to save the currently entered amount. */
         data object ConfirmRequested : Event
+
+        /**
+         * The entry cleared validation and, when one was already stored, the user confirmed
+         * replacing it. This is what actually writes to the profile.
+         */
+        data class CommitRequested(val amount: Fiat) : Event
 
         data class UpdateSavingState(
             val loading: Boolean = false,
@@ -158,8 +165,32 @@ internal class MinimumTipEntryViewModel @Inject constructor(
                     return@onEach
                 }
 
+                // Replacing a stored fee asks first; a first one has nothing to overwrite. Asked
+                // after validation so a rejected amount never gets a confirmation dialog.
+                if (stateFlow.value.saved == null) {
+                    dispatchEvent(Event.CommitRequested(amount))
+                    return@onEach
+                }
+                BottomBarManager.showAlert(
+                    title = resources.getString(R.string.prompt_title_changeMinimumTip),
+                    message = resources.getString(R.string.prompt_description_changeMinimumTip),
+                    actions = listOf(
+                        BottomBarAction(resources.getString(R.string.action_changeMinimumTip)) {
+                            dispatchEvent(Event.CommitRequested(amount))
+                        }
+                    ),
+                    showCancel = true,
+                )
+            }
+            .launchIn(viewModelScope)
+
+        eventFlow
+            .filterIsInstance<Event.CommitRequested>()
+            .onEach { event ->
+                if (!stateFlow.value.saving.isIdle) return@onEach
+
                 dispatchEvent(Event.UpdateSavingState(loading = true))
-                profileController.setMinDmChatInitFee(amount)
+                profileController.setMinDmChatInitFee(event.amount)
                     .onSuccess {
                         viewModelScope.launch {
                             dispatchEvent(Event.UpdateSavingState(success = true))
@@ -207,6 +238,7 @@ internal class MinimumTipEntryViewModel @Inject constructor(
                     )
                 }
                 is Event.ConfirmRequested -> { state -> state }
+                is Event.CommitRequested -> { state -> state }
                 is Event.Saved -> { state -> state }
             }
         }

--- a/apps/flipcash/features/user-profile/src/main/kotlin/com/flipcash/app/userprofile/internal/name/NameEntryScreen.kt
+++ b/apps/flipcash/features/user-profile/src/main/kotlin/com/flipcash/app/userprofile/internal/name/NameEntryScreen.kt
@@ -122,7 +122,7 @@ private fun NameEntryScreenContent(
                 isSuccess = state.processingState.success,
                 onClick = {
                     keyboard.hideIfVisible {
-                        dispatchEvent(NameEntryViewModel.Event.CheckName(source))
+                        dispatchEvent(NameEntryViewModel.Event.ConfirmNameChange(source))
                     }
                 },
             )
@@ -150,7 +150,7 @@ private fun NameEntryScreenContent(
                 ),
                 onKeyboardAction = {
                     keyboard.hideIfVisible {
-                        dispatchEvent(NameEntryViewModel.Event.CheckName(source))
+                        dispatchEvent(NameEntryViewModel.Event.ConfirmNameChange(source))
                     }
                 },
             )

--- a/apps/flipcash/features/user-profile/src/main/kotlin/com/flipcash/app/userprofile/internal/name/NameEntryViewModel.kt
+++ b/apps/flipcash/features/user-profile/src/main/kotlin/com/flipcash/app/userprofile/internal/name/NameEntryViewModel.kt
@@ -14,6 +14,7 @@ import com.flipcash.services.models.ModerationResult
 import com.flipcash.services.models.SetDisplayNameError
 import com.flipcash.services.models.TextModerationError
 import com.flipcash.services.user.UserManager
+import com.getcode.manager.BottomBarAction
 import com.getcode.manager.BottomBarManager
 import com.getcode.opencode.model.core.errors.ValidationException
 import com.getcode.util.resources.ResourceHelper
@@ -61,6 +62,12 @@ class NameEntryViewModel @Inject constructor(
     }
 
     sealed interface Event {
+        /**
+         * Save was pressed. Replacing a stored name asks first; a first name has nothing to
+         * overwrite and goes straight to [CheckName].
+         */
+        data class ConfirmNameChange(val source: DisplayNameSource) : Event
+
         data class CheckName(val source: DisplayNameSource) : Event
         data class UpdateProcessingState(
             val loading: Boolean = false,
@@ -94,6 +101,25 @@ class NameEntryViewModel @Inject constructor(
                 if (pristine) {
                     stateFlow.value.nameFieldState.setTextAndPlaceCursorAtEnd(name)
                 }
+            }.launchIn(viewModelScope)
+
+        eventFlow
+            .filterIsInstance<Event.ConfirmNameChange>()
+            .onEach { event ->
+                if (stateFlow.value.savedName.isBlank()) {
+                    dispatchEvent(Event.CheckName(event.source))
+                    return@onEach
+                }
+                BottomBarManager.showAlert(
+                    title = resources.getString(R.string.prompt_title_changeDisplayName),
+                    message = resources.getString(R.string.prompt_description_changeDisplayName),
+                    actions = listOf(
+                        BottomBarAction(resources.getString(R.string.action_changeDisplayName)) {
+                            dispatchEvent(Event.CheckName(event.source))
+                        }
+                    ),
+                    showCancel = true,
+                )
             }.launchIn(viewModelScope)
 
         eventFlow
@@ -194,6 +220,7 @@ class NameEntryViewModel @Inject constructor(
     internal companion object {
         val updateStateForEvent: (Event) -> (State.() -> State) = { event ->
             when (event) {
+                is Event.ConfirmNameChange -> { state -> state }
                 is Event.CheckName -> { state -> state }
                 is Event.OnSavedNameLoaded -> { state -> state.copy(savedName = event.name) }
                 Event.DiscardChanges -> { state -> state }

--- a/apps/flipcash/features/user-profile/src/main/kotlin/com/flipcash/app/userprofile/internal/photo/PhotoSelectionScreen.kt
+++ b/apps/flipcash/features/user-profile/src/main/kotlin/com/flipcash/app/userprofile/internal/photo/PhotoSelectionScreen.kt
@@ -124,7 +124,7 @@ private fun PhotoSelectionScreenContent(
                     isLoading = state.processingState.loading,
                     isSuccess = state.processingState.success,
                     onClick = {
-                        dispatchEvent(PhotoSelectionViewModel.Event.CheckImage)
+                        dispatchEvent(PhotoSelectionViewModel.Event.ConfirmImageChange)
                     },
                 )
             }

--- a/apps/flipcash/features/user-profile/src/main/kotlin/com/flipcash/app/userprofile/internal/photo/PhotoSelectionViewModel.kt
+++ b/apps/flipcash/features/user-profile/src/main/kotlin/com/flipcash/app/userprofile/internal/photo/PhotoSelectionViewModel.kt
@@ -21,6 +21,7 @@ import com.flipcash.services.models.TextModerationError
 import com.flipcash.services.models.chat.MediaItem
 import com.flipcash.services.models.chat.RejectionReason
 import com.flipcash.services.user.UserManager
+import com.getcode.manager.BottomBarAction
 import com.getcode.manager.BottomBarManager
 import com.getcode.opencode.model.core.errors.ValidationException
 import com.getcode.util.resources.ContentReader
@@ -88,6 +89,12 @@ class PhotoSelectionViewModel @Inject constructor(
     }
 
     sealed interface Event {
+        /**
+         * Save was pressed. Replacing a stored picture asks first; a first picture has nothing to
+         * overwrite and goes straight to [CheckImage].
+         */
+        data object ConfirmImageChange : Event
+
         data object CheckImage : Event
 
         /** The stored picture arrived, or changed — including to null when it is unset. */
@@ -123,6 +130,25 @@ class PhotoSelectionViewModel @Inject constructor(
             .onEach { dispatchEvent(Event.UploadPolicyLoaded(it)) }
             .launchIn(viewModelScope)
 
+
+        eventFlow
+            .filterIsInstance<Event.ConfirmImageChange>()
+            .onEach {
+                if (stateFlow.value.savedPicture == null) {
+                    dispatchEvent(Event.CheckImage)
+                    return@onEach
+                }
+                BottomBarManager.showAlert(
+                    title = resources.getString(R.string.prompt_title_changeProfilePicture),
+                    message = resources.getString(R.string.prompt_description_changeProfilePicture),
+                    actions = listOf(
+                        BottomBarAction(resources.getString(R.string.action_changeProfilePicture)) {
+                            dispatchEvent(Event.CheckImage)
+                        }
+                    ),
+                    showCancel = true,
+                )
+            }.launchIn(viewModelScope)
 
         eventFlow
             .filterIsInstance<Event.OnImageSelected>()
@@ -405,6 +431,7 @@ class PhotoSelectionViewModel @Inject constructor(
 
         internal val updateStateForEvent: (Event) -> (State.() -> State) = { event ->
             when (event) {
+                Event.ConfirmImageChange -> { state -> state }
                 Event.CheckImage -> { state -> state }
                 is Event.OnSavedPictureLoaded -> { state ->
                     state.copy(savedPicture = event.picture)

--- a/apps/flipcash/features/user-profile/src/main/kotlin/com/flipcash/app/userprofile/internal/username/UsernameEntryScreen.kt
+++ b/apps/flipcash/features/user-profile/src/main/kotlin/com/flipcash/app/userprofile/internal/username/UsernameEntryScreen.kt
@@ -114,7 +114,7 @@ private fun UsernameEntryScreenContent(
                 isSuccess = state.processingState.success,
                 onClick = {
                     keyboard.hideIfVisible {
-                        dispatchEvent(UsernameEntryViewModel.Event.CheckUsername)
+                        dispatchEvent(UsernameEntryViewModel.Event.ConfirmUsernameChange)
                     }
                 },
             )
@@ -140,7 +140,7 @@ private fun UsernameEntryScreenContent(
                 ),
                 onKeyboardAction = {
                     keyboard.hideIfVisible {
-                        dispatchEvent(UsernameEntryViewModel.Event.CheckUsername)
+                        dispatchEvent(UsernameEntryViewModel.Event.ConfirmUsernameChange)
                     }
                 },
                 inputTransformation = UsernameInputTransformation,

--- a/apps/flipcash/features/user-profile/src/main/kotlin/com/flipcash/app/userprofile/internal/username/UsernameEntryViewModel.kt
+++ b/apps/flipcash/features/user-profile/src/main/kotlin/com/flipcash/app/userprofile/internal/username/UsernameEntryViewModel.kt
@@ -73,8 +73,9 @@ class UsernameEntryViewModel @Inject constructor(
 
     sealed interface Event {
         /**
-         * Save was pressed. Changing a claimed handle asks first — the old one is released and
-         * anyone can take it — while a first claim goes straight to [CheckUsername].
+         * Save was pressed. Checks the length, then, when a handle is already claimed, asks
+         * before replacing it — the old one is released and anyone can take it. A first claim
+         * that clears the length check goes straight to [CheckUsername].
          */
         data object ConfirmUsernameChange : Event
 
@@ -116,6 +117,17 @@ class UsernameEntryViewModel @Inject constructor(
         eventFlow
             .filterIsInstance<Event.ConfirmUsernameChange>()
             .onEach {
+                // Length is checked here rather than on the way to the server, so an input that
+                // could never be claimed says why instead of asking the user to confirm claiming
+                // it. Mirrors iOS, whose `submit()` bails on `UsernameValidator.failure(for:)`
+                // before it calls `setUsername`. The charset is already held by the field's input
+                // transformation, so length is all that is left to check locally.
+                lengthComplaint(stateFlow.value.usernameFieldState.text.toString())
+                    ?.let { complaint ->
+                        handleUsernameSetFailure(complaint)
+                        return@onEach
+                    }
+
                 if (stateFlow.value.savedUsername.isBlank()) {
                     dispatchEvent(Event.CheckUsername)
                     return@onEach
@@ -143,11 +155,7 @@ class UsernameEntryViewModel @Inject constructor(
             .filterIsInstance<Event.CheckUsername>()
             .onEach { dispatchEvent(Event.UpdateProcessingState(loading = true)) }
             .map { stateFlow.value.usernameFieldState.text.toString() }
-            .map { username ->
-                lengthComplaint(username)
-                    ?.let { Result.failure(it) }
-                    ?: profileController.setUsername(username)
-            }
+            .map { username -> profileController.setUsername(username) }
             .onResult(
                 onSuccess = {
                     viewModelScope.launch {

--- a/apps/flipcash/features/user-profile/src/main/kotlin/com/flipcash/app/userprofile/internal/username/UsernameEntryViewModel.kt
+++ b/apps/flipcash/features/user-profile/src/main/kotlin/com/flipcash/app/userprofile/internal/username/UsernameEntryViewModel.kt
@@ -12,6 +12,7 @@ import com.flipcash.services.models.MinUsernameLength
 import com.flipcash.services.models.ModerationResult
 import com.flipcash.services.models.SetUsernameError
 import com.flipcash.services.user.UserManager
+import com.getcode.manager.BottomBarAction
 import com.getcode.manager.BottomBarManager
 import com.getcode.opencode.model.core.errors.ValidationException
 import com.getcode.opencode.model.financial.Fiat
@@ -71,6 +72,12 @@ class UsernameEntryViewModel @Inject constructor(
     }
 
     sealed interface Event {
+        /**
+         * Save was pressed. Changing a claimed handle asks first — the old one is released and
+         * anyone can take it — while a first claim goes straight to [CheckUsername].
+         */
+        data object ConfirmUsernameChange : Event
+
         data object CheckUsername : Event
         data class UpdateProcessingState(
             val loading: Boolean = false,
@@ -104,6 +111,25 @@ class UsernameEntryViewModel @Inject constructor(
                 if (pristine) {
                     stateFlow.value.usernameFieldState.setTextAndPlaceCursorAtEnd(username)
                 }
+            }.launchIn(viewModelScope)
+
+        eventFlow
+            .filterIsInstance<Event.ConfirmUsernameChange>()
+            .onEach {
+                if (stateFlow.value.savedUsername.isBlank()) {
+                    dispatchEvent(Event.CheckUsername)
+                    return@onEach
+                }
+                BottomBarManager.showAlert(
+                    title = resources.getString(R.string.prompt_title_changeUsername),
+                    message = resources.getString(R.string.prompt_description_changeUsername),
+                    actions = listOf(
+                        BottomBarAction(resources.getString(R.string.action_changeUsername)) {
+                            dispatchEvent(Event.CheckUsername)
+                        }
+                    ),
+                    showCancel = true,
+                )
             }.launchIn(viewModelScope)
 
         eventFlow
@@ -225,6 +251,7 @@ class UsernameEntryViewModel @Inject constructor(
     internal companion object {
         val updateStateForEvent: (Event) -> (State.() -> State) = { event ->
             when (event) {
+                Event.ConfirmUsernameChange -> { state -> state }
                 Event.CheckUsername -> { state -> state }
                 is Event.OnSavedUsernameLoaded -> { state ->
                     state.copy(savedUsername = event.username)


### PR DESCRIPTION
Saving a display name, username, profile picture, or minimum tip wrote straight through on the first tap. Each of those four is an overwrite with no undo, and the username case is worse than the rest: changing a handle releases the old one, so someone else can claim it.

Each of the four screens now dispatches a confirm event from its Save button instead of the save event. The ViewModel gate shows a destructive (red) `BottomBarManager.showAlert` with one filled action and `showCancel = true`; only that action dispatches the original save event. The save pipelines are otherwise untouched.

Copy follows one template — "Change X?" / "Are you sure you want to permanently change your X?" / "Change X" / "Cancel" — with username carrying an extra sentence: "You might not be able to get your old username back".

Two judgment calls worth a second opinion:

**The prompt only fires on a change.** "Permanently change your X" doesn't fit a first claim, and the display-name step is mandatory during onboarding, where a confirmation would sit on a screen you can't back out of. Each gate checks the stored value first (`savedUsername.isBlank()`, `savedName.isBlank()`, `savedPicture == null`, `saved == null`) and goes straight to the save when there isn't one.

**"Profile Picture", not "Profile Photo".** That matches the My Account row and the rest of that surface (`title_profilePicture`, `title_setProfilePicture`).

Both gates that have something local to check run the check first, so an entry that can never be saved says why instead of asking the user to confirm saving it:

- **Username** — the length check moved out of the `CheckUsername` pipeline and into the gate, ahead of both the confirmation and the first-claim path. This matches iOS, whose `submit()` returns on `UsernameValidator.failure(for:)` before it calls `setUsername`. Only the local rules move: taken, moderated, reserved, and insufficient balance all come back from `setUsername` itself, which is the claim as well as the check, so there is nothing to pre-check without claiming the handle.
- **Minimum tip** — the confirmation sits after the below-minimum validation, so an amount the server would reject still gets the existing minimum-tip error. Its write moved into a new `CommitRequested` event so it runs on `viewModelScope` instead of from the dialog's callback.

Display name and profile picture have no local rules to hoist. The name step's only client-side gate is non-blank, which already disables Save, and a picture's size and type are checked when it is picked.

No new tests. The gates live in the ViewModels' init flows, which need mocked Hilt dependencies; the existing `*StateTest` files only exercise the pure reducer, where the new events are pass-throughs.

The same change on iOS is [code-payments/code-ios-app#688](https://github.com/code-payments/code-ios-app/pull/688). That one already validated the username locally before submitting, which is where the second commit here comes from.
