### PR TITLE
fix(chat): stop the send bounce and drop the receipt reveal's scale

### DIFF
--- a/apps/flipcash/features/messenger/src/main/kotlin/com/flipcash/app/messenger/internal/screens/components/MessageList.kt
+++ b/apps/flipcash/features/messenger/src/main/kotlin/com/flipcash/app/messenger/internal/screens/components/MessageList.kt
@@ -302,12 +302,17 @@ internal fun MessageList(
                     // Always scroll for own messages; only near-bottom for incoming
                     val nearBottom = listState.firstVisibleItemIndex <= 5
                     val newest = messages.peek(0) as? ChatListItem.ContentBubble
-                    if (newest?.isFromSelf == true || nearBottom) {
-                        if (nearBottom) {
-                            listState.animateScrollToItem(0)
-                        } else {
-                            listState.scrollToItem(0)
-                        }
+                    when {
+                        // Own message: anchor the new bubble during the next measure pass
+                        // rather than animating to it. An animated scroll resolves its target
+                        // offset up front, so the previous message's receipt collapsing out
+                        // from under it moves the target mid-flight and the list overshoots
+                        // and corrects — read as the bubble bouncing. iOS never hand-rolls
+                        // this scroll at all: ChatLayout's keepContentOffsetAtBottomOnBatchUpdates
+                        // pins the bottom edge across the one batch that both inserts the new
+                        // cell and reconfigures the old one's receipt away.
+                        newest?.isFromSelf == true -> listState.requestScrollToItem(0, 0)
+                        nearBottom -> listState.animateScrollToItem(0)
                     }
                 }
         }

--- a/apps/flipcash/features/messenger/src/main/kotlin/com/flipcash/app/messenger/internal/screens/components/ReceiptLabel.kt
+++ b/apps/flipcash/features/messenger/src/main/kotlin/com/flipcash/app/messenger/internal/screens/components/ReceiptLabel.kt
@@ -84,9 +84,10 @@ internal fun ReceiptLabel(
     ) {
         AnimatedVisibility(
             visible = deliveredVisible,
+            // Expand + opacity, no scale: iOS un-hides the label and cross-fades its text in,
+            // letting the cell self-size. The line itself never scales.
             enter = if (animateEntrance) {
-                expandVertically() +
-                        scaleIn(deliveredSpec, initialScale = 0.95f) + fadeIn(deliveredSpec)
+                expandVertically() + fadeIn(deliveredSpec)
             } else {
                 expandVertically(snap()) + fadeIn(snap())
             },


### PR DESCRIPTION
Two animation bugs when sending a message, both reported against the iOS behaviour.

### The bubble bounced on send

`MessageList` ran `animateScrollToItem(0)` for the newly sent message while the previous message's receipt label collapsed its height away above it. An animated scroll resolves its target offset when it starts, so the collapse moved that target mid-flight and the list overshot and corrected. That correction is what read as the bubble bouncing.

Own messages now use `requestScrollToItem(0, 0)`. The new bubble is anchored during the next measure pass, in the same frame the receipt collapses, so there is no target to move. Incoming messages keep the animated scroll when the reader is near the bottom.

iOS has no scroll here to race in the first place. `ChatViewController` never computes a content offset by hand, and ChatLayout's `keepContentOffsetAtBottomOnBatchUpdates` pins the bottom edge across the single `performBatchUpdates` that both inserts the new cell and reconfigures the old one's receipt away.

One behaviour change: sending while scrolled well up the transcript now snaps to the newest message instead of the previous instant `scrollToItem(0)`. Same destination, and the animated branch was never taken in that case.

### The receipt reveal scaled

The "Delivered" line grew in with `expandVertically() + scaleIn(0.95f) + fadeIn`. The scale has no counterpart on iOS: `ChatColumnCell` un-hides a `ChatReceiptLabel` inside its stack view and cross-fades the text, so the line only ever changes opacity while the cell self-sizes around it. The vertical growth is the cell resizing, which is what `expandVertically` already models.

`scaleIn` is removed from the reveal. The expand, the fade, the receipt's exit, the Delivered/Read swap, and every spring spec in `ChatAnimations` are unchanged, since design signed off on the current tuning.
