### PR TITLE
fix(userflags): give the message window overrides their test cases

### DIFF
--- a/apps/flipcash/shared/userflags/src/test/kotlin/com/flipcash/app/userflags/ResolvedUserFlagsTest.kt
+++ b/apps/flipcash/shared/userflags/src/test/kotlin/com/flipcash/app/userflags/ResolvedUserFlagsTest.kt
@@ -211,4 +211,16 @@ private val OverrideCases: List<OverrideCase<*>> = listOf(
         set = { copy(requireCoinbaseEmailVerification = it) },
         select = { it.requireCoinbaseEmailVerification },
     ),
+    OverrideCase(
+        name = "messageEditWindow",
+        overrideValue = 45.seconds,
+        set = { copy(messageEditWindow = it) },
+        select = { it.messageEditWindow },
+    ),
+    OverrideCase(
+        name = "messageDeleteWindow",
+        overrideValue = 120.seconds,
+        set = { copy(messageDeleteWindow = it) },
+        select = { it.messageDeleteWindow },
+    ),
 )


### PR DESCRIPTION
`ResolvedUserFlagsTest > every Overrides field has a case` has failed on `code/cash` since #1403 merged, taking `:apps:flipcash:shared:userflags:testDebugUnitTest` down on every PR.

That PR made the message edit and delete windows overridable, adding `messageEditWindow` and `messageDeleteWindow` to `Overrides` without matching entries in `OverrideCases`. The guard test exists to catch precisely this — its doc says a new field on `Overrides` has to gain a case here — so it was doing its job.

Adding the two cases restores the guard and brings both fields under the `resolve()` checks the rest of the list already gets: that an override lands on its own field, leaves the others alone, and is not reported for `Overrides.None`. Both override values differ from the server baseline (45s against 15s, 120s against 60s), per the note above the list, so a field reading the wrong override cannot pass by coincidence.