### PR TITLE
fix(ci): pass the release keystore to Gradle as an absolute path

### DIFF
--- a/.github/workflows/build-fcash2-upload-android.yml
+++ b/.github/workflows/build-fcash2-upload-android.yml
@@ -127,19 +127,12 @@ jobs:
           fileDir: ./apps/flipcash/app/src
           encodedString: ${{ secrets.FLIPCASH2_GOOGLE_SERVICES }}
 
-      - name: Decode Upload Key Store file into location 1
+      - name: Decode Upload Key Store file
         uses: timheuer/base64-to-file@v1
         id: signing_key
         with:
           fileName: key
           fileDir: ./key
-          encodedString: ${{ secrets.UPLOAD_KEY_STORE }}
-
-      - name: Decode Upload Key Store file into location 2
-        uses: timheuer/base64-to-file@v1
-        with:
-          fileName: key
-          fileDir: ./apps/flipcash/app/key
           encodedString: ${{ secrets.UPLOAD_KEY_STORE }}
 
       - name: Setup BugSnag API Key
@@ -157,7 +150,10 @@ jobs:
       - name: Build release
         run: bundle exec fastlane android build_flipcash
         env:
-          STORE_FILE: ${{ steps.signing_key.outputs.filePath }}
+          # base64-to-file reports a workspace-relative path, and AGP resolves
+          # android.injected.signing.store.file against the Gradle daemon's working
+          # directory, not the project — so pass it absolute.
+          STORE_FILE: ${{ github.workspace }}/${{ steps.signing_key.outputs.filePath }}
           STORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}


### PR DESCRIPTION
`Flipcash2 Build and Deploy` has failed since the AGP 9.4.0 bump ([#1421](https://github.com/code-payments/code-android-app/pull/1421)). The last green release run was on 4 Sep, before that landed; [run 34237943672](https://github.com/code-payments/code-android-app/actions/runs/34237943672) dies in `build-release`:

```
Execution failed for task ':apps:flipcash:app:validateSigningRelease'.
> Keystore file '/home/runner/.gradle/daemon/9.7.1/key/key' not found
  for signing config 'externalOverride'.
```

`timheuer/base64-to-file` reports a workspace-relative path, so the workflow was handing Gradle `-Pandroid.injected.signing.store.file=key/key`. AGP resolves that property against the Gradle daemon's working directory rather than the project directory, which is how the lookup ended up under `~/.gradle/daemon/9.7.1/`.

Prefixing the value with `github.workspace` removes the resolution question entirely — nothing downstream has to guess a base directory, including the `bundletool` call that reuses `STORE_FILE` as `ks_path`.

That also lets the second decode step go. `apps/flipcash/app/key/` only existed to cover module-relative resolution; no signing config or script reads it. The `contributors` config is unaffected — it builds its path from `rootDir`.
