### PR TITLE
build(deps): bump agp from 9.3.2 to 9.4.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ kotlinx-serialization = "1.11.0"
 kotlinx-datetime = "0.8.0"
 
 kover = "0.9.9"
-agp = "9.3.2"
+agp = "9.4.0"
 kmmbridge = "1.2.1"
 google-services = "4.5.0"
 


### PR DESCRIPTION
Replaces #1413. Dependabot opened that PR for the same bump, then closed it in response to a `@dependabot rebase` with "Looks like these dependencies are up-to-date now, so this is no longer needed." It was evaluating its own branch, which already carried 9.4.0, rather than the base. `code/cash` is on 9.3.2 and `com.android.tools.build:gradle:9.4.0` is published, so the bump still applies. A `@dependabot reopen` did not bring it back, hence this branch.

The change is the `agp` version in the catalog, which drives `com.android.application`, `com.android.library`, `com.android.kotlin.multiplatform.library` and `com.android.tools.build:gradle`.

`:apps:flipcash:app:bundleRelease` links and shrinks off this branch, with `minifyReleaseWithR8` executing rather than resolving up to date. That is worth doing by hand for an AGP bump: `flipcash_tests` builds `flipcashTestDebug` and `lintDebug` only, so CI never exercises R8, and this project sets `android.enableR8.fullMode=true`. The build emits the same warning set as 9.3.2 — six pre-existing `package`-attribute manifest notices, nothing new — and the bundle is 14KB larger, which is noise rather than a shrinking regression.

Worth noting that #1408 landed between Dependabot's PR and this one, so this branch is the first release build covering AGP 9.4.0 together with `androidx-benchmark-macro` 1.5.0-rc02. The two share a plugin surface through `androidx.baselineprofile`, which the app module applies.
