### PR TITLE
perf(r8): keep exception names without keeping every exception

### DIFF
--- a/apps/flipcash/app/proguard-rules.pro
+++ b/apps/flipcash/app/proguard-rules.pro
@@ -1,7 +1,9 @@
 # Preserve source file names and line numbers for stack traces (call site tracking, Bugsnag)
 -keepattributes SourceFile,LineNumberTable
 
-# Keep AppRoute class names for analytics screen tracking
+# Keep AppRoute class names. `annotatedEntry` derives each screen's root test tag
+# from the route's simple name (NavMetadata.screenRootTag), so obfuscating these
+# renames every screen-root resource-id the UI tests address.
 -keepnames class com.flipcash.app.core.AppRoute
 -keepnames class com.flipcash.app.core.AppRoute$**
 
@@ -15,7 +17,11 @@
 -keep class * extends io.grpc.stub.AbstractStub { *; }
 -keep class * implements io.grpc.BindableService { *; }
 
-# Keep our scan classes that interact with native
+# Keep our scan classes that interact with native. The scanner's JNI constructs
+# these from C++ by name (FindClass("com/kik/scan/UsernameKikCode"), GetMethodID
+# for <init>) and reads their backing fields directly (GetFieldID for "_username",
+# "nativePtr"), none of which AGP's default native-methods rule covers. Five
+# classes, so the wildcard costs little.
 -keep class com.kik.scan.** { *; }
 
 -assumenosideeffects class android.util.Log {
@@ -26,4 +32,10 @@
     public static int e(...);
 }
 
--keep public class * extends java.lang.Throwable
+# Error telemetry reads exception names at runtime — Coinbase onramp traces send
+# `it::class.simpleName` as `errorType`, and Events.kt does the same for analytics.
+# Those are plain strings by the time they leave the device, so the Bugsnag mapping
+# upload cannot repair them; the names have to survive obfuscation. Nothing reads
+# the members, and an exception nothing throws need not survive, so this is
+# -keepnames rather than a full keep.
+-keepnames public class * extends java.lang.Throwable


### PR DESCRIPTION
Stacked on #1371.

`-keep public class * extends java.lang.Throwable` kept 972 classes whole. Only their *names* are load-bearing.

### Why the names have to stay

The Coinbase onramp traces send `it::class.simpleName` as `errorType` (`CoinbaseOnRampController.kt:326,385,451`), and `Events.kt:90,103` does the same for analytics. By the time those leave the device they are plain strings, so the Bugsnag mapping upload cannot repair them. Deleting the rule outright would turn every `errorType` in telemetry into a one-character name.

### Why the members and the classes themselves need not

Nothing reads the members, and an exception nothing constructs need not survive. `-keepnames` is the rule that states exactly that.

### Measured, release build

| | `-keep` | `-keepnames` |
|---|---|---|
| DEX (uncompressed) | 16,101,032 | 16,028,404 |
| classes | 21,361 | 21,020 |
| members | 1,330,404 | 1,329,949 |

72,628 bytes, 341 classes.

The dropped set is what the old rule was propping up — 316 of 357 have `Error` or `Exception` in the name, led by `com.flipcash.services.models` (94) and `com.getcode.opencode.model` (41). `AddReactionError` and its six subclasses are representative: `ChatMessagingService.addReaction` has no caller outside tests, and R8 had already shrunk the method in *both* builds, so the rule was holding the error classes alive on their own.

`CoinbaseOnRampApiError` and `GetJwtError` subclass names are unchanged in the new mapping.

### Two comment corrections

Both rules were described as doing something other than what the code does.

The `AppRoute` rule is not for analytics. `annotatedEntry` derives each screen's root test tag from the route's simple name via `NavMetadata.screenRootTag`, so obfuscating those renames every screen-root resource-id the UI tests address. The rule stays; the comment now says why.

The `com.kik.scan` wildcard is genuinely load-bearing. The scanner's JNI constructs those classes by name from C++ (`FindClass("com/kik/scan/UsernameKikCode")`, `GetMethodID` for `<init>`) and reads their backing fields through `GetFieldID` (`_username`, `nativePtr`) — none of which AGP's default `-keepclasseswithmembernames class * { native <methods>; }` covers. Five classes, so the wildcard costs little.