### PR TITLE
feat(flipcash): thread message edit/delete windows through UserFlags

### DIFF
--- a/apps/flipcash/shared/userflags/src/main/kotlin/com/flipcash/app/userflags/ResolvedUserFlags.kt
+++ b/apps/flipcash/shared/userflags/src/main/kotlin/com/flipcash/app/userflags/ResolvedUserFlags.kt
@@ -37,6 +37,8 @@ data class ResolvedUserFlags(
     val requireCoinbaseEmailVerification: ResolvedFlag<Boolean>,
     val tipPresets: ResolvedFlag<List<TipPresets>>,
     val usernameMinBalance: ResolvedFlag<Fiat>,
+    val messageEditWindow: ResolvedFlag<Duration?>,
+    val messageDeleteWindow: ResolvedFlag<Duration?>,
 )
 
 internal fun UserFlags.resolve(overrides: Overrides): ResolvedUserFlags = ResolvedUserFlags(
@@ -56,4 +58,7 @@ internal fun UserFlags.resolve(overrides: Overrides): ResolvedUserFlags = Resolv
     requireCoinbaseEmailVerification = ResolvedFlag(requireCoinbaseEmailVerification, overrides.requireCoinbaseEmailVerification),
     tipPresets = ResolvedFlag(tipPresets, FieldOverride.None),
     usernameMinBalance = ResolvedFlag(usernameMinBalance, FieldOverride.None),
+    // Read-only for now — no debug override support until the edit/delete UI lands.
+    messageEditWindow = ResolvedFlag(messageEditWindow, FieldOverride.None),
+    messageDeleteWindow = ResolvedFlag(messageDeleteWindow, FieldOverride.None),
 )

--- a/apps/flipcash/shared/userflags/src/main/kotlin/com/flipcash/app/userflags/UserFlagsCoordinator.kt
+++ b/apps/flipcash/shared/userflags/src/main/kotlin/com/flipcash/app/userflags/UserFlagsCoordinator.kt
@@ -182,6 +182,8 @@ private data class CachedFlags(
     val requireCoinbaseEmailVerification: Boolean,
     val tipPresets: List<CachedTipPresets> = emptyList(),
     val usernameMinBalance: CachedFiat = CachedFiat(quarks = 0),
+    val messageEditWindowMillis: Long? = null,
+    val messageDeleteWindowMillis: Long? = null,
 ) {
     fun toDomain(): UserFlags = UserFlags(
         isStaff = isStaff,
@@ -202,6 +204,8 @@ private data class CachedFlags(
         requireCoinbaseEmailVerification = requireCoinbaseEmailVerification,
         tipPresets = tipPresets.map { it.toDomain() },
         usernameMinBalance = usernameMinBalance.toDomain(),
+        messageEditWindow = messageEditWindowMillis?.milliseconds,
+        messageDeleteWindow = messageDeleteWindowMillis?.milliseconds,
     )
 
     companion object {
@@ -226,6 +230,8 @@ private data class CachedFlags(
             requireCoinbaseEmailVerification = flags.requireCoinbaseEmailVerification,
             tipPresets = flags.tipPresets.map { CachedTipPresets.fromDomain(it) },
             usernameMinBalance = CachedFiat.fromDomain(flags.usernameMinBalance),
+            messageEditWindowMillis = flags.messageEditWindow?.inWholeMilliseconds,
+            messageDeleteWindowMillis = flags.messageDeleteWindow?.inWholeMilliseconds,
         )
     }
 }

--- a/apps/flipcash/shared/userflags/src/test/kotlin/com/flipcash/app/userflags/ResolvedUserFlagsTest.kt
+++ b/apps/flipcash/shared/userflags/src/test/kotlin/com/flipcash/app/userflags/ResolvedUserFlagsTest.kt
@@ -36,6 +36,8 @@ class ResolvedUserFlagsTest {
         assertEquals(true, resolved.requireCoinbaseEmailVerification.effectiveValue)
         assertEquals(ServerFlags.tipPresets, resolved.tipPresets.effectiveValue)
         assertEquals(Fiat(quarks = 5_000_000L), resolved.usernameMinBalance.effectiveValue)
+        assertEquals(15.seconds, resolved.messageEditWindow.effectiveValue)
+        assertEquals(60.seconds, resolved.messageDeleteWindow.effectiveValue)
     }
 
     @Test
@@ -142,6 +144,8 @@ private val ServerFlags = UserFlags(
         TipPresets(region = "US", minimum = 1.0, low = 2.0, medium = 3.0, high = 4.0),
     ),
     usernameMinBalance = Fiat(quarks = 5_000_000L),
+    messageEditWindow = 15.seconds,
+    messageDeleteWindow = 60.seconds,
 )
 
 // Every value here differs from the matching server value above, so a flag that reads the

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -69,7 +69,7 @@ protovalidate-kt = "0.1.1"
 # 0.3.0 is the first release of either package to ship R8 keep rules for its generated
 # messages, which is what lets proguard-rules.pro drop its own.
 ocp-client-protocol = "0.3.0"
