### PR TITLE
fix(shared-core): keep symlinks in the macOS XCFramework zip

### DIFF
--- a/kmp/shared-core/build.gradle.kts
+++ b/kmp/shared-core/build.gradle.kts
@@ -1,3 +1,6 @@
+import co.touchlab.kmmbridge.KmmBridgeExtension
+import org.gradle.api.tasks.bundling.Zip
+
 plugins {
     kotlin("multiplatform")
     id("com.android.kotlin.multiplatform.library")
@@ -68,5 +71,35 @@ kmmbridge {
     spm(spmDirectory = spmPackageDir, useCustomPackageFile = true, swiftToolVersion = "5.9") {
         iOS { v("15") }
         macOS { v("14") }
+    }
+}
+
+// KMMBridge 1.2.1's `zipXCFramework` task (a bare Gradle `Zip` task, only registered when
+// `ENABLE_PUBLISHING=true`) dereferences symlinks instead of preserving them. A macOS framework
+// bundle depends entirely on symlinks — `Versions/Current -> A`, and the top-level
+// Headers/Modules/Resources/binary each symlink into `Versions/Current/*` — so the archive it
+// produces for the macOS slice ships three literal duplicate copies of the same content instead of
+// a real `Versions/A` plus symlinks. That breaks codesign for anything that consumes the macOS
+// slice (nested-bundle signing needs the real bundle layout). `matching {}.configureEach {}` is a
+// no-op when the task doesn't exist (i.e. every non-publishing build), and applies once KMMBridge
+// registers it otherwise, regardless of task-registration order.
+tasks.withType<Zip>().matching { it.name == "zipXCFramework" }.configureEach {
+    // Resolved at configuration time — `project` can't be touched inside `doLast` under the
+    // configuration cache, so only plain values and the `ProviderFactory` itself cross into it.
+    val buildType = project.extensions.getByType<KmmBridgeExtension>().buildType.get().getName()
+    val sourceDir = project.layout.buildDirectory.dir("XCFrameworks/$buildType").get().asFile
+    val execOperations = project.providers
+    doLast {
+        val xcframeworkDir = sourceDir.listFiles { file -> file.isDirectory && file.name.endsWith(".xcframework") }
+            ?.singleOrNull()
+            ?: error("Expected exactly one .xcframework under $sourceDir")
+        val zipFile = archiveFile.get().asFile
+        zipFile.delete()
+        // `-y` stores symlinks as symlinks instead of following them (the default `zip` behavior,
+        // and Gradle's `Zip` task, both dereference).
+        execOperations.exec {
+            workingDir = sourceDir
+            commandLine("zip", "-y", "-r", zipFile.absolutePath, xcframeworkDir.name)
+        }.result.get()
     }
 }


### PR DESCRIPTION
KMMBridge's `zipXCFramework` task is a bare Gradle `Zip` task, and Gradle's `Zip`/`CopySpec` machinery dereferences symlinks instead of storing them. A macOS framework bundle is built entirely from symlinks — `Versions/Current -> A`, and the top-level `Headers`/`Modules`/`Resources`/binary each symlinking into `Versions/Current/*` — so the archive KMMBridge produces for the macOS slice ships three literal duplicate copies of the same content instead of the real bundle layout. iOS framework bundles are flat, which is why this was invisible until the macOS targets landed (#1402).

The published `0.5.0` release confirms it: unzipping the release asset and listing the macOS slice shows `Versions/Current`, `Headers`, `Modules`, `Resources`, and the binary as full duplicated files rather than symlinks. Any consumer that builds and codesigns against the macOS slice fails with `code object is not signed at all` on the nested framework, because codesign's recursive bundle signing needs the real symlinked structure.

KMMBridge 1.2.1 is still the newest release (checked the Gradle Plugin Portal and GitHub releases) and its issue tracker has nothing open about this, so there is no upstream fix to pick up. This reconfigures the existing `zipXCFramework` task: once KMMBridge's own zip runs, `doLast` deletes the result and re-zips the same source directory with `zip -y`, which stores symlinks as symlinks instead of following them. The reconfiguration only touches the task when KMMBridge registers it (`matching {}`), so it stays a no-op on any build where publishing is not enabled.

Verified locally by running `:kmp:shared-core:zipXCFramework` directly (placeholder `local.properties` and `spmRepoDir`, no real publish) and extracting the resulting archive: the macOS slice now has real symlinks (`Headers -> Versions/Current/Headers`, `Current -> A`, etc.) instead of duplicated files.

This unblocks a `0.5.1` release of `flipcash-shared-core-spm` — needed before code-ios-app#725 can adopt shared mnemonic derivation against a macOS-capable build.
