### PR TITLE
fix(flipcash): treat an unset bill_exchange_data_timeout as absent

### DIFF
--- a/services/flipcash/src/main/kotlin/com/flipcash/services/internal/domain/UserFlagsMapper.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/internal/domain/UserFlagsMapper.kt
@@ -22,7 +22,9 @@ internal class UserFlagsMapper @Inject constructor():
             preferredOnRampProvider = from.preferredOnRampProvider.toDomain().takeIf { it != OnRampProvider.Unknown },
             supportedOnRampProviders = from.supportedOnRampProvidersList.map { it.toDomain() },
             minimumVersion = from.minBuildNumber,
-            billExchangeDataTimeout = from.billExchangeDataTimeout.seconds.toDuration(DurationUnit.SECONDS),
+            billExchangeDataTimeout = if (from.hasBillExchangeDataTimeout()) {
+                from.billExchangeDataTimeout.seconds.toDuration(DurationUnit.SECONDS)
+            } else null,
             newCurrencyPurchaseAmount = Fiat(quarks = from.newCurrencyPurchaseAmount),
             newCurrencyFeeAmount = Fiat(quarks = from.newCurrencyFeeAmount),
             withdrawalFeeAmount = Fiat(quarks = from.withdrawalFeeAmount),

--- a/services/flipcash/src/main/kotlin/com/flipcash/services/models/UserFlags.kt
+++ b/services/flipcash/src/main/kotlin/com/flipcash/services/models/UserFlags.kt
@@ -12,6 +12,9 @@ data class UserFlags(
     val preferredOnRampProvider: OnRampProvider?,
     val supportedOnRampProviders: List<OnRampProvider>,
     val minimumVersion: Int?,
+    // How long a verified exchange rate stays usable for a bill. Absent when the
+    // server hasn't set a timeout (not the same as a zero-length one, which
+    // disables verified exchange data entirely).
     val billExchangeDataTimeout: Duration?,
     val newCurrencyPurchaseAmount: Fiat,
     val newCurrencyFeeAmount: Fiat,

--- a/services/flipcash/src/test/kotlin/com/flipcash/services/internal/domain/UserFlagsMapperTest.kt
+++ b/services/flipcash/src/test/kotlin/com/flipcash/services/internal/domain/UserFlagsMapperTest.kt
@@ -117,6 +117,15 @@ class UserFlagsMapperTest {
     }
 
     @Test
+    fun `bill exchange data timeout is null when unset, not zero`() {
+        val proto = userFlags { }
+
+        val result = mapper.map(proto)
+
+        assertNull(result.billExchangeDataTimeout)
+    }
+
+    @Test
     fun `maps new currency purchase amount`() {
         val proto = userFlags {
             newCurrencyPurchaseAmount = 5_000_000L


### PR DESCRIPTION
`bill_exchange_data_timeout` is a `google.protobuf.Duration`, so an unset field still deserializes to the default instance. `UserFlagsMapper` read it unconditionally and turned that into `0.seconds`, even though the domain field is `Duration?` and `UserFlags.Default` uses `null`. A consumer could not tell "no timeout configured" from "timeout of zero".

This guards the mapping on `hasBillExchangeDataTimeout()`, which is how every other optional message-typed field in this package is read — `UserProfileMapper`'s `profilePicture` and `joinTs`, `ChatMetadataMapper`'s `lastMessage`.

## Why the distinction matters

`VerifiedState.exchangeDataFor` treats the two values as opposites:

```kotlin
val timeout = billExchangeDataTimeout ?: DefaultBillExchangeDataTimeout // 15.minutes
if (timeout <= Duration.ZERO) return null
```

So for any user whose flags omitted the field, `GiveBillTransactor.start` discarded the `VerifiedState` it already held — however fresh the rate was — and fell into its "rate expired" branch, refetching a verified state on every bill presentation. When that refetch failed (offline, or no rate for the currency/mint pair) the give flow returned `ExchangeRateExpiredException` while holding a usable rate. With `null` the held state gets the intended 15 minute window.

A server that deliberately sends `0s` still disables verified exchange data, unchanged.

## Consumers

No changes needed. `Field.BillExchangeDataTimeout` already encodes `null` as `-1L` and formats it as `"None"`, `CachedFlags` round-trips it as a nullable `Long`, and `TransactionController`'s gift-card path never passed the flag — it relies on the same `null` default.

The one visible difference is the debug flags screen, which now reads "None" rather than "0s" when the server omits the field.
