### PR TITLE
build: drop the Material Components dependency

### DIFF
--- a/apps/flipcash/app/build.gradle.kts
+++ b/apps/flipcash/app/build.gradle.kts
@@ -295,8 +295,8 @@ dependencies {
     implementation(libs.androidx.lifecycle.viewmodel)
     implementation(libs.androidx.work)
     implementation(libs.androidx.webkit)
-    // Resources only: Theme.Code in res/values/themes.xml extends Theme.MaterialComponents.
-    implementation(libs.google.material)
+    // Resources only: Theme.Code in res/values/themes.xml extends Theme.AppCompat.
+    implementation(libs.androidx.appcompat)
 
     //hilt dependency injection
     implementation(libs.hilt.android)

--- a/apps/flipcash/app/src/main/res/values-v31/themes.xml
+++ b/apps/flipcash/app/src/main/res/values-v31/themes.xml
@@ -1,15 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="Theme.Code" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+    <style name="Theme.Code" parent="Theme.AppCompat.DayNight.NoActionBar">
         <!-- Primary brand color. -->
         <item name="colorPrimary">@color/purple_dark</item>
-        <item name="colorPrimaryVariant">@color/purple_light</item>
-        <item name="colorOnPrimary">@color/white</item>
-        <!-- Secondary brand color. -->
-        <item name="colorSecondary">@color/purple_dark</item>
-        <item name="colorSecondaryVariant">@color/purple_background</item>
-        <item name="colorOnSecondary">@color/white</item>
         <item name="colorPrimaryDark">@color/purple_dark</item>
         <item name="colorAccent">@color/purple_light</item>
         <item name="android:statusBarColor">@android:color/transparent</item>

--- a/apps/flipcash/app/src/main/res/values/colors.xml
+++ b/apps/flipcash/app/src/main/res/values/colors.xml
@@ -26,7 +26,6 @@
     <color name="forty_percent_black">#66000000</color>
     <color name="seventy_percent_black">#B3000000</color>
     <color name="clear">#00000000</color>
-    <color name="purple_background">#1D1A30</color>
 
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>

--- a/apps/flipcash/app/src/main/res/values/themes.xml
+++ b/apps/flipcash/app/src/main/res/values/themes.xml
@@ -1,15 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
-    <style name="Theme.Code" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+    <style name="Theme.Code" parent="Theme.AppCompat.DayNight.NoActionBar">
         <!-- Primary brand color. -->
         <item name="colorPrimary">@color/purple_dark</item>
-        <item name="colorPrimaryVariant">@color/purple_light</item>
-        <item name="colorOnPrimary">@color/white</item>
-        <!-- Secondary brand color. -->
-        <item name="colorSecondary">@color/purple_dark</item>
-        <item name="colorSecondaryVariant">@color/purple_background</item>
-        <item name="colorOnSecondary">@color/white</item>
         <item name="colorPrimaryDark">@color/purple_dark</item>
         <item name="colorAccent">@color/purple_light</item>
         <item name="android:statusBarColor">@android:color/transparent</item>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -55,7 +55,6 @@ play-service-ml-barcode = "18.3.1"
 play-services-auth-api-phone = "18.3.1"
 google-play-billing = "9.1.0"
 google-play-updates = "2.1.0"
-google-material = "1.4.0"
 
 grpc = "1.84.0"
 grpc-okhttp = "1.84.0"
@@ -246,7 +245,6 @@ google-play-billing-runtime = { module = "com.android.billingclient:billing", ve
 google-play-billing-ktx = { module = "com.android.billingclient:billing-ktx", version.ref = "google-play-billing" }
 google-play-app-updates-runtime = { module = "com.google.android.play:app-update", version.ref = "google-play-updates" }
 google-play-app-updates-ktx = { module = "com.google.android.play:app-update-ktx", version.ref = "google-play-updates" }
-google-material = { module = "com.google.android.material:material", version.ref = "google-material" }
 
 # Kin
 kin-sdk = { module = "org.kin.sdk.android:base", version.ref = "kin-sdk" }


### PR DESCRIPTION
`com.google.android.material:material` was carried for one thing: `Theme.Code` extended `Theme.MaterialComponents.DayNight.NoActionBar`. Nothing else used it. There are no Kotlin or Java imports of it, no XML references beyond that parent, and the project has no `layout/` directories at all, so no Material view was ever inflated.

Reparenting onto `Theme.AppCompat.DayNight.NoActionBar` covers what the theme actually needs. AppCompat is already here — `FlipcashApp` calls `AppCompatDelegate.setDefaultNightMode`, and `:ui:resources` exposes it as `api` — so this drops a dependency rather than swapping one for another. The app now declares AppCompat directly instead of leaning on the transitive path.

The five MaterialComponents-only attributes go with it: `colorPrimaryVariant`, `colorOnPrimary`, `colorSecondary`, `colorSecondaryVariant` and `colorOnSecondary` are not AppCompat attributes and had no reader. `colorPrimary`, `colorPrimaryDark` and `colorAccent` are AppCompat attributes and stay, and the `android:` window and splash-screen attributes are untouched. `purple_background` was referenced only by `colorSecondaryVariant`, so it goes too.

`com.google.android.material` is no longer on the app's `debugRuntimeClasspath`.

Supersedes #1452, the 1.4.0 to 1.14.0 bump: with the dependency out of the catalog there is nothing left for Dependabot to raise.
