### PR TITLE
fix(logging): silence AUTHENTICATION_FAILED and INTERNAL_SERVER_ERROR from Bugsnag

### DIFF
--- a/libs/logging/src/main/kotlin/com/getcode/utils/ErrorUtils.kt
+++ b/libs/logging/src/main/kotlin/com/getcode/utils/ErrorUtils.kt
@@ -93,9 +93,24 @@ object ErrorUtils {
                 throwable is SocketException ||
                 throwable.cause is SocketException
 
-    private val gmsTransientMessages = setOf("SERVICE_NOT_AVAILABLE", "FIS_AUTH_ERROR", "MISSING_INSTANCEID_SERVICE", "TOO_MANY_REGISTRATIONS")
+    /**
+     * Error strings Google Play Services returns for a failed FCM registration. They describe the
+     * device's GMS state or the FCM backend, not app code, so they stay out of Bugsnag. Firebase
+     * wraps them as `IOException("FCM Registration failed!")` -> `ExecutionException` ->
+     * `IOException(<code>)`, which is why the cause chain is walked.
+     */
+    private val gmsTransientMessages = setOf(
+        "SERVICE_NOT_AVAILABLE",
+        "FIS_AUTH_ERROR",
+        "MISSING_INSTANCEID_SERVICE",
+        "TOO_MANY_REGISTRATIONS",
+        "AUTHENTICATION_FAILED",
+        "INTERNAL_SERVER_ERROR",
+        "InternalServerError",
+        "PHONE_REGISTRATION_ERROR",
+    )
 
-    private fun isGmsTransientError(throwable: Throwable): Boolean =
+    internal fun isGmsTransientError(throwable: Throwable): Boolean =
         generateSequence(throwable) { it.cause }
             .any { it is java.io.IOException && it.message in gmsTransientMessages }
 

--- a/libs/logging/src/test/kotlin/com/getcode/utils/ErrorUtilsTest.kt
+++ b/libs/logging/src/test/kotlin/com/getcode/utils/ErrorUtilsTest.kt
@@ -1,6 +1,8 @@
 package com.getcode.utils
 
+import java.io.IOException
 import java.net.UnknownHostException
+import java.util.concurrent.ExecutionException
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -33,5 +35,25 @@ class ErrorUtilsTest {
         val error = UnknownHostException("no dns")
         assertFalse(ErrorUtils.shouldReport(error, error))
         assertFalse(ErrorUtils.shouldReport(Fault(), error))
+    }
+
+    @Test
+    fun `a wrapped FCM registration failure is a transient GMS error`() {
+        for (code in listOf("AUTHENTICATION_FAILED", "INTERNAL_SERVER_ERROR", "SERVICE_NOT_AVAILABLE")) {
+            val error = IOException("FCM Registration failed!", ExecutionException(IOException(code)))
+            assertTrue(ErrorUtils.isGmsTransientError(error), code)
+        }
+    }
+
+    @Test
+    fun `a bare GMS error code is a transient GMS error`() {
+        assertTrue(ErrorUtils.isGmsTransientError(IOException("InternalServerError")))
+    }
+
+    @Test
+    fun `an unrelated IOException is not a transient GMS error`() {
+        val error = IOException("FCM Registration failed!", ExecutionException(IOException("disk full")))
+        assertFalse(ErrorUtils.isGmsTransientError(error))
+        assertFalse(ErrorUtils.isGmsTransientError(Fault()))
     }
 }


### PR DESCRIPTION
Bugsnag [6a9df0a95ab98605a9dfcb88](https://app.bugsnag.com/1000710770-ontario-inc/flipcash-android/errors/6a9df0a95ab98605a9dfcb88) picked up on 2026.8.5 internal: 57 events from 4 devices in three days, 17 of them from one Samsung SM-A556E relaunching mid-onboarding. The inner cause is `IOException("AUTHENTICATION_FAILED")` (47) or `IOException("INTERNAL_SERVER_ERROR")` (10) thrown by Play Services out of `FirebaseMessaging.getToken()`, wrapped by the SDK as `IOException("FCM Registration failed!")` -> `ExecutionException`.

`ErrorUtils.gmsTransientMessages` already drops `SERVICE_NOT_AVAILABLE`, `FIS_AUTH_ERROR`, `MISSING_INSTANCEID_SERVICE` and `TOO_MANY_REGISTRATIONS`, each added by an earlier round of this triage (#943 and predecessors). These two codes were never added, so `FirebasePushTokenProvider` reports them through `ErrorUtils.handleError` on every login.

This is not a regression. 2026.8.5 ships Firebase BOM 34.17.0, the same as 2026.8.2 through 2026.8.4, out since Aug 20. The 34.18.0 bump is not in any tagged release. The same codes show up in the older, unwrapped groups on builds back to 2025.7.4, and `INTERNAL_SERVER_ERROR` is one Firebase's own `GmsRpc.isErrorMessageForRetryableError` retries on.

Changes:

- Add `AUTHENTICATION_FAILED`, `INTERNAL_SERVER_ERROR`, Firebase's alternate spelling `InternalServerError`, and `PHONE_REGISTRATION_ERROR` (seen once in the sibling group on 2026.8.4) to `gmsTransientMessages`.
- Make `isGmsTransientError` internal and cover the nested `FCM Registration failed!` shape plus a negative case in `ErrorUtilsTest`.

Behaviour for users is unchanged. The provider already resumes `null` on failure and `updateFcmToken()` returns early, so push stays unregistered until a later login succeeds.
