### PR TITLE
fix(profile): confirm the reversible profile changes in the grey banner

### DIFF
--- a/apps/flipcash/core/src/main/res/values/strings.xml
+++ b/apps/flipcash/core/src/main/res/values/strings.xml
@@ -967,18 +967,20 @@
     <!-- Confirmation before a profile edit is committed. Only shown on a change: a first display
          name, username, picture, or minimum tip overwrites nothing, so there is nothing to warn
          about. Username carries the extra sentence because the old handle is released on change
-         and someone else can claim it. -->
+         and someone else can claim it — the only one of the four the user may not be able to undo,
+         so the only one shown in the red banner. The rest state what the change does and confirm in
+         the grey one. -->
     <string name="prompt_title_changeDisplayName">Change Display Name?</string>
-    <string name="prompt_description_changeDisplayName">Are you sure you want to permanently change your display name?</string>
+    <string name="prompt_description_changeDisplayName">This will change your display name</string>
     <string name="action_changeDisplayName">Change Display Name</string>
     <string name="prompt_title_changeUsername">Change Username?</string>
     <string name="prompt_description_changeUsername">Are you sure you want to permanently change your username? You might not be able to get your old username back</string>
     <string name="action_changeUsername">Change Username</string>
     <string name="prompt_title_changeProfilePicture">Change Profile Picture?</string>
-    <string name="prompt_description_changeProfilePicture">Are you sure you want to permanently change your profile picture?</string>
+    <string name="prompt_description_changeProfilePicture">This will change your profile picture</string>
     <string name="action_changeProfilePicture">Change Profile Picture</string>
     <string name="prompt_title_changeMinimumTip">Change Minimum Tip?</string>
-    <string name="prompt_description_changeMinimumTip">Are you sure you want to permanently change your minimum tip?</string>
+    <string name="prompt_description_changeMinimumTip">This will change your minimum tip</string>
     <string name="action_changeMinimumTip">Change Minimum Tip</string>
 
     <!-- A tapped `flipcash.com/{username}` link that resolves to nothing. -->

--- a/apps/flipcash/features/user-profile/src/main/kotlin/com/flipcash/app/userprofile/internal/mintip/MinimumTipEntryViewModel.kt
+++ b/apps/flipcash/features/user-profile/src/main/kotlin/com/flipcash/app/userprofile/internal/mintip/MinimumTipEntryViewModel.kt
@@ -173,7 +173,7 @@ internal class MinimumTipEntryViewModel @Inject constructor(
                     dispatchEvent(Event.CommitRequested(amount))
                     return@onEach
                 }
-                BottomBarManager.showAlert(
+                BottomBarManager.showMessage(
                     title = resources.getString(R.string.prompt_title_changeMinimumTip),
                     message = resources.getString(R.string.prompt_description_changeMinimumTip),
                     actions = listOf(

--- a/apps/flipcash/features/user-profile/src/main/kotlin/com/flipcash/app/userprofile/internal/name/NameEntryViewModel.kt
+++ b/apps/flipcash/features/user-profile/src/main/kotlin/com/flipcash/app/userprofile/internal/name/NameEntryViewModel.kt
@@ -110,7 +110,7 @@ class NameEntryViewModel @Inject constructor(
                     dispatchEvent(Event.CheckName(event.source))
                     return@onEach
                 }
-                BottomBarManager.showAlert(
+                BottomBarManager.showMessage(
                     title = resources.getString(R.string.prompt_title_changeDisplayName),
                     message = resources.getString(R.string.prompt_description_changeDisplayName),
                     actions = listOf(

--- a/apps/flipcash/features/user-profile/src/main/kotlin/com/flipcash/app/userprofile/internal/photo/PhotoSelectionViewModel.kt
+++ b/apps/flipcash/features/user-profile/src/main/kotlin/com/flipcash/app/userprofile/internal/photo/PhotoSelectionViewModel.kt
@@ -138,7 +138,7 @@ class PhotoSelectionViewModel @Inject constructor(
                     dispatchEvent(Event.CheckImage)
                     return@onEach
                 }
-                BottomBarManager.showAlert(
+                BottomBarManager.showMessage(
                     title = resources.getString(R.string.prompt_title_changeProfilePicture),
                     message = resources.getString(R.string.prompt_description_changeProfilePicture),
                     actions = listOf(


### PR DESCRIPTION
All four profile-change confirmations went through `BottomBarManager.showAlert`, so changing a display name, profile picture, or minimum tip raised the red destructive banner and asked "Are you sure you want to permanently change ...?" — the same treatment as changing a username, which releases the old handle for anyone to claim and is the only one of the four the user may not be able to undo.

The three reversible edits now use `showMessage` (`DEFAULT` → `bannerThemed`, `#252526`) and state what the change does:

| Field | Message |
|---|---|
| Display name | This will change your display name |
| Profile picture | This will change your profile picture |
| Minimum tip | This will change your minimum tip |

Titles and confirm buttons are unchanged, and username keeps the red banner along with its sentence about losing the old handle.

This is the shape iOS already ships: `DialogItem.confirmProfileChange` routes username to `.alert` and the other three to `.info` on the same wording. iOS says "profile photo" in its subtitle while its title and button say "Profile Picture"; this keeps "picture" throughout, so the Android modal is internally consistent and the two platforms differ by that one noun.