### PR TITLE
fix(chat): stop naming the reserve in the cash preview

### DIFF
--- a/apps/flipcash/shared/chat-ui/src/main/kotlin/com/flipcash/shared/chat/ui/ChatSummaryMapping.kt
+++ b/apps/flipcash/shared/chat-ui/src/main/kotlin/com/flipcash/shared/chat/ui/ChatSummaryMapping.kt
@@ -58,7 +58,13 @@ private fun ChatSummary.formatPreview(
             }
             is MessageContent.Cash -> {
                 val formatted = content.amount.formatted()
-                val name = content.tokenName.ifBlank { tokensByMint[content.mint]?.name.orEmpty() }
+                // The reserve is branded "Dollars", so naming it reads as "$1.00 of Dollars" —
+                // the amount alone already says it. Every other token still gets named.
+                val name = if (content.mint == Mint.usdf) {
+                    ""
+                } else {
+                    content.tokenName.ifBlank { tokensByMint[content.mint]?.name.orEmpty() }
+                }
                 val label = if (name.isNotBlank()) {
                     resources.getString(R.string.label_chat_preview_cash_suffix, formatted, name)
                 } else {


### PR DESCRIPTION
A cash message preview appended the token name whenever the message carried one, so a Dollars transfer read "You sent $1.00 of Dollars". USDF is branded "Dollars" and the formatted amount already carries the dollar sign, so the suffix repeats the unit it just printed.

`formatPreview` in `ChatSummaryMapping` took `content.tokenName` unconditionally, falling back to the mint lookup, and wrapped any non-blank result in `label_chat_preview_cash_suffix` (`"%1$s of %2$s"`). The reserve mint now resolves to an empty name, which drops the label to the bare formatted amount. Every other token still gets named, since "$1.00 of Waylon" is the only thing that says which currency moved.

This is the same rule the swap processing screen already applies through `isConvertingToDollars`.

`MessageBubble`'s `CashBubble` still renders the icon-and-name header for the reserve. That reads as a token identity chip rather than a sentence, so it is left alone here.
