### PR TITLE
ci(shared-core): resolve the framework over the unauthenticated download URL

### DIFF
--- a/.github/workflows/publish-shared-core.yml
+++ b/.github/workflows/publish-shared-core.yml
@@ -88,6 +88,20 @@ jobs:
             -PsharedCoreVersion=${{ inputs.version }} \
             -PspmRepoDir=$GITHUB_WORKSPACE/spm-repo
 
+      # KMMBridge points the binary target at the release asset's *API* URL, which
+      # serves private repos but is rate limited to 60 requests an hour per IP for
+      # anyone unauthenticated. This repo is public, so the plain download URL fetches
+      # the same bytes with no limit and no credentials -- without this, a developer or
+      # a CI runner that has spent its anonymous quota fails to resolve the package.
+      - name: Point the binary target at the unauthenticated download URL
+        working-directory: spm-repo
+        run: |
+          set -euo pipefail
+          download="https://github.com/${SPM_REPO}/releases/download/${{ inputs.version }}/SharedCore.xcframework.zip"
+          perl -pi -e 's{^let remoteKotlinUrl = ".*"$}{let remoteKotlinUrl = "'"$download"'"}' Package.swift
+          grep -q "$download" Package.swift
+          curl -fsSLI "$download" > /dev/null
+
       # The release asset is up by now but the tag still points at the old
       # Package.swift, so nothing consumes this build until the next step. Compiling
       # the Swift glue against the framework we just uploaded is the last moment a


### PR DESCRIPTION
The 0.4.0 publish run failed at its own verify step:

```
failed downloading 'https://api.github.com/repos/code-payments/flipcash-shared-core-spm/releases/assets/540211749.zip'
which is required by binary target 'SharedCore': badResponseStatusCode(403)
```

KMMBridge points the binary target at the release asset's **API** URL. That endpoint serves private repos, but it rate limits unauthenticated callers to 60 requests an hour per IP — which is what a shared macOS runner, or a developer resolving the package, hits. `flipcash-shared-core-spm` is public, so `github.com/<repo>/releases/download/<tag>/SharedCore.xcframework.zip` serves the same bytes with no limit and no credentials.

This step already existed: it was written for the 0.3.1 publish, which was dispatched from `feat/shared-badge-cgpath`. That branch never opened a PR, so `code/cash` has never carried the fix and the next publish from `code/cash` was the first to hit it. The workflow file here is byte-identical to the one 0.3.1 published from.

After the rewrite the step greps the URL back out of `Package.swift` and `curl -I`s it, so a wrong tag or a missing asset fails before the tag moves.

### Fallout to clean up separately

Tag `0.4.0` and release `0.4.0` exist in `flipcash-shared-core-spm` — the release upload creates them before the verify step runs. Because "Commit and tag the Swift Package" was skipped, the tag still points at `5b1a6e83` ("SharedCore 0.3.1"), so `0.4.0` currently resolves to the **0.3.1** binary. It has to be deleted and re-cut, or skipped in favour of `0.4.1`, before anything depends on it.
