### PR TITLE
ci(shared-core): write release notes and tag the source commit on publish

### DIFF
--- a/.github/workflows/publish-shared-core.yml
+++ b/.github/workflows/publish-shared-core.yml
@@ -10,6 +10,10 @@ on:
       version:
         description: 'Version to publish, e.g. 0.1.0 — also the Swift Package tag'
         required: true
+      summary:
+        description: 'Optional lede for the release notes. The changelog below it is generated either way.'
+        required: false
+        type: string
 
 concurrency:
   # Two publishes at once would race on the same tag and release.
@@ -23,13 +27,21 @@ env:
 jobs:
   publish:
     name: Publish SharedCore ${{ inputs.version }}
+    # `contents: write` is for this repo's `shared-core/*` tag; the Swift Package
+    # repo is reached with the PAT below, not with GITHUB_TOKEN.
+    permissions:
+      contents: write
     # Apple targets and `swift package compute-checksum` both need Xcode, so this
     # lane can't share the Ubuntu runners the rest of CI uses.
     runs-on: macos-15
     steps:
+      # The release notes are a `git log` between this publish and the previous
+      # `shared-core/*` tag, so this lane needs history and tags rather than the
+      # single commit a build would want.
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Validate Gradle wrapper
         uses: gradle/actions/wrapper-validation@v4
@@ -139,6 +151,45 @@ jobs:
           git tag -f "${{ inputs.version }}"
           git push -f origin "${{ inputs.version }}"
 
