### PR TITLE
feat(chat): hint "Reply" while the composer is replying

### DIFF
--- a/apps/flipcash/core/src/main/res/values/strings.xml
+++ b/apps/flipcash/core/src/main/res/values/strings.xml
@@ -863,6 +863,10 @@
     <string name="action_sendCashViaSymbol">Send %1$s</string>
     <string name="action_sendMessage">Send Message</string>
 
+    <!-- Chat composer -->
+    <string name="hint_chatMessage">Message</string>
+    <string name="hint_chatReply">Reply</string>
+
     <string name="subtitle_chatNoLongerAvailable">This user unlinked their phone number and this conversation is no longer available</string>
 
     <string name="subtitle_verb_youSent">You sent</string>

--- a/apps/flipcash/features/messenger/src/main/kotlin/com/flipcash/app/messenger/internal/screens/components/ChatBottomBar.kt
+++ b/apps/flipcash/features/messenger/src/main/kotlin/com/flipcash/app/messenger/internal/screens/components/ChatBottomBar.kt
@@ -235,7 +235,10 @@ internal fun UserControlBottomBar(
                                     )
                                     .hazeBlur(HazeInput.Sources(hazeState), material),
                                 focusRequester = focusRequester,
-                                hint = "Message",
+                                hint = stringResource(
+                                    if (state.replyingTo != null) R.string.hint_chatReply
+                                    else R.string.hint_chatMessage
+                                ),
                                 state = state.chatInputState,
                                 // One read of the edit state decides both the glyph and what the tap
                                 // does, so the composer cannot show a checkmark and send a new message.


### PR DESCRIPTION
The composer hint read "Message" in every state. A reply starts from a swipe or a long press, and once the keyboard comes up over the reply strip there was nothing left in the composer saying the next send would be a reply.

The hint now reads the same `state.replyingTo` that gates the reply strip, so the placeholder and the strip appear and clear on one state change.

Both hints move to string resources (`hint_chatMessage`, `hint_chatReply`) in `:apps:flipcash:core`, next to the other chat strings. They resolve through the feature's own `R` because `android.nonTransitiveRClass=false`, the same way the existing `R.string.action_cancelEdit` reference in this file does.