-flipcash2-client-protocol = "0.3.0"
+flipcash2-client-protocol = "0.4.0"
 
 # The Android port is the ONLY libphonenumber this app depends on, deliberately. Google's
 # `com.googlecode` artifact used to sit alongside it; the two ship separate copies of the metadata,

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/internal/domain/UserFlagsMapper.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/internal/domain/UserFlagsMapper.kt
@@ -32,6 +32,12 @@ internal class UserFlagsMapper @Inject constructor():
             requireCoinbaseEmailVerification = from.requireCoinbaseEmailVerification,
             tipPresets = from.tipPresetsList.map { it.toDomain() },
             usernameMinBalance = Fiat(quarks = from.usernameMinBalance),
+            messageEditWindow = if (from.hasMessageEditWindow()) {
+                from.messageEditWindow.seconds.toDuration(DurationUnit.SECONDS)
+            } else null,
+            messageDeleteWindow = if (from.hasMessageDeleteWindow()) {
+                from.messageDeleteWindow.seconds.toDuration(DurationUnit.SECONDS)
+            } else null,
         )
     }
 }

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/models/UserFlags.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/models/UserFlags.kt
@@ -23,6 +23,12 @@ data class UserFlags(
     val tipPresets: List<TipPresets>,
     // USDF that must be held across all currencies before a username can be set.
     val usernameMinBalance: Fiat,
+    // Duration after message creation when a message can be edited. Absent when
+    // the server hasn't set a window (not the same as a zero-length window).
+    val messageEditWindow: Duration?,
+    // Duration after message creation when a message can be deleted. Absent when
+    // the server hasn't set a window (not the same as a zero-length window).
+    val messageDeleteWindow: Duration?,
 ) {
     companion object {
         val Default = UserFlags(
@@ -42,6 +48,8 @@ data class UserFlags(
             requireCoinbaseEmailVerification = false,
             tipPresets = emptyList(),
             usernameMinBalance = Fiat.Zero,
+            messageEditWindow = null,
+            messageDeleteWindow = null,
         )
     }
 }

--- a/services/flipcash/src/test/kotlin/com/flipcash/services/internal/domain/UserFlagsMapperTest.kt
+++ b/services/flipcash/src/test/kotlin/com/flipcash/services/internal/domain/UserFlagsMapperTest.kt
@@ -180,4 +180,27 @@ class UserFlagsMapperTest {
 
         assertTrue(result.tipPresets.isEmpty())
     }
+
+    @Test
+    fun `maps message edit and delete windows when set`() {
+        val proto = FlipcashAccountService.UserFlags.newBuilder()
+            .setMessageEditWindow(com.google.protobuf.Duration.newBuilder().setSeconds(15).build())
+            .setMessageDeleteWindow(com.google.protobuf.Duration.newBuilder().setSeconds(60).build())
+            .build()
+
+        val result = mapper.map(proto)
+
+        assertEquals(15.seconds, result.messageEditWindow)
+        assertEquals(60.seconds, result.messageDeleteWindow)
+    }
+
+    @Test
+    fun `message edit and delete windows are null when unset, not zero`() {
+        val proto = userFlags { }
+
+        val result = mapper.map(proto)
+
+        assertNull(result.messageEditWindow)
+        assertNull(result.messageDeleteWindow)
+    }
 }


### PR DESCRIPTION
Threads the two new `UserFlags` durations from [flipcash2-protobuf-api#89](https://github.com/code-payments/flipcash2-protobuf-api/pull/89) through to the domain layer, and pins the contract package release that carries them.

## Blocked on the release

**Draft until `com.flipcash:flipcash2-client-protocol:0.4.0` is on Maven Central.** That version does not exist yet — it is published from [flipcash2-client-protocol#7](https://github.com/code-payments/flipcash2-client-protocol/pull/7), which has to merge first. Until then CI reports `com.flipcash:flipcash2-client-protocol:0.4.0 FAILED` at resolution.

The scaffolding was developed and tested against the client checkout directly, via `protoLocalRoot` in `local.properties`. CI never sees that override — `local.properties` is untracked — so it resolves the pin and nothing else.

## Contract change

Two fields appended to `account.v1.UserFlags`, both `google.protobuf.Duration` with explicit presence:

- `message_edit_window = 17` — the window after a message is created during which it can still be edited
- `message_delete_window = 18` — the same, for deletion

Nothing else in the contract moved, and nothing was renumbered.

## What this does

- `UserFlags` gains `messageEditWindow: Duration?` and `messageDeleteWindow: Duration?`, both `null` in `Default`.
- `UserFlagsMapper` maps them behind `hasMessageEditWindow()` / `hasMessageDeleteWindow()`, so an unset field stays `null` rather than becoming a zero-length window. That matches the `hasX()`-guarded convention in `UserProfileMapper` and `ChatMetadataMapper`.
- `ResolvedUserFlags` exposes both as read-only `ResolvedFlag<Duration?>` with `FieldOverride.None`.
- `UserFlagsCoordinator.CachedFlags` round-trips them through the offline cache. This was not optional: `CachedFlags.toDomain()` calls the `UserFlags` constructor positionally, so it would not compile otherwise. Both default to `null`, so previously cached JSON still deserializes.

Tests cover the mapper for both the set and absent cases, and `ResolvedUserFlagsTest` asserts the resolved values.

## Scope

No edit or delete behaviour is wired up — this stops at getting the values into the domain layer. The debug flags UI (`UserFlagsViewModel`, `Field.kt`, `strings.xml`) is untouched.
