### PR TITLE
build: compile against Android 37.2

### DIFF
--- a/apps/flipcash/app/build.gradle.kts
+++ b/apps/flipcash/app/build.gradle.kts
@@ -46,7 +46,11 @@ val skipExpensiveReleaseTasks = providers.gradleProperty("skipExpensiveReleaseTa
 android {
     // static namespace
     namespace = appNamespace
-    compileSdk = libs.versions.android.compileSdk.get().toInt()
+    compileSdk {
+        version = release(libs.versions.android.compileSdk.get().toInt()) {
+            minorApiLevel = libs.versions.android.compileSdkMinor.get().toInt()
+        }
+    }
 
     defaultConfig {
         versionCode = Packaging.Flipcash.versionCode ?: gitVersionCode()

--- a/apps/flipcash/benchmark/build.gradle.kts
+++ b/apps/flipcash/benchmark/build.gradle.kts
@@ -7,7 +7,11 @@ val contributorsSigningConfig = ContributorsSignatory(rootDir)
 
 android {
     namespace = "com.flipcash.benchmark"
-    compileSdk = libs.versions.android.compileSdk.get().toInt()
+    compileSdk {
+        version = release(libs.versions.android.compileSdk.get().toInt()) {
+            minorApiLevel = libs.versions.android.compileSdkMinor.get().toInt()
+        }
+    }
 
     defaultConfig {
         minSdk = 29

--- a/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
@@ -25,11 +25,16 @@ class AndroidLibraryConventionPlugin : Plugin<Project> {
 
             val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
             val compileSdkVersion = libs.findVersion("android-compileSdk").get().requiredVersion.toInt()
+            val compileSdkMinorVersion = libs.findVersion("android-compileSdkMinor").get().requiredVersion.toInt()
             val minSdkVersion = libs.findVersion("android-minSdk").get().requiredVersion.toInt()
             val javaVersion = libs.findVersion("android-java").get().requiredVersion
 
             extensions.configure<LibraryExtension> {
-                compileSdk = compileSdkVersion
+                compileSdk {
+                    version = release(compileSdkVersion) {
+                        minorApiLevel = compileSdkMinorVersion
+                    }
+                }
 
                 defaultConfig {
                     minSdk = minSdkVersion

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 android-compileSdk = "37"
+android-compileSdkMinor = "2"
 android-minSdk = "29"
 android-targetSdk = "37"
 android-java = "21"

--- a/kmp/shared-core/build.gradle.kts
+++ b/kmp/shared-core/build.gradle.kts
@@ -24,7 +24,11 @@ val spmPackageDir = findProperty("spmRepoDir") as String?
 kotlin {
     android {
         namespace = "com.flipcash.shared"
-        compileSdk = 37
+        compileSdk {
+            version = release(libs.versions.android.compileSdk.get().toInt()) {
+                minorApiLevel = libs.versions.android.compileSdkMinor.get().toInt()
+            }
+        }
         minSdk = 29
     }
     

--- a/libs/codes/kikcode/build.gradle.kts
+++ b/libs/codes/kikcode/build.gradle.kts
@@ -13,7 +13,11 @@ testFixtures {
 kotlin {
     android {
         namespace = "com.getcode.codes.kikcode"
-        compileSdk = 37
+        compileSdk {
+            version = release(libs.versions.android.compileSdk.get().toInt()) {
+                minorApiLevel = libs.versions.android.compileSdkMinor.get().toInt()
+            }
+        }
         minSdk = 29
         withHostTest {}
     }

--- a/libs/encryption/base58/build.gradle.kts
+++ b/libs/encryption/base58/build.gradle.kts
@@ -13,7 +13,11 @@ testFixtures {
 kotlin {
     android {
         namespace = "com.getcode.encryption.base58"
-        compileSdk = 37
+        compileSdk {
+            version = release(libs.versions.android.compileSdk.get().toInt()) {
+                minorApiLevel = libs.versions.android.compileSdkMinor.get().toInt()
+            }
+        }
         minSdk = 29
         withHostTest {}
     }

--- a/libs/encryption/ed25519/build.gradle.kts
+++ b/libs/encryption/ed25519/build.gradle.kts
@@ -75,7 +75,11 @@ appleTargetDefs.forEach { target ->
 kotlin {
     android {
         namespace = "com.getcode.encryption.ed25519"
-        compileSdk = 37
+        compileSdk {
+            version = release(libs.versions.android.compileSdk.get().toInt()) {
+                minorApiLevel = libs.versions.android.compileSdkMinor.get().toInt()
+            }
+        }
         minSdk = 29
         withHostTest {}
     }

--- a/libs/encryption/hmac/build.gradle.kts
+++ b/libs/encryption/hmac/build.gradle.kts
@@ -6,7 +6,11 @@ plugins {
 kotlin {
     android {
         namespace = "com.getcode.encryption.hmac"
-        compileSdk = 37
+        compileSdk {
+            version = release(libs.versions.android.compileSdk.get().toInt()) {
+                minorApiLevel = libs.versions.android.compileSdkMinor.get().toInt()
+            }
+        }
         minSdk = 29
         withHostTest {}
     }

--- a/libs/encryption/mnemonic/build.gradle.kts
+++ b/libs/encryption/mnemonic/build.gradle.kts
@@ -13,7 +13,11 @@ testFixtures {
 kotlin {
     android {
         namespace = "com.getcode.encryption.mnemonic"
-        compileSdk = 37
+        compileSdk {
+            version = release(libs.versions.android.compileSdk.get().toInt()) {
+                minorApiLevel = libs.versions.android.compileSdkMinor.get().toInt()
+            }
+        }
         minSdk = 29
         withHostTest {}
         withDeviceTest {}

--- a/libs/encryption/sha256/build.gradle.kts
+++ b/libs/encryption/sha256/build.gradle.kts
@@ -6,7 +6,11 @@ plugins {
 kotlin {
     android {
         namespace = "com.getcode.encryption.sha256"
-        compileSdk = 37
+        compileSdk {
+            version = release(libs.versions.android.compileSdk.get().toInt()) {
+                minorApiLevel = libs.versions.android.compileSdkMinor.get().toInt()
+            }
+        }
         minSdk = 29
         withHostTest {}
     }

--- a/libs/encryption/sha512/build.gradle.kts
+++ b/libs/encryption/sha512/build.gradle.kts
@@ -6,7 +6,11 @@ plugins {
 kotlin {
     android {
         namespace = "com.getcode.encryption.sha512"
-        compileSdk = 37
+        compileSdk {
+            version = release(libs.versions.android.compileSdk.get().toInt()) {
+                minorApiLevel = libs.versions.android.compileSdkMinor.get().toInt()
+            }
+        }
         minSdk = 29
         withHostTest {}
     }

--- a/libs/encryption/utils/build.gradle.kts
+++ b/libs/encryption/utils/build.gradle.kts
@@ -6,7 +6,11 @@ plugins {
 kotlin {
     android {
         namespace = "com.getcode.encryption.utils"
-        compileSdk = 37
+        compileSdk {
+            version = release(libs.versions.android.compileSdk.get().toInt()) {
+                minorApiLevel = libs.versions.android.compileSdkMinor.get().toInt()
+            }
+        }
         minSdk = 29
         withHostTest {}
     }


### PR DESCRIPTION
Dependabot's haze 2.0.0-beta03 bump (#1443) fails at configuration:

```
Dependency 'dev.chrisbanes.haze:haze-blur-materials-android:2.0.0-beta03'
requires libraries and applications that depend on it to compile against
version 37.2 or later of the Android APIs.
:apps:flipcash:shared:persistence:db is currently compiled against android-37.0.
```

The catalog holds `compileSdk` as an integer and every consumer calls `.toInt()`, so there was nowhere to put a minor version. AGP 9.4.0 takes one through a spec block instead:

```kotlin
compileSdk {
    version = release(37) { minorApiLevel = 2 }
}
```

That form is the only one available on both `CommonExtension` and `KotlinMultiplatformAndroidLibraryExtension` — the KMP extension has no `compileSdkMinor` property — so all twelve sites use it.

Nine of those sites are KMP modules that hardcoded `compileSdk = 37` rather than reading the catalog, which is why this is a twelve-site change instead of a one-line one. They now read `android-compileSdk` and `android-compileSdkMinor` like everything else.

`Build.VERSION.SDK_INT` still reports 37; only `SDK_INT_FULL` carries the minor, so no runtime behaviour changes.

CI needs SDK Platform 37.2. The workflow has no explicit platform install step, and `android.builder.sdkDownload` is unset (defaults on), so AGP downloads it the same way it obtains 37.0 today.

Unblocks #1443.
