### PR TITLE
chore(deps): drop the unused Navigation 2 dependencies

### DIFF
--- a/apps/flipcash/app/build.gradle.kts
+++ b/apps/flipcash/app/build.gradle.kts
@@ -9,7 +9,6 @@ plugins {
     id("org.jetbrains.kotlin.plugin.parcelize")
     id("com.google.devtools.ksp")
     id("org.jetbrains.kotlin.plugin.serialization")
-    alias(libs.plugins.navigation.safeargs)
     id("dagger.hilt.android.plugin")
     alias(libs.plugins.google.services)
     alias(libs.plugins.firebase.perf)
@@ -294,7 +293,6 @@ dependencies {
     implementation(libs.androidx.core)
     implementation(libs.androidx.lifecycle.runtime)
     implementation(libs.androidx.lifecycle.viewmodel)
-    implementation(libs.androidx.navigation.ui)
     implementation(libs.androidx.work)
     implementation(libs.androidx.webkit)
 

--- a/apps/flipcash/app/build.gradle.kts
+++ b/apps/flipcash/app/build.gradle.kts
@@ -295,6 +295,8 @@ dependencies {
     implementation(libs.androidx.lifecycle.viewmodel)
     implementation(libs.androidx.work)
     implementation(libs.androidx.webkit)
+    // Resources only: Theme.Code in res/values/themes.xml extends Theme.MaterialComponents.
+    implementation(libs.google.material)
 
     //hilt dependency injection
     implementation(libs.hilt.android)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,7 +37,6 @@ plugins {
     alias(libs.plugins.firebase.perf) apply false
     alias(libs.plugins.bugsnag.gradle) apply false
     alias(libs.plugins.secrets) apply false
-    alias(libs.plugins.navigation.safeargs) apply false
     alias(libs.plugins.androidx.room) apply false
     alias(libs.plugins.screenshot) apply false
     alias(libs.plugins.kover)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -55,6 +55,7 @@ play-service-ml-barcode = "18.3.1"
 play-services-auth-api-phone = "18.3.1"
 google-play-billing = "9.1.0"
 google-play-updates = "2.1.0"
+google-material = "1.4.0"
 
 grpc = "1.83.1"
 grpc-okhttp = "1.83.1"
@@ -245,6 +246,7 @@ google-play-billing-runtime = { module = "com.android.billingclient:billing", ve
 google-play-billing-ktx = { module = "com.android.billingclient:billing-ktx", version.ref = "google-play-billing" }
 google-play-app-updates-runtime = { module = "com.google.android.play:app-update", version.ref = "google-play-updates" }
 google-play-app-updates-ktx = { module = "com.google.android.play:app-update-ktx", version.ref = "google-play-updates" }
+google-material = { module = "com.google.android.material:material", version.ref = "google-material" }
 
 # Kin
 kin-sdk = { module = "org.kin.sdk.android:base", version.ref = "kin-sdk" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,7 +25,6 @@ androidx-core = "1.19.0"
 androidx-datastore = "1.2.1"
 androidx-exif = "1.4.2"
 androidx-lifecycle = "2.11.0"
-androidx-navigation = "2.9.8"
 navigation3 = "1.1.4"
 navigation3-lifecycle = "2.11.0"
 androidx-browser = "1.10.0"
@@ -142,8 +141,6 @@ androidx-exifinterface = { module = "androidx.exifinterface:exifinterface", vers
 androidx-lifecycle-process = { module = "androidx.lifecycle:lifecycle-process", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-runtime = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-viewmodel = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "androidx-lifecycle" }
-androidx-navigation-fragment = { module = "androidx.navigation:navigation-fragment-ktx", version.ref = "androidx-navigation" }
-androidx-navigation-ui = { module = "androidx.navigation:navigation-ui-ktx", version.ref = "androidx-navigation" }
 navigation3-runtime = { module = "androidx.navigation3:navigation3-runtime", version.ref = "navigation3" }
 navigation3-ui = { module = "androidx.navigation3:navigation3-ui", version.ref = "navigation3" }
 lifecycle-viewmodel-navigation3 = { module = "androidx.lifecycle:lifecycle-viewmodel-navigation3", version.ref = "navigation3-lifecycle" }
@@ -357,7 +354,6 @@ google-services = { id = "com.google.gms.google-services", version.ref = "google
 firebase-perf = { id = "com.google.firebase.firebase-perf", version.ref = "firebase-perf-plugin" }
 bugsnag-gradle = { id = "com.bugsnag.gradle", version.ref = "bugsnag-gradle-plugin" }
 secrets = { id = "com.google.android.libraries.mapsplatform.secrets-gradle-plugin", version.ref = "secrets-gradle-plugin" }
-navigation-safeargs = { id = "androidx.navigation.safeargs.kotlin", version.ref = "androidx-navigation" }
 androidx-room = { id = "androidx.room", version.ref = "androidx-room" }
 androidx-baselineprofile = { id = "androidx.baselineprofile", version.ref = "androidx-benchmark-macro" }
 screenshot = { id = "com.android.compose.screenshot", version.ref = "screenshot" }

--- a/ui/theme/build.gradle.kts
+++ b/ui/theme/build.gradle.kts
@@ -19,5 +19,4 @@ dependencies {    debugImplementation(libs.compose.ui.tools)
     implementation(libs.androidx.appcompat)
     implementation(libs.androidx.core)
     implementation(libs.androidx.activity)
-    implementation(libs.androidx.navigation.fragment)
 }


### PR DESCRIPTION
Dependabot opened #1411 to bump Navigation from 2.9.8 to 2.10.0. No code uses Navigation 2, so this removes the dependency instead of upgrading it.

Navigation happens through Navigation 3 behind `CodeNavigator`. The Navigation 2 artifacts that were still declared:

- `navigation-fragment-ktx` in `:ui:theme`
- `navigation-ui-ktx` in the app module
- the `androidx.navigation.safeargs.kotlin` plugin, in both the root and app build scripts
- the `androidx-navigation` version and its three catalog aliases

No Kotlin source imports `androidx.navigation`, and there is no navigation graph XML, no `NavHostFragment`, and no generated `Directions` or `Args` classes.

Two things were reaching the build transitively through these artifacts, and only one of them survives the removal on its own.

`FragmentActivity`, used by `Context.getActivity()` in `ui/theme/src/main/kotlin/com/getcode/ui/utils/View.kt`, came in through `navigation-fragment-ktx`. It still resolves, because `:ui:theme` declares `androidx-appcompat`, which has an `api` dependency on `androidx.fragment`.

`com.google.android.material:material` came in through `navigation-ui-ktx`, which pins it at 1.4.0, and it was never declared anywhere in the build. `Theme.Code` in `apps/flipcash/app/src/main/res/values/themes.xml` extends `Theme.MaterialComponents.DayNight.NoActionBar`, so removing `navigation-ui-ktx` failed `processDebugResources` on the theme parent and on `colorPrimaryVariant`, `colorOnPrimary`, `colorSecondary`, `colorSecondaryVariant` and `colorOnSecondary`. The second commit declares it explicitly at 1.4.0, the version already resolving, which keeps this a build-graph change rather than a theming one. Material 1.5 reworked the color attributes, so a bump belongs in its own PR.

Closes #1411.