### PR TITLE
test(chat): cover the selection bar's re-narrowing of a stale bubble

### DIFF
--- a/apps/flipcash/features/messenger/src/test/kotlin/com/flipcash/app/messenger/internal/ChatMessageActionReducerTest.kt
+++ b/apps/flipcash/features/messenger/src/test/kotlin/com/flipcash/app/messenger/internal/ChatMessageActionReducerTest.kt
@@ -3,6 +3,7 @@ package com.flipcash.app.messenger.internal
 import androidx.compose.foundation.text.input.TextFieldState
 import com.flipcash.services.models.chat.MessageContent
 import com.flipcash.shared.chat.MessageCapability
+import com.flipcash.shared.chat.MessagePolicy
 import com.flipcash.shared.chat.models.ChatListItem
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -10,6 +11,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Instant
 
 /**
@@ -56,6 +58,36 @@ class ChatMessageActionReducerTest {
 
         assertEquals(target, state.selection)
         assertEquals(target.capabilities, state.selectionCapabilities)
+    }
+
+    @Test
+    fun `selecting a bubble past its edit window drops Edit`() {
+        // The transcript resolved this bubble when it was mapped, which may have been well inside a
+        // window that has since closed. Offering Edit anyway costs a round-trip the server answers
+        // CANNOT_EDIT. sentAt is decades old, so any finite window here has closed.
+        val state = reduce(
+            ChatViewModel.State(messagePolicy = MessagePolicy(editWindow = 5.minutes)),
+            ChatViewModel.Event.ToggleMessageSelection(bubble(1)),
+        )
+
+        assertEquals(
+            setOf(MessageCapability.Copy, MessageCapability.Delete),
+            state.selectionCapabilities,
+        )
+    }
+
+    @Test
+    fun `selecting a bubble past its delete window drops Delete`() {
+        // Separate from the case above so a window wired to the wrong capability cannot pass both.
+        val state = reduce(
+            ChatViewModel.State(messagePolicy = MessagePolicy(deleteWindow = 5.minutes)),
+            ChatViewModel.Event.ToggleMessageSelection(bubble(1)),
+        )
+
+        assertEquals(
+            setOf(MessageCapability.Copy, MessageCapability.Edit),
+            state.selectionCapabilities,
+        )
     }
 
     @Test


### PR DESCRIPTION
#1403 made the `ToggleMessageSelection` reducer re-apply the edit and delete windows to the bubble it selects, so a transcript row that resolved well inside a window stops offering an action the server would answer `CANNOT_EDIT` or `CANNOT_DELETE`. Nothing asserted that behaviour, which is how the gap went unnoticed.

One test per window, because a window wired to the wrong capability would pass either test on its own. Both were checked against a reducer with the narrowing removed and fail there, so neither is vacuous.

The bubble helper's `sentAt` is decades in the past, so any finite window in the test has closed by the time the reducer compares it against `Clock.System.now()`.