### PR TITLE
fix(txn-details): match "View in Chat" to the cards it sits under

### DIFF
--- a/apps/flipcash/shared/transaction-history/src/main/kotlin/com/flipcash/shared/transactionhistory/TransactionDetailsContent.kt
+++ b/apps/flipcash/shared/transaction-history/src/main/kotlin/com/flipcash/shared/transactionhistory/TransactionDetailsContent.kt
@@ -107,6 +107,9 @@ fun TransactionDetailsContent(
                     modifier = Modifier.fillMaxWidth(),
                     text = stringResource(R.string.action_txnDetails_viewInChat),
                     buttonState = ButtonState.Filled05,
+                    // [DetailsCard]'s radius, not CodeButton's default 8dp — the fill alone is
+                    // not enough to read as one more card if the corners disagree.
+                    shape = CodeTheme.shapes.extraSmall,
                     onClick = onViewInChat,
                 )
             }

--- a/apps/flipcash/shared/transaction-history/src/main/kotlin/com/flipcash/shared/transactionhistory/TransactionDetailsContent.kt
+++ b/apps/flipcash/shared/transaction-history/src/main/kotlin/com/flipcash/shared/transactionhistory/TransactionDetailsContent.kt
@@ -106,7 +106,7 @@ fun TransactionDetailsContent(
                 CodeButton(
                     modifier = Modifier.fillMaxWidth(),
                     text = stringResource(R.string.action_txnDetails_viewInChat),
-                    buttonState = ButtonState.Filled10,
+                    buttonState = ButtonState.Filled05,
                     onClick = onViewInChat,
                 )
             }

--- a/ui/components/src/main/kotlin/com/getcode/ui/theme/CodeButton.kt
+++ b/ui/components/src/main/kotlin/com/getcode/ui/theme/CodeButton.kt
@@ -62,6 +62,7 @@ import com.getcode.theme.Black50
 import com.getcode.theme.CodeTheme
 import com.getcode.theme.Transparent
 import com.getcode.theme.White
+import com.getcode.theme.White05
 import com.getcode.theme.White10
 import com.getcode.theme.White20
 import com.getcode.theme.White50
@@ -76,6 +77,7 @@ enum class ButtonState {
     Filled50,
     Filled20,
     Filled10,
+    Filled05,
     BgBlur20,
     Subtle,
     ;
@@ -89,6 +91,7 @@ enum class ButtonState {
             Filled50 -> White50
             Filled20 -> White20
             Filled10 -> White10
+            Filled05 -> White05
             Subtle -> White
             BgBlur20 -> White20
         }
@@ -130,6 +133,15 @@ enum class ButtonState {
             Filled10 ->
                 ButtonDefaults.outlinedButtonColors(
                     backgroundColor = White10,
+                    disabledContentColor = White50,
+                    contentColor = textColor.takeOrElse { White },
+                )
+
+            // The card fill, for a button meant to read as one more card in a stack rather than
+            // as a control sitting on top of them.
+            Filled05 ->
+                ButtonDefaults.outlinedButtonColors(
+                    backgroundColor = White05,
                     disabledContentColor = White50,
                     contentColor = textColor.takeOrElse { White },
                 )


### PR DESCRIPTION
The "View in Chat" button on Transaction Details doesn't match the cards directly above it, on two counts.

**Fill.** It used `ButtonState.Filled10` → `White10` (`0x1AFFFFFF`), while `DetailsCard` — the panel behind both the receipt card and the ID card — uses `White05` (`0x0CFFFFFF`).

**Corner radius.** `CodeButton` defaults to `CodeTheme.shapes.small` (8dp); `DetailsCard` uses `extraSmall` (6dp).

Figma `9708:118142` holds all three as siblings — receipt card `9708:118165`, ID card `9708:118143`, button `9708:118123` — and gives every one of them `rgba(255,255,255,0.05)` and `rounded-[6px]`. All three are even named "Button" in the file. The point of the design is that the button reads as a fourth card in the stack rather than as a control sitting on top of them. The two cards were already correct; only the button had drifted, so this is button-only and not screen-wide. Height needed no change — Figma's 60px is what it already rendered.

`CodeButton` takes its background solely from `ButtonState.colors()` and exposes no per-call background override, so no existing state could express the card fill. This adds `ButtonState.Filled05` next to `Filled10`. `Filled10` itself is untouched, so its other caller — the action button in `Callout` — is unaffected. The radius is a per-call `shape` argument, which `CodeButton` already supports.

This mirrors the iOS side, which added a `.filled05` style for the same discrepancy in code-payments/code-ios-app#739.

The module's `TransactionDetailsScreenshotTest` renders PNGs for eyeballing rather than asserting against checked-in goldens, so there were no reference images to update.
