### PR TITLE
build(shared-core): resolve a local XCFramework when FLIPCASH_SHARED_CORE_LOCAL is set

### DIFF
--- a/kmp/shared-core/spm/.gitignore
+++ b/kmp/shared-core/spm/.gitignore
@@ -1,0 +1,3 @@
+# Left behind by `swift package` / `xcodebuild` runs against this package.
+.build/
+.swiftpm/

--- a/kmp/shared-core/spm/Package.swift
+++ b/kmp/shared-core/spm/Package.swift
@@ -1,5 +1,6 @@
 // swift-tools-version:5.9
 import PackageDescription
+import Foundation
 
 // The publish job rewrites this block — everything else in this file is ours. Note the
 // tags are load-bearing: KMMBridge looks for them verbatim and fails the publish if
@@ -9,6 +10,46 @@ let remoteKotlinUrl = "https://api.github.com/repos/code-payments/flipcash-share
 let remoteKotlinChecksum = "b86241d770fa186e44eec4c9ff0ff092d54cf66329828485d243cb7b6cf588b5"
 let packageName = "SharedCore"
 // END KMMBRIDGE BLOCK
+
+// FLIPCASH_SHARED_CORE_LOCAL points at a code-android-app checkout and swaps the published
+// XCFramework for one assembled from that checkout's Kotlin, so a Kotlin change can be tried
+// from an iOS build without cutting a release and moving a tag:
+//
+//   ./gradlew :kmp:shared-core:assembleSharedCoreReleaseXCFramework
+//
+// This manifest is what gets published, so the override also works from the tagged copy the
+// iOS app resolves — nothing on the iOS side has to change. That copy sits in DerivedData, and
+// SwiftPM only accepts a binary target path relative to the package root, so the absolute path
+// the variable gives us is rewritten as a relative one from wherever the manifest was checked
+// out to.
+//
+// The publish workflow never sets the variable, so CI always resolves the binary target
+// through the URL and checksum above.
+func relativePath(from base: String, to target: String) -> String {
+    let from = (base as NSString).resolvingSymlinksInPath.split(separator: "/").map(String.init)
+    let to = (target as NSString).resolvingSymlinksInPath.split(separator: "/").map(String.init)
+    var shared = 0
+    while shared < from.count, shared < to.count, from[shared] == to[shared] { shared += 1 }
+    return (Array(repeating: "..", count: from.count - shared) + to[shared...]).joined(separator: "/")
+}
+
+let sharedCoreLocalRoot = ProcessInfo.processInfo.environment["FLIPCASH_SHARED_CORE_LOCAL"]
+    .map { ($0 as NSString).expandingTildeInPath }
+    .flatMap { $0.isEmpty ? nil : $0 }
+
+let binaryTarget: Target = sharedCoreLocalRoot.map {
+    .binaryTarget(
+        name: packageName,
+        path: relativePath(
+            from: Context.packageDirectory,
+            to: "\($0)/kmp/shared-core/build/XCFrameworks/release/\(packageName).xcframework"
+        )
+    )
+} ?? .binaryTarget(
+    name: packageName,
+    url: remoteKotlinUrl,
+    checksum: remoteKotlinChecksum
+)
 
 let package = Package(
     name: packageName,
@@ -25,11 +66,7 @@ let package = Package(
         ),
     ],
     targets: [
-        .binaryTarget(
-            name: packageName,
-            url: remoteKotlinUrl,
-            checksum: remoteKotlinChecksum
-        ),
+        binaryTarget,
         .target(
             name: "SharedCoreKit",
             dependencies: [.target(name: packageName)]


### PR DESCRIPTION
Android compiles `:kmp:shared-core` from source, so a Kotlin change shows up in the next Android build. iOS consumes it as a published XCFramework pinned by version, so the same change needed the publish workflow, a moved tag, and a bumped pin before it could be tried at all. Setting `FLIPCASH_SHARED_CORE_LOCAL` to a `code-android-app` checkout swaps the published binary for one assembled from that checkout:

```bash
./gradlew :kmp:shared-core:assembleSharedCoreReleaseXCFramework
export FLIPCASH_SHARED_CORE_LOCAL=~/dev/bmcreations/code/code-android-app
xed ../code-ios-app
```

This is `FLIPCASH_PROTO_LOCAL`'s equivalent for shared-core, and it matters more: the derivation and bonding-curve moves are far more iterative than the beachhead was.

**Why the switch is in the package manifest and not in the app.** The iOS app reaches `SharedCoreKit` twice — `FlipcashUI/Package.swift` depends on it, and `Code.xcodeproj` carries its own `XCRemoteSwiftPackageReference` because the app target imports it directly. Overriding only FlipcashUI leaves the project reference on the published package, and resolution fails with `multiple similar targets 'SharedCore', 'SharedCoreKit' appear in package 'spm' and 'flipcash-shared-core-spm'`. A SwiftPM mirror doesn't help either: it will only map a source-control dependency onto another git repository, not onto a directory. Putting the switch in this manifest works because the publish job copies it verbatim into the SPM repo, so the tagged copy the app resolves carries the same conditional and both consumers follow it — `code-ios-app` needs no change.

Two constraints follow from that. The variable holds a path to the checkout, since the published manifest lands in DerivedData with no Kotlin beside it; and SwiftPM rejects an absolute binary-target path, so the manifest rewrites it relative to `Context.packageDirectory`.

The override reaches the app only once a release carrying this manifest is published — `0.3.1` predates it. The facade work cuts `0.4.0` anyway, so this needs no publish of its own.

Local state can't ship: the opt-in is an environment variable, so no manifest is edited and `Package.resolved` is unchanged; the publish workflow never sets it, and its verify step compiles against the uploaded asset. If the variable is set and the framework hasn't been assembled, resolution fails naming the missing path rather than falling back to the published binary.

The loop is written up in `docs/shared-core-local-development.md` in the orchestrator repo.