+      # The Swift Package repo has no commits of its own to describe — it holds a
+      # generated `Package.swift` and the zip it points at — so the notes are
+      # derived here, from the range between this publish and the last one.
+      - name: Write the release notes
+        env:
+          GH_TOKEN: ${{ secrets.SHARED_CORE_PUBLISH_TOKEN }}
+          SUMMARY: ${{ inputs.summary }}
+        run: |
+          set -euo pipefail
+
+          checksum=$(sed -n 's/^let remoteKotlinChecksum = "\(.*\)"$/\1/p' spm-repo/Package.swift)
+
+          summary_arg=()
+          if [ -n "$SUMMARY" ]; then
+            printf '%s\n' "$SUMMARY" > "$RUNNER_TEMP/summary.md"
+            summary_arg=(--summary-file "$RUNNER_TEMP/summary.md")
+          fi
+
+          bash scripts/shared-core-release-notes.sh "${{ inputs.version }}" \
+            --source "$GITHUB_SHA" \
+            --checksum "$checksum" \
+            "${summary_arg[@]+"${summary_arg[@]}"}" > "$RUNNER_TEMP/notes.md"
+
+          cat "$RUNNER_TEMP/notes.md"
+
+          gh release edit "${{ inputs.version }}" \
+            --repo "$SPM_REPO" \
+            --title "SharedCore ${{ inputs.version }}" \
+            --notes-file "$RUNNER_TEMP/notes.md"
+
+      # Nothing else records which Kotlin a published framework was built from, and
+      # without that the next release has no range to generate its notes over. The
+      # tag is created last so a failed publish doesn't claim a version.
+      - name: Tag the source commit
+        run: |
+          set -euo pipefail
+          git tag "shared-core/${{ inputs.version }}" "$GITHUB_SHA"
+          git push origin "shared-core/${{ inputs.version }}"
+
       - name: Summary
         run: |
           {
@@ -146,4 +197,5 @@ jobs:
             echo
             echo "- Release: https://github.com/${SPM_REPO}/releases/tag/${{ inputs.version }}"
             echo '- Consume: `.package(url: "https://github.com/'"${SPM_REPO}"'", from: "${{ inputs.version }}")`'
+            echo "- Built from \`${GITHUB_SHA}\`, tagged \`shared-core/${{ inputs.version }}\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/shared-core-release-notes.sh
+++ b/scripts/shared-core-release-notes.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# scripts/shared-core-release-notes.sh
+#
+# Write the release notes for a SharedCore publish into
+# code-payments/flipcash-shared-core-spm.
+#
+# That repo holds only a generated `Package.swift` and the XCFramework it points
+# at, so a release there has no commits of its own to describe. The Kotlin and
+# the Swift glue both live here, which makes this repo the only place the notes
+# can be derived from.
+#
+# Usage:
+#   scripts/shared-core-release-notes.sh <version> [options]
+#
+#   --since <ref>        Commit/tag to diff from. Defaults to the newest
+#                        shared-core/* tag older than <version>.
+#   --source <ref>       Commit the framework was built from. Defaults to HEAD.
+#   --summary-file <f>   Prose to place above the generated changelog.
+#   --checksum <sha256>  Checksum of the uploaded zip, as recorded in Package.swift.
+#
+# Prints markdown on stdout.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SPM_REPO="code-payments/flipcash-shared-core-spm"
+SOURCE_REPO="code-payments/code-android-app"
+BUILD_FILE="kmp/shared-core/build.gradle.kts"
+
+VERSION="${1:?Usage: shared-core-release-notes.sh <version> [--since <ref>] ...}"
+shift
+
+SINCE="" SOURCE_REF="HEAD" SUMMARY_FILE="" CHECKSUM=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --since)        SINCE="$2"; shift 2;;
+    --source)       SOURCE_REF="$2"; shift 2;;
+    --summary-file) SUMMARY_FILE="$2"; shift 2;;
+    --checksum)     CHECKSUM="$2"; shift 2;;
+    *) echo "Unknown option: $1" >&2; exit 2;;
+  esac
+done
+
+cd "$REPO_ROOT"
+
+SOURCE_SHA=$(git rev-parse "$SOURCE_REF")
+SOURCE_SHORT=$(git rev-parse --short "$SOURCE_SHA")
+
+# The framework exports a hand-maintained list of Gradle modules, and that list
+# grows. Reading it out of the build script at release time keeps the changelog
+# honest as modules are added, instead of pinning a path list here that silently
+# goes stale.
+exported_modules() {
+  local ref="$1"
+  git show "$ref:$BUILD_FILE" 2>/dev/null \
+    | sed -n 's/^ *export(project("\(:[^"]*\)")).*/\1/p' \
+    | sort -u
+}
+
+# A change in a module the framework depends on lands in the binary just as
+# surely as a change in an exported one, so walk the `project(":…")` references
+# out from the exported set until it stops growing.
+transitive_modules() {
+  local ref="$1" frontier next seen path
+  seen=$(exported_modules "$ref")
+  frontier="$seen"
+  while [ -n "$frontier" ]; do
+    next=""
+    while IFS= read -r module; do
+      [ -n "$module" ] || continue
+      path="${module#:}"; path="${path//://}"
+      next+=$(git show "$ref:$path/build.gradle.kts" 2>/dev/null \
+        | sed -n 's/.*project("\(:[^"]*\)").*/\1/p')$'\n'
+    done <<< "$frontier"
+    frontier=$(printf '%s' "$next" | sort -u | comm -23 - <(printf '%s\n' "$seen" | sort -u))
+    seen=$(printf '%s\n%s\n' "$seen" "$frontier" | sed '/^$/d' | sort -u)
+  done
+  printf '%s\n' "$seen"
+}
+
+module_paths() {
+  transitive_modules "$1" | sed 's|^:||; s|:|/|g'
+}
+
+# `--since` unset: the newest shared-core tag that sorts below this version. Using
+# the tag rather than a date means a publish cut from a feature branch still
+# diffs against what was actually last released.
+if [ -z "$SINCE" ]; then
+  SINCE=$(git tag --list 'shared-core/*' \
+    | sed 's|^shared-core/||' \
+    | sort -V \
+    | awk -v v="$VERSION" '{ print } $0 == v { exit }' \
+    | sort -V | awk -v v="$VERSION" '$0 != v' | tail -1)
+  [ -n "$SINCE" ] && SINCE="shared-core/$SINCE"
+fi
+
+# `mapfile` is bash 4; the macOS runners still ship 3.2, so read the list the
+# portable way.
+PATHS=()
+while IFS= read -r p; do
+  [ -n "$p" ] && PATHS+=("$p")
+done < <(module_paths "$SOURCE_SHA")
+PATHS+=("kmp/shared-core")
+
+# Turn "feat(codes): share geometry (#1287)" into a bullet that keeps the scope,
+# drops the type prefix, and links the PR (or the commit, when there isn't one).
+format_bullet() {
+  local sha="$1" subject="$2" scope="" desc pr
+  if [[ "$subject" =~ ^[a-z]+\(([^\)]+)\): ]]; then
+    scope="${BASH_REMATCH[1]}"
+  fi
+  desc="${subject#*: }"
+  if [[ "$desc" =~ ^(.*)\ \(#([0-9]+)\)$ ]]; then
+    desc="${BASH_REMATCH[1]}"
+    pr="[#${BASH_REMATCH[2]}](https://github.com/$SOURCE_REPO/pull/${BASH_REMATCH[2]})"
+  else
+    pr="[\`$(git rev-parse --short "$sha")\`](https://github.com/$SOURCE_REPO/commit/$sha)"
+  fi
+  if [ -n "$scope" ]; then
+    echo "- **$scope**: $desc ($pr)"
+  else
+    echo "- $desc ($pr)"
+  fi
+}
+
+section() {
+  local heading="$1"; shift
+  [ $# -eq 0 ] && return 0
+  echo "### $heading"
+  echo
+  printf '%s\n' "$@"
+  echo
+}
+
+FEATS=() FIXES=() IMPROVEMENTS=() BUILDS=() OTHERS=()
+
+if [ -n "$SINCE" ]; then
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    sha="${line%% *}"; subject="${line#* }"
+    bullet=$(format_bullet "$sha" "$subject")
+    case "$subject" in
+      feat*:*)                      FEATS+=("$bullet");;
+      fix*:*)                       FIXES+=("$bullet");;
+      refactor*:*|perf*:*|style*:*) IMPROVEMENTS+=("$bullet");;
+      build*:*|chore*:*|ci*:*)      BUILDS+=("$bullet");;
+      test*:*|docs*:*)              ;;  # no effect on what ships in the framework
+      *)                            OTHERS+=("$bullet");;
+    esac
+  done < <(git log --no-merges --format='%H %s' "$SINCE..$SOURCE_SHA" -- "${PATHS[@]}")
+fi
+
+# Header
+if [ -n "$SUMMARY_FILE" ] && [ -s "$SUMMARY_FILE" ]; then
+  cat "$SUMMARY_FILE"
+  echo
+fi
+
+if [ -z "$SINCE" ]; then
+  # No previous tag to diff against, so there is no changelog to print. Say so
+  # only when nothing else has introduced the release.
+  if [ -z "$SUMMARY_FILE" ] || [ ! -s "$SUMMARY_FILE" ]; then
+    echo "First published version."
+    echo
+  fi
+else
+  # An added export is the one change an iOS consumer can act on immediately:
+  # new Kotlin API reaches `import SharedCore` without any Swift glue.
+  NEW_MODULES=$(comm -13 \
+    <(exported_modules "$SINCE") \
+    <(exported_modules "$SOURCE_SHA") || true)
+  if [ -n "$NEW_MODULES" ]; then
+    echo "### Newly exported modules"
+    echo
+    printf '%s\n' "$NEW_MODULES" | sed 's/^/- `/; s/$/`/'
+    echo
+  fi
+
+  section "Features" "${FEATS[@]+"${FEATS[@]}"}"
+  section "Fixes" "${FIXES[@]+"${FIXES[@]}"}"
+  section "Improvements" "${IMPROVEMENTS[@]+"${IMPROVEMENTS[@]}"}"
+  section "Build" "${BUILDS[@]+"${BUILDS[@]}"}"
+  section "Other" "${OTHERS[@]+"${OTHERS[@]}"}"
+
+  if [ ${#FEATS[@]} -eq 0 ] && [ ${#FIXES[@]} -eq 0 ] && [ ${#IMPROVEMENTS[@]} -eq 0 ] \
+     && [ ${#BUILDS[@]} -eq 0 ] && [ ${#OTHERS[@]} -eq 0 ]; then
+    echo "No change to the framework's sources since ${SINCE#shared-core/}. This is a rebuild: same API, new checksum."
+    echo
+  fi
+fi
+
+# Provenance
+cat <<EOF
+### Package
+
+\`\`\`swift
+.package(url: "https://github.com/$SPM_REPO", from: "$VERSION")
+\`\`\`
+
+Built from [\`$SOURCE_SHORT\`](https://github.com/$SOURCE_REPO/commit/$SOURCE_SHA) in \`$SOURCE_REPO\`.
+EOF
+
+if [ -n "$CHECKSUM" ]; then
+  echo "XCFramework checksum \`$CHECKSUM\`."
+fi


### PR DESCRIPTION
Every release in [flipcash-shared-core-spm](https://github.com/code-payments/flipcash-shared-core-spm/releases) was empty — no title, no body. KMMBridge creates the GitHub release as a bare asset drop and this workflow never goes back to it, so an iOS engineer picking a version had a tag and nothing else. Nothing recorded which Kotlin a framework was built from either.

The notes can't come from the Swift Package repo: it holds a generated `Package.swift` and the zip it points at, and no commits of its own worth describing. So derive them here.

### What this adds

`scripts/shared-core-release-notes.sh` reads the exported module list out of `kmp/shared-core/build.gradle.kts`, walks the `project(":…")` references out to the modules those depend on, and logs that path set between the previous `shared-core/*` tag and the commit being published. Reading the module list rather than hardcoding it matters — the list has grown four times already, most recently with `:libs:currency-math:discrete-curve`, and a stale path list fails silently by omitting commits.

The publish now also tags this repo `shared-core/<version>` at the commit it built. That's the diff base for the next release's notes, and the first record of what a published framework contains.

An optional `summary` dispatch input prepends prose to the generated changelog, for what commit subjects can't carry. Two real examples from the history: 0.4.0 silently dropped the KikCode figure API because 0.3.0 had been cut from an unmerged branch, and 0.5.1 fixed a zip that broke codesign for macOS consumers.

`fetch-depth` goes from 1 to 0 because the changelog needs history and tags.

### Backfill

The nine existing releases are already filled in, and this repo is tagged `shared-core/0.1.0` through `shared-core/0.6.0` at the commits each was built from. `shared-core/0.3.0` and `shared-core/0.3.1` point at `feat/shared-badge-cgpath`, which is where those two were dispatched from.