### PR TITLE
fix(chat): capitalize Message in the delete confirmation title

### DIFF
--- a/apps/flipcash/core/src/main/res/values/strings.xml
+++ b/apps/flipcash/core/src/main/res/values/strings.xml
@@ -909,7 +909,7 @@
     <string name="action_deleteForEveryone">Delete For Everyone</string>
     <string name="action_cancelEdit">Cancel edit</string>
     <string name="action_confirmEdit">Confirm edit</string>
-    <string name="title_deleteMessage">Delete message?</string>
+    <string name="title_deleteMessage">Delete Message?</string>
     <string name="description_deleteMessage">This can\'t be undone</string>
     <string name="title_messageNotEdited">Message Not Edited</string>
     <string name="description_messageNotEdited">Your change couldn\'t be saved, so the message is unchanged.</string>


### PR DESCRIPTION
The delete confirmation modal read "Delete message?", out of step with the other chat modal titles next to it in `strings.xml` — `Message Not Edited` and `Message Not Deleted` are both title case.

One string change: `title_deleteMessage` is now "Delete Message?